### PR TITLE
updated stac-item json schema for hackathon 2

### DIFF
--- a/json-spec/json-schema/stac-item.json
+++ b/json-spec/json-schema/stac-item.json
@@ -8,23 +8,6 @@
   "allOf": [
     {
       "$ref": "#/definitions/core"
-    },
-    {
-      "properties": {
-        "properties": {
-          "required": [
-            "start",
-            "end"
-          ]
-        }
-      },
-      "required": [
-        "id",
-        "type",
-        "geometry",
-        "links",
-        "assets"
-      ]
     }
   ],
   "definitions": {
@@ -39,6 +22,13 @@
         },
         {
           "type": "object",
+          "required": [
+            "id",
+            "type",
+            "geometry",
+            "links",
+            "assets"
+          ],
           "properties": {
             "geometry": {
               "properties": {
@@ -55,37 +45,58 @@
               "description": "Provider item ID",
               "type": "string"
             },
-           "links": {
-                  "title": "Item links",
-                  "description": "Links to item relations, including thumbnail",
-                  "type": "array",
-                  "items": { "$ref": "#/definitions/link" },
-                  "minItems": 1,
-                  "contains": {
-                    "type": "object",
-                    "required": ["rel", "href"],
-                    "properties": {
-                      "rel": {
-                        "type": "string",
-                        "pattern": "^thumbnail$"
-                      },
-                      "href": {
-                        "type": "string"
-                      }
-                    }
+            "links": {
+              "title": "Item links",
+              "description": "Links to item relations",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/link"
+              },
+              "minItems": 1,
+              "contains": {
+                "type": "object",
+                "required": [
+                  "rel",
+                  "href"
+                ],
+                "properties": {
+                  "rel": {
+                    "type": "string",
+                    "pattern": "^self$"
+                  },
+                  "href": {
+                    "type": "string"
                   }
-                
+                }
+              }
             },
             "assets": {
-                  "title": "Asset links",
-                  "description": "Links to assets to download",
-                  "type": "array",
-                  "items": { "$ref": "#/definitions/asset" },
-                  "minItems": 1
-                
+              "title": "Asset links",
+              "description": "Links to assets",
+              "type": "object",
+              "items": {
+                "$ref": "#/definitions/asset"
+              },
+              "minItems": 1,
+              "properties": {
+                "thumbnail": {
+                  "title": "thumbnail",
+                  "description": "Thumbnail representation of the image, generally consumed by browsers",
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/asset"
+                    }
+                  ]
+                }
+              }
             },
             "properties": {
               "type": "object",
+              "required": [
+                "start",
+                "end"
+              ],
               "properties": {
                 "start": {
                   "title": "Date Start",
@@ -114,21 +125,19 @@
                 "license": {
                   "title": "Data license",
                   "description": "Data license name based on SPDX License List"
-                },
-                "assets": {
-                  "title": "Resource links",
-                  "description": "Links to assets of this item to be downloaded",
-                  "type": "array"
                 }
               }
             }
           }
         }
-      ] 
+      ]
     },
     "link": {
       "type": "object",
-      "required": ["rel", "href"],
+      "required": [
+        "rel",
+        "href"
+      ],
       "properties": {
         "rel": {
           "type": "string"
@@ -140,7 +149,9 @@
     },
     "asset": {
       "type": "object",
-      "required": ["href"],
+      "required": [
+        "href"
+      ],
       "properties": {
         "href": {
           "type": "string"


### PR DESCRIPTION
Changed assets to a object (dictionary)
added thumbnails as an optional item in assets, set the type to #asset
moved requirements from the root properties into the referenced core properties