### PR TITLE
Features/api review

### DIFF
--- a/api-spec/STAC-fragment.yaml
+++ b/api-spec/STAC-fragment.yaml
@@ -62,6 +62,81 @@ paths:
               schema:
                 type: string
 components:
+  parameters:
+    limit:
+      name: limit
+      in: query
+      description: |
+        The optional limit parameter limits the number of items that are
+        presented in the response document.
+
+        Only items are counted that are on the first level of the collection in
+        the response document. Nested objects contained within the explicitly
+        requested items shall not be counted.
+
+        * Minimum = 1
+        * Maximum = 10000
+        * Default = 10
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 10000
+        default: 10
+      style: form
+      explode: false
+    bbox:
+      name: bbox
+      in: query
+      description: |
+        Only features that have a geometry that intersects the bounding box are
+        selected. The bounding box is provided as four or six numbers,
+        depending on whether the coordinate reference system includes a
+        vertical axis (elevation or depth):
+
+        * Lower left corner, coordinate axis 1
+        * Lower left corner, coordinate axis 2  
+        * Lower left corner, coordinate axis 3 (optional) 
+        * Upper right corner, coordinate axis 1 
+        * Upper right corner, coordinate axis 2 
+        * Upper right corner, coordinate axis 3 (optional)
+
+        The coordinate reference system of the values is WGS84
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
+        a different coordinate reference system is specified in the parameter
+        `bbox-crs`.
+
+        For WGS84 longitude/latitude the values are in most cases the sequence
+        of minimum longitude, minimum latitude, maximum longitude and maximum
+        latitude. However, in cases where the box spans the antimeridian the
+        first value (west-most box edge) is larger than the third value
+        (east-most box edge).
+
+
+        If a feature has multiple spatial geometry properties, it is the
+        decision of the server whether only a single spatial geometry property
+        is used to determine the extent or all relevant geometries.
+      required: false
+      schema:
+        $ref: '#/components/schemas/bbox'
+      style: form
+      explode: false
+    time:
+      name: time
+      in: query
+      description: >-
+        A time range search that accepts a JSON search object.
+        
+        Only features that have a temporal property that intersects the value of
+        `time` are selected.
+
+        If a feature has multiple temporal properties, it is the decision of the
+        server whether only a single temporal property is used to determine the
+        extent or all relevant temporal properties.
+      required: false
+      schema:
+        $ref: '#/components/schemas/timeRange'
+      explode: false
   schemas:
     searchBody:
       description: The search criteria

--- a/api-spec/STAC-standalone.yaml
+++ b/api-spec/STAC-standalone.yaml
@@ -31,7 +31,7 @@ paths:
         - STAC
       parameters:
       - $ref: '#/components/parameters/bbox'
-      - $ref: '#/components/parameters/timeRange'
+      - $ref: '#/components/parameters/time'
       - $ref: '#/components/parameters/limit'
       responses:
         '200':
@@ -147,7 +147,7 @@ components:
           type: number
       style: form
       explode: false
-    timeRange:
+    time:
       name: time
       in: query
       description: >-
@@ -161,7 +161,16 @@ components:
         extent or all relevant temporal properties.
       required: false
       schema:
-        $ref: '#/components/schemas/timeRange'
+        type: object
+        properties:
+          gt:
+            $ref: '#/components/schemas/time'
+          lt:
+            $ref: '#/components/schemas/time'
+          gte:
+            $ref: '#/components/schemas/time'
+          lte:
+            $ref: '#/components/schemas/time'
       explode: false
     collectionId:
       name: collectionId
@@ -230,7 +239,7 @@ components:
       type: object
       properties:
         time:
-          $ref: '#/components/schemas/timeRange'
+          $ref: '#/components/parameters/time'
     intersectsFilter:
       type: object
       description: Only returns items that intersect with the provided polygon.
@@ -286,17 +295,6 @@ components:
       description: >-
         A single date-time string that adheres to RFC3339, for example
         1985-04-12T23:20:50.52Z
-    timeRange:
-      type: object
-      properties:
-        gt:
-          $ref: '#/components/schemas/time'
-        lt:
-          $ref: '#/components/schemas/time'
-        gte:
-          $ref: '#/components/schemas/time'
-        lte:
-          $ref: '#/components/schemas/time'
     itemCollection:
       type: object
       required:

--- a/api-spec/STAC-standalone.yaml
+++ b/api-spec/STAC-standalone.yaml
@@ -31,7 +31,7 @@ paths:
         - STAC
       parameters:
       - $ref: '#/components/parameters/bbox'
-      - $ref: '#/components/parameters/time'
+      - $ref: '#/components/parameters/timeRange'
       - $ref: '#/components/parameters/limit'
       responses:
         '200':
@@ -110,16 +110,18 @@ components:
     bbox:
       name: bbox
       in: query
-      description: >
+      description: |
         Only features that have a geometry that intersects the bounding box are
-        selected. The bounding box is provided as four or six numbers, depending
-        on whether the coordinate reference system includes a vertical axis
-        (elevation or depth):
+        selected. The bounding box is provided as four or six numbers,
+        depending on whether the coordinate reference system includes a
+        vertical axis (elevation or depth):
 
-        * Lower left corner, coordinate axis 1 * Lower left corner, coordinate
-        axis 2 * Lower left corner, coordinate axis 3 (optional) * Upper right
-        corner, coordinate axis 1 * Upper right corner, coordinate axis 2 *
-        Upper right corner, coordinate axis 3 (optional)
+        * Lower left corner, coordinate axis 1
+        * Lower left corner, coordinate axis 2  
+        * Lower left corner, coordinate axis 3 (optional) 
+        * Upper right corner, coordinate axis 1 
+        * Upper right corner, coordinate axis 2 
+        * Upper right corner, coordinate axis 3 (optional)
 
         The coordinate reference system of the values is WGS84
         longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
@@ -131,6 +133,7 @@ components:
         latitude. However, in cases where the box spans the antimeridian the
         first value (west-most box edge) is larger than the third value
         (east-most box edge).
+
 
         If a feature has multiple spatial geometry properties, it is the
         decision of the server whether only a single spatial geometry property
@@ -144,17 +147,12 @@ components:
           type: number
       style: form
       explode: false
-    time:
+    timeRange:
       name: time
       in: query
       description: >-
-        Either a date-time or a period string that adheres to RFC 3339.
-        Examples:
-
-        * A date-time: "2018-02-12T23:20:50Z" * A period:
-        "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z" or
-        "2018-02-12T00:00:00Z/P1M6DT12H31M12S"
-
+        A time range search that accepts a JSON search object.
+        
         Only features that have a temporal property that intersects the value of
         `time` are selected.
 
@@ -163,8 +161,7 @@ components:
         extent or all relevant temporal properties.
       required: false
       schema:
-        type: string
-      style: form
+        $ref: '#/components/schemas/timeRange'
       explode: false
     collectionId:
       name: collectionId
@@ -429,4 +426,4 @@ components:
             http://api.cool-sat.com/query/gasd312fsaeg/ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
 tags:
   - name: STAC
-    description: 'Extension to WFS3 Core to support STAC metadata model and search API    '
+    description: 'Extension to WFS3 Core to support STAC metadata model and search API'

--- a/api-spec/WFS3core+STAC.yaml
+++ b/api-spec/WFS3core+STAC.yaml
@@ -267,16 +267,18 @@ components:
     bbox:
       name: bbox
       in: query
-      description: >
+      description: |
         Only features that have a geometry that intersects the bounding box are
-        selected. The bounding box is provided as four or six numbers, depending
-        on whether the coordinate reference system includes a vertical axis
-        (elevation or depth):
+        selected. The bounding box is provided as four or six numbers,
+        depending on whether the coordinate reference system includes a
+        vertical axis (elevation or depth):
 
-        * Lower left corner, coordinate axis 1 * Lower left corner, coordinate
-        axis 2 * Lower left corner, coordinate axis 3 (optional) * Upper right
-        corner, coordinate axis 1 * Upper right corner, coordinate axis 2 *
-        Upper right corner, coordinate axis 3 (optional)
+        * Lower left corner, coordinate axis 1
+        * Lower left corner, coordinate axis 2  
+        * Lower left corner, coordinate axis 3 (optional) 
+        * Upper right corner, coordinate axis 1 
+        * Upper right corner, coordinate axis 2 
+        * Upper right corner, coordinate axis 3 (optional)
 
         The coordinate reference system of the values is WGS84
         longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
@@ -288,6 +290,7 @@ components:
         latitude. However, in cases where the box spans the antimeridian the
         first value (west-most box edge) is larger than the third value
         (east-most box edge).
+
 
         If a feature has multiple spatial geometry properties, it is the
         decision of the server whether only a single spatial geometry property
@@ -305,13 +308,8 @@ components:
       name: time
       in: query
       description: >-
-        Either a date-time or a period string that adheres to RFC 3339.
-        Examples:
-
-        * A date-time: "2018-02-12T23:20:50Z" * A period:
-        "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z" or
-        "2018-02-12T00:00:00Z/P1M6DT12H31M12S"
-
+        A time range search that accepts a JSON search object.
+        
         Only features that have a temporal property that intersects the value of
         `time` are selected.
 
@@ -320,8 +318,16 @@ components:
         extent or all relevant temporal properties.
       required: false
       schema:
-        type: string
-      style: form
+        type: object
+        properties:
+          gt:
+            $ref: '#/components/schemas/time'
+          lt:
+            $ref: '#/components/schemas/time'
+          gte:
+            $ref: '#/components/schemas/time'
+          lte:
+            $ref: '#/components/schemas/time'
       explode: false
     collectionId:
       name: collectionId
@@ -598,7 +604,7 @@ components:
       type: object
       properties:
         time:
-          $ref: '#/components/schemas/timeRange'
+          $ref: '#/components/parameters/time'
     intersectsFilter:
       type: object
       description: Only returns items that intersect with the provided polygon.
@@ -654,17 +660,6 @@ components:
       description: >-
         A single date-time string that adheres to RFC3339, for example
         1985-04-12T23:20:50.52Z
-    timeRange:
-      type: object
-      properties:
-        gt:
-          $ref: '#/components/schemas/time'
-        lt:
-          $ref: '#/components/schemas/time'
-        gte:
-          $ref: '#/components/schemas/time'
-        lte:
-          $ref: '#/components/schemas/time'
     itemCollection:
       type: object
       required:


### PR DESCRIPTION
Updating to use the object syntax for time range queries instead of the period syntax. The period syntax is not well supported by libraries, so I don't think it should be part of the core. I think it should be an extension to add period syntax support.

I also changed the organization of timeRange to be in line with the bbox schema being defined as a parameter and removed the timeRange schema.

Also some minor formatting fixes for the bbox description.