### PR TITLE
WFS3 core yaml doc

### DIFF
--- a/api-spec/WFS3-core.yaml
+++ b/api-spec/WFS3-core.yaml
@@ -107,15 +107,17 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{name}':
+  '/collections/{collectionId}':
     get:
-      summary: describe the {name} feature collection
+      summary: 'describe the {name} feature collection'
       operationId: describeCollection
       tags:
         - Capabilities
+      parameters:
+      - $ref: '#/components/parameters/collectionId'
       responses:
         '200':
-          description: Metadata about the {name} collection shared by this API.
+          description: 'Metadata about the {name} collection shared by this API.'
           content:
             application/json:
               schema:
@@ -132,9 +134,9 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{name}/items':
+  '/collections/{collectionId}/items':
     get:
-      summary: retrieve {name} features
+      summary: 'retrieve {collectionId} features'
       description: >-
         Every feature in a dataset belongs to a collection. A dataset may
         consist of multiple feature collections. A feature collection is often a
@@ -145,8 +147,9 @@ paths:
       tags:
         - Features
       parameters:
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/bbox'
+      - $ref: '#/components/parameters/collectionId'
+      - $ref: '#/components/parameters/limit'
+      - $ref: '#/components/parameters/bbox'
       responses:
         '200':
           description: >-
@@ -168,14 +171,15 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{name}/items/{fid}':
+  '/collections/{collectionId}/items/{featureId}':
     get:
       summary: retrieve a feature; use content negotiation to request HTML or GeoJSON
       operationId: getFeature
       tags:
         - Features
       parameters:
-        - $ref: '#/components/parameters/id'
+      - $ref: '#/components/parameters/collectionId'
+      - $ref: '#/components/parameters/featureId'
       responses:
         '200':
           description: A feature.
@@ -222,8 +226,9 @@ components:
     bbox:
       name: bbox
       in: query
-      description: |
-        Only features that have a geometry that intersects the bounding box are selected. The bounding box is provided as four numbers: 
+      description: >
+        Only features that have a geometry that intersects the bounding box are
+        selected. The bounding box is provided as four numbers: 
         * Lower left corner, coordinate axis 1
         * Lower left corner, coordinate axis 2 
         * Lower left corner, coordinate axis 3 (optional)        
@@ -247,10 +252,17 @@ components:
           maximum: 180
       style: form
       explode: false
-    id:
-      name: id
+    collectionId:
+      name: collectionId
       in: path
-      description: The id of a feature
+      required: true
+      description: ID (name) of a specific collection
+      schema:
+        type: string
+    featureId:
+      name: featureId
+      in: path
+      description: ID of a specific feature
       required: true
       schema:
         type: string
@@ -272,12 +284,24 @@ components:
         links:
           type: array
           items:
-            $ref: '#/components/schema/link'
+            $ref: '#/components/schemas/link'
           example:
-            - { "href": "http://data.example.org/", "rel": "self", "type": "application/json", "title": "this document" }
-            - { "href": "http://data.example.org/api", "rel": "service", "type": "application/openapi+json;version=3.0","title": "the API definition" }
-            - { "href": "http://data.example.org/conformance", "rel": "conformance", "type": "application/json", "title": "WFS 3.0 conformance classes implemented by this server" }
-            - { "href": "http://data.example.org/collections", "rel": "data", "type": "application/json", "title": "Metadata about the feature collections" }           
+            - href: 'http://data.example.org/'
+              rel: self
+              type: application/json
+              title: this document
+            - href: 'http://data.example.org/api'
+              rel: service
+              type: application/openapi+json;version=3.0
+              title: the API definition
+            - href: 'http://data.example.org/conformance'
+              rel: conformance
+              type: application/json
+              title: WFS 3.0 conformance classes implemented by this server
+            - href: 'http://data.example.org/collections'
+              rel: data
+              type: application/json
+              title: Metadata about the feature collections
     req-classes:
       type: object
       required:
@@ -292,6 +316,22 @@ components:
             - 'http://www.opengis.net/spec/wfs-1/3.0/req/oas30'
             - 'http://www.opengis.net/spec/wfs-1/3.0/req/html'
             - 'http://www.opengis.net/spec/wfs-1/3.0/req/geojson'
+    link:
+      type: object
+      required:
+        - href
+      properties:
+        href:
+          type: string
+        rel:
+          type: string
+          example: prev
+        type:
+          type: string
+          example: application/geo+json
+        hreflang:
+          type: string
+          example: en
     content:
       type: object
       required:
@@ -302,10 +342,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/link'
-          example: 
-            - { "href": "http://data.example.org/collections.json", "rel": "self", "type": "application/json", "title": "this document" }
-            - { "href": "http://data.example.org/collections.html", "rel": "alternate", "type": "text/html", "title": "this document as HTML" }
-            - { "href": "http://schemas.example.org/1.0/foobar.xsd", "rel": "describedBy", "type": "application/xml", "title": "XML schema for Acme Corporation data" }          
+          example:
+            - href: 'http://data.example.org/collections.json'
+              rel: self
+              type: application/json
+              title: this document
+            - href: 'http://data.example.org/collections.html'
+              rel: alternate
+              type: text/html
+              title: this document as HTML
+            - href: 'http://schemas.example.org/1.0/foobar.xsd'
+              rel: describedBy
+              type: application/xml
+              title: XML schema for Acme Corporation data
         collections:
           type: array
           items:
@@ -317,36 +366,41 @@ components:
         - links
       properties:
         name:
-          description: identifier of the collection used, for example, in URIs
+          description: 'identifier of the collection used, for example, in URIs'
           type: string
-          example: 'buildings'
+          example: buildings
         title:
           description: human readable title of the collection
           type: string
-          example: 'Buildings'
+          example: Buildings
         description:
           description: a description of the features in the collection
           type: string
-          example: 'Buildings in the city of Bonn.'
+          example: Buildings in the city of Bonn.
         links:
           type: array
           items:
             $ref: '#/components/schemas/link'
-          example: 
-            - { "href": "http://data.example.org/collections/buildings/items", "rel": "item", "type": "application/geo+json",
-          "title": "Buildings" }
-            - { "href": "http://example.org/concepts/building.html", "rel": "describedBy", "type": "text/html",
-          "title": "Feature catalogue for buildings" }          
+          example:
+            - href: 'http://data.example.org/collections/buildings/items'
+              rel: item
+              type: application/geo+json
+              title: Buildings
+            - href: 'http://example.org/concepts/building.html'
+              rel: describedBy
+              type: text/html
+              title: Feature catalogue for buildings
         extent:
           $ref: '#/components/schemas/bbox'
         crs:
-          description: >- 
-            the list of coordinate reference systems supported by the service; the first item is the default coordinate reference system
+          description: >-
+            the list of coordinate reference systems supported by the service;
+            the first item is the default coordinate reference system
           type: array
           items:
             type: string
           default:
-            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
     bbox:
       type: object
       required:

--- a/api-spec/WFS3-core.yaml
+++ b/api-spec/WFS3-core.yaml
@@ -1,0 +1,424 @@
+openapi: 3.0.0
+info:
+  title: A sample API conforming to the OGC Web Feature Service standard
+  version: 0.0.1
+  description: >-
+    This is a sample OpenAPI definition that conforms to the OGC Web Feature
+    Service specification (conformance classes: "Core", "GeoJSON", "HTML" and
+    "OpenAPI 3.0").
+  contact:
+    name: Acme Corporation
+    email: info@example.org
+    url: 'http://example.org/'
+  license:
+    name: CC-BY 4.0 license
+    url: 'https://creativecommons.org/licenses/by/4.0/'
+servers:
+  - url: 'https://dev.example.org/'
+    description: Development server
+  - url: 'https://data.example.org/'
+    description: Production server
+paths:
+  /:
+    get:
+      summary: landing page of this API
+      description: >-
+        The landing page provides links to the API definition, the Conformance
+        statements and the metadata about the building data in this dataset.
+      operationId: getLandingPage
+      tags:
+        - Capabilities
+      responses:
+        '200':
+          description: links to the API capabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/root'
+            text/html:
+              schema:
+                type: string
+  /api:
+    get:
+      summary: The API description - this document
+      description: The formal API definition as an Open API document
+      operationId: getApiDescription
+      tags:
+        - Capabilities
+      responses:
+        '200':
+          description: >-
+            The formal documentation of this API according to the OpenAPI
+            specification, version 3.0. I.e., this document.
+          content:
+            application/json:
+              schema:
+                type: object
+        default:
+          description: An error occured.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+  /conformance:
+    get:
+      summary: information about standards that this API conforms to
+      description: >-
+        list all requirements classes specified in a standard (e.g., WFS 3.0
+        Part 1: Core) that the server conforms to
+      operationId: getRequirementsClasses
+      tags:
+        - Capabilities
+      responses:
+        '200':
+          description: the URIs of all requirements classes supported by the server
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/req-classes'
+        default:
+          description: An error occured.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+  /collections:
+    get:
+      summary: describe the feature collections in the dataset
+      operationId: describeCollections
+      tags:
+        - Capabilities
+      responses:
+        '200':
+          description: Metdata about the feature collections shared by this API.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/content'
+            text/html:
+              schema:
+                type: string
+        default:
+          description: An error occured.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+  '/collections/{name}':
+    get:
+      summary: describe the {name} feature collection
+      operationId: describeCollection
+      tags:
+        - Capabilities
+      responses:
+        '200':
+          description: Metadata about the {name} collection shared by this API.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/collectionInfo'
+            text/html:
+              schema:
+                type: string
+        default:
+          description: An error occured.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+  '/collections/{name}/items':
+    get:
+      summary: retrieve {name} features
+      description: >-
+        Every feature in a dataset belongs to a collection. A dataset may
+        consist of multiple feature collections. A feature collection is often a
+        collection of features of a similar type, based on a common schema.\
+
+        Use content negotiation to request HTML or GeoJSON.
+      operationId: getFeatures
+      tags:
+        - Features
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/bbox'
+      responses:
+        '200':
+          description: >-
+            Information about the feature collection plus the first features
+            matching the selection parameters.
+          content:
+            application/geo+json:
+              schema:
+                $ref: '#/components/schemas/featureCollectionGeoJSON'
+            text/html:
+              schema:
+                type: string
+        default:
+          description: An error occured.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+  '/collections/{name}/items/{fid}':
+    get:
+      summary: retrieve a feature; use content negotiation to request HTML or GeoJSON
+      operationId: getFeature
+      tags:
+        - Features
+      parameters:
+        - $ref: '#/components/parameters/id'
+      responses:
+        '200':
+          description: A feature.
+          content:
+            application/geo+json:
+              schema:
+                $ref: '#/components/schemas/featureGeoJSON'
+            text/html:
+              schema:
+                type: string
+        default:
+          description: An error occured.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+components:
+  parameters:
+    limit:
+      name: limit
+      in: query
+      description: |
+        The optional limit parameter limits the number of items that are
+        presented in the response document.
+
+        Only items are counted that are on the first level of the collection in
+        the response document. Nested objects contained within the explicitly
+        requested items shall not be counted.
+
+        * Minimum = 1
+        * Maximum = 10000
+        * Default = 10
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 10000
+        default: 10
+      style: form
+      explode: false
+    bbox:
+      name: bbox
+      in: query
+      description: |
+        Only features that have a geometry that intersects the bounding box are selected. The bounding box is provided as four numbers: 
+        * Lower left corner, coordinate axis 1
+        * Lower left corner, coordinate axis 2 
+        * Lower left corner, coordinate axis 3 (optional)        
+        * Upper right corner, coordinate axis 1
+        * Upper right corner, coordinate axis 2
+        * Upper right corner, coordinate axis 3 (optional)
+
+        For WGS84 longitude/latitude this is in most cases the sequence of
+        minimum longitude, minimum latitude, maximum longitude and maximum
+        latitude. However, in cases where the box spans the antimeridian the
+        first value (west-most box edge) is larger than the third value
+        (east-most box edge).
+      required: false
+      schema:
+        type: array
+        minItems: 4
+        maxItems: 6
+        items:
+          type: number
+          minimum: -180
+          maximum: 180
+      style: form
+      explode: false
+    id:
+      name: id
+      in: path
+      description: The id of a feature
+      required: true
+      schema:
+        type: string
+  schemas:
+    exception:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+        description:
+          type: string
+    root:
+      type: object
+      required:
+        - links
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schema/link'
+          example:
+            - { "href": "http://data.example.org/", "rel": "self", "type": "application/json", "title": "this document" }
+            - { "href": "http://data.example.org/api", "rel": "service", "type": "application/openapi+json;version=3.0","title": "the API definition" }
+            - { "href": "http://data.example.org/conformance", "rel": "conformance", "type": "application/json", "title": "WFS 3.0 conformance classes implemented by this server" }
+            - { "href": "http://data.example.org/collections", "rel": "data", "type": "application/json", "title": "Metadata about the feature collections" }           
+    req-classes:
+      type: object
+      required:
+        - conformsTo
+      properties:
+        conformsTo:
+          type: array
+          items:
+            type: string
+          example:
+            - 'http://www.opengis.net/spec/wfs-1/3.0/req/core'
+            - 'http://www.opengis.net/spec/wfs-1/3.0/req/oas30'
+            - 'http://www.opengis.net/spec/wfs-1/3.0/req/html'
+            - 'http://www.opengis.net/spec/wfs-1/3.0/req/geojson'
+    content:
+      type: object
+      required:
+        - links
+        - collections
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+          example: 
+            - { "href": "http://data.example.org/collections.json", "rel": "self", "type": "application/json", "title": "this document" }
+            - { "href": "http://data.example.org/collections.html", "rel": "alternate", "type": "text/html", "title": "this document as HTML" }
+            - { "href": "http://schemas.example.org/1.0/foobar.xsd", "rel": "describedBy", "type": "application/xml", "title": "XML schema for Acme Corporation data" }          
+        collections:
+          type: array
+          items:
+            $ref: '#/components/schemas/collectionInfo'
+    collectionInfo:
+      type: object
+      required:
+        - name
+        - links
+      properties:
+        name:
+          description: identifier of the collection used, for example, in URIs
+          type: string
+          example: 'buildings'
+        title:
+          description: human readable title of the collection
+          type: string
+          example: 'Buildings'
+        description:
+          description: a description of the features in the collection
+          type: string
+          example: 'Buildings in the city of Bonn.'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+          example: 
+            - { "href": "http://data.example.org/collections/buildings/items", "rel": "item", "type": "application/geo+json",
+          "title": "Buildings" }
+            - { "href": "http://example.org/concepts/building.html", "rel": "describedBy", "type": "text/html",
+          "title": "Feature catalogue for buildings" }          
+        extent:
+          $ref: '#/components/schemas/bbox'
+        crs:
+          description: >- 
+            the list of coordinate reference systems supported by the service; the first item is the default coordinate reference system
+          type: array
+          items:
+            type: string
+          default:
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+    bbox:
+      type: object
+      required:
+        - bbox
+      properties:
+        crs:
+          type: string
+          enum:
+            - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+          default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+        bbox:
+          description: 'west, north, east, south edges of the bounding box'
+          type: array
+          minItems: 4
+          maxItems: 4
+          items:
+            type: number
+            minimum: -180
+            maximum: 180
+          example:
+            - -180
+            - -90
+            - 180
+            - 90
+    featureCollectionGeoJSON:
+      type: object
+      required:
+        - features
+      properties:
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/featureGeoJSON'
+    featureGeoJSON:
+      type: object
+      required:
+        - type
+        - geometry
+        - properties
+      properties:
+        type:
+          type: string
+          enum:
+            - Feature
+        geometry:
+          $ref: '#/components/schemas/geometryGeoJSON'
+        properties:
+          type: object
+          nullable: true
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+    geometryGeoJSON:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+            - MultiPoint
+            - LineString
+            - MultiLineString
+            - Polygon
+            - MultiPolygon
+            - GeometryCollection
+tags:
+  - name: Capabilities
+    description: >-
+      Essential characteristics of this API including information about the
+      data.
+  - name: Features
+    description: Access to data (features).


### PR DESCRIPTION
I've spent some time this week working toward an updated OpenAPI spec for the union of WFS3 core, STAC core, and STAC extensions. Of course, the starting point has to be a usable WFS3 core yaml doc. Such a doc doesn't yet exist, and there are at least three sources of information:
- **Sample OpenAPI doc** (https://github.com/opengeospatial/WFS_FES/blob/master/openapi.yaml)
- **OpenAPI fragments** (https://github.com/opengeospatial/WFS_FES/tree/master/core/openapi)
- **Latest draft of the core standard** (https://rawgit.com/opengeospatial/WFS_FES/master/docs/17-069.html)

Unfortunately, these are not synchronized, resulting in contradictions. The wfs3-core.yaml doc is my attempt to reconcile these sources. In general, I have given deference to the standard doc, as it seems most up-to-date, and probably should be considered definitive.

This yaml doc surely has plenty of errors - even though the Swagger editor doesn't flag any problems, until you try to generate and run some code from it, you won't really know if it is correct. Nevertheless, if this looks like a decent starting point, I propose to use this as a basis for:
- Josh's extensions (both STAC and "transactions")
- Tim's filter proposal
- An OpenAPI 2 backport to use with the tools.

If it looks correct enough, I would also suggest that we give it to the WFS team. It really belongs on their repo.