### PR TITLE
changing start/end to datetime, as per #64

### DIFF
--- a/api-spec/wfs-stac.yaml
+++ b/api-spec/wfs-stac.yaml
@@ -490,8 +490,7 @@ definitions:
             - - -122.308150179
               - 37.488035566
       properties:
-        start: '2016-05-03T13:21:30.040Z'
-        end: '2016-05-03T13:21:30.410Z'
+        datetime: '2016-05-03T13:21:30.040Z'
         provider: 'http://www.cool-sat.com'
         license: CC-BY-4.0
       links:
@@ -503,13 +502,10 @@ definitions:
   ItemProperties:
     type: object
     required:
-      - start
-      - end
+      - datetime
     description: provides the core metatdata fields plus extensions
     properties:
-      start:
-        $ref: '#/definitions/Time'
-      end:
+      datetime:
         $ref: '#/definitions/Time'
       provider:
         type: string

--- a/json-spec/json-schema/stac-item.json
+++ b/json-spec/json-schema/stac-item.json
@@ -98,15 +98,9 @@
                 "end"
               ],
               "properties": {
-                "start": {
-                  "title": "Date Start",
-                  "description": "First date/time",
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "end": {
-                  "title": "Date End",
-                  "description": "Last date/time",
+                "datetime": {
+                  "title": "Date and Time",
+                  "description": "The searchable date/time of the assets, in UTC (Formatted in RFC 3339) ",
                   "type": "string",
                   "format": "date-time"
                 },

--- a/json-spec/json-spec.md
+++ b/json-spec/json-spec.md
@@ -28,8 +28,7 @@ your feedback will be directly incorporated.
 |-----------------|-----------------|----------------------------|--------------------------------------------------------------------------------------------------| 
 | id              | string          | Provider ID                | Provider ID for the item                       													| 
 | geometry        | geojson         | Geometry                   | Bounding Box + Footprint of the item in lat/long (EPSG 4326)										|
-| start      	  | date and time   | Date & Time Start          | First date/time in UTC (Combined date and time representation)    								| 
-| end        	  | date and time   | Date & Time End            | Last date/time in UTC (Combined date and time representation)         							| 
+| datetime 		  | date and time   | Date and Time 	         | The searchable date/time of the assets, in UTC (Formatted in RFC 3339)    						| 
 | links           | array           | Resource Links             | Array of link objects to resources and related URLs (self required) 								|
 | assets          | array           | Assets            	   	 | Dict of asset objects that can be be download (at least one required, thumbnail strong recommended)		|
 | provider        | string          | Provider     (optional)    | Provider name  																					|
@@ -51,14 +50,15 @@ unique, including things like unique satellite id's.
 **geometry** defines the full footprint of the asset represented by this item, formatted according to [RFC7946](https://tools.ietf.org/html/rfc7946) - [GeoJSON](http://geojson.org). The footprint should be the default GeoJSON geometry, though additional geometries can be included. All geometries should 
 be either Polygons or MultiPolygons, as assets represent an area, not a line or point. Bounding Boxes are required, on the 'Feature' 
 level in GeoJSON, and most software can easily generate BBOX's for footprints. This is to enable more naive clients to easily index 
-and search geospatially. GeoJSON is specified in Long/Latitude - EPSG code 4326, and the 'geometry' element of all STAC `Items` 
+and search geospatially. GeoJSON is specified in Long/Latitude - EPSG code 4326, and the `geometry` element of all STAC `Items` 
 should be the same. 
 
-**start** and **end** are the date-times that represent the beginning and end times of the capture of the asset. They are formatted
-according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). It is acceptable to have `start` and `end` to
-be the same as one another, generally representing a single capture. Many satellites do record the beginning and end of their
-capture, down to milliseconds, so if those are available then it is recommended to use them. But things like drone captures are often
-composites over several hours, and mosaics can use data from months or even years to make a coherent capture. 
+**datetime** is the representative time and date for the asset, likely the acquisition (in the case of single camera type captures)
+or the 'nominal' or representative time in the case of assets that are combined together. It is formatted
+according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Though time can be a complex thing to capture,
+for this purpose keep in mind the STAC spec is primarily searching for data, so use whatever single date and time is most useful for
+a user to search for. STAC content profiles may further specify the meaning of the main `datetime` field, and many will also add 
+more datetime fields.
 
 **links** are used primarily to represent relationships with other entities, relying on the [rel](https://www.w3schools.com/tags/att_link_rel.asp) 
 attribute on links to describe relationships. Link objects require an 'href' to provide the actual link - relative and

--- a/static-catalog/README.md
+++ b/static-catalog/README.md
@@ -153,6 +153,7 @@ An `Item` represents a single record in the catalog. An `item` must define the f
 - id
 - type
 - geometry
+- datetime
 - links (0 or more links to items or catalogs)
 - assets (a link to at least one `asset` (data that pertains to a location and time))
 
@@ -165,7 +166,7 @@ See the json-spec folder's [README](../json-spec/README.md) for links to samples
 It's possible to have an `Item` which only links to other `Item`s.
 `Item`s are represented by GeoJSON elements, and so represent [SimpleFeature](https://en.wikipedia.org/wiki/Simple_Features)s (specifically
 Polygons and MultiPolygons).
-They are also tagged with temporal component, and so fix a location at a specific time or time range.
+They are also tagged with temporal component, and so fix a location at a specific time.
 
 
 #### Links
@@ -246,8 +247,7 @@ an RGB [COG](http://www.cogeo.org/) and an RGBIR GeoTiff.
     ],
 
     "properties": {
-        "start": "2013-08-05T00:00:00+00:00",
-        "end": "2013-08-06T00:00:00+00:00",
+        "datetime": "2013-08-05T00:00:00+00:00",
         ...
     }
 }


### PR DESCRIPTION
Updates for the main spec changes to go to `datetime` from `start` and `end`. Fuller discussion at https://github.com/radiantearth/community-sprints/blob/master/03072018-ft-collins-co/notes/group-discussion.md#name-of-time-fields

@joshfix / @gsf-trutherford - would be great to have your review. Also I just updated wfs-stac.yaml - is that going to be the go forward? Will we delete spec.yaml? Or rename wfs-stac.yaml to that when it's done? Happy to update there too.

Would be great to have other's eyes on this too. I'm not doing the examples, as I want to update all the examples at once, so just doing these updates makes the changes clear.