### PR TITLE
changed spec from items to features

### DIFF
--- a/api-spec/spec.yaml
+++ b/api-spec/spec.yaml
@@ -216,14 +216,14 @@ definitions:
   ItemCollection:
     type: object
     required:
-      - items
+      - features
       - type
     properties:
       type:
         type: string
         enum:
-          - ItemCollection
-      items:
+          - FeatureCollection
+      features:
         type: array
         items:
           $ref: '#/definitions/Item'


### PR DESCRIPTION
From chat on gitter with @joshfix and  @tomkralidis - in the rush to rename 'features' to 'items' we went a bit too far and failed to be an actual featurecollection.

Being a real GeoJSON featurecollection enables lots of software to easily visualize the results. So this rolls it back.