### PR TITLE
Update links

### DIFF
--- a/extensions/examples/L1T-collection.json
+++ b/extensions/examples/L1T-collection.json
@@ -3,8 +3,8 @@
 
 
     "properties": {
-        "collection_name": "L1T",
-        "collection_description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
+        "collection": "L1T",
+        "description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
         "provider": "USGS",
         "license": "PDDL-1.0",
         "eo:gsd" : 30,

--- a/extensions/examples/landsat8-merged.json
+++ b/extensions/examples/landsat8-merged.json
@@ -37,9 +37,10 @@
     "datetime": "2014-06-02T09:22:02Z",
     "provider": "USGS",
     "license": "PDDL-1.0",
+    "collection": "L1T",
+    "description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "eo:platform": "landsat-8",
     "eo:instrument": "OLI_TIRS",
-    "eo:collection": "L1T",
     "eo:gsd": 30.0,
     "eo:cloud_cover" : 10,
     "eo:off_nadir" : 0.000,
@@ -59,11 +60,11 @@
     "landsat:image_quality_oli": 9
   },
 
-  "links": [
-    { "rel":"self", "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00.json"},
-    { "rel":"alternate", "href": "https://landsatonaws.com/L8/153/025/LC81530252014153LGN00", "type": "html"},
-    { "rel":"catalog", "href":  "http://landsat-pds.s3.amazonaws.com/L8/catalog.json"}
-  ],
+  "links": {
+    "self": { "rel":"self", "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00.json"},
+    "alternate": { "rel":"alternate", "href": "https://landsatonaws.com/L8/153/025/LC81530252014153LGN00", "type": "html"},
+    "catalog": { "rel":"catalog", "href":  "http://landsat-pds.s3.amazonaws.com/L8/catalog.json"}
+  },
 
   "assets" :{
     "thumbnail": {

--- a/extensions/examples/landsat8-sample.json
+++ b/extensions/examples/landsat8-sample.json
@@ -37,7 +37,8 @@
     "datetime": "2014-06-02T09:22:02Z",
     "provider": "USGS",
     "license": "PDDL-1.0",
-    "eo:collection": "L1T",
+    "collection": "L1T",
+    "description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "eo:gsd": 30.0,
     "eo:cloud_cover" : 10,
     "eo:off_nadir" : 0.000,
@@ -57,12 +58,12 @@
     "landsat:image_quality_oli": 9
   },
 
-  "links": [
-    { "rel":"self", "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00.json"},
-    { "rel":"alternate", "href": "https://landsatonaws.com/L8/153/025/LC81530252014153LGN00", "type": "html"},
-    { "rel":"catalog", "href":  "http://landsat-pds.s3.amazonaws.com/L8/catalog.json"}
-    { "rel":"collection", "href": "http://landsat-pds.s3.amazonaws.com/L8/L1T-collection.json"}
-  ],
+  "links": {
+    "self": { "rel":"self", "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00.json"},
+    "alternate": { "rel":"alternate", "href": "https://landsatonaws.com/L8/153/025/LC81530252014153LGN00", "type": "html"},
+    "catalog": { "rel":"catalog", "href":  "http://landsat-pds.s3.amazonaws.com/L8/catalog.json"},
+    "collection": { "rel":"collection", "href": "http://landsat-pds.s3.amazonaws.com/L8/L1T-collection.json"}
+  },
 
   "assets" :{
     "thumbnail": {

--- a/json-spec/examples/README.md
+++ b/json-spec/examples/README.md
@@ -32,7 +32,7 @@ These examples demonstrate that there is a range of potential implementations of
 the current implementations as minimally as possible. The hope is that there will emerge more consensus and best practices
 on the things outside of the core fields, to increase interoperability. 
 
-### Static Catalogs vs Catalog API's
+### Static Catalogs vs Catalog APIs
 
 The Planet example is likely the least 'static' of the examples, as it was taken from Planet's Data API and just added on a
 few fields. DigitalGlobe's made a bit more changes to make it static, but still has that lineage. Landsat8 and NAIP are

--- a/json-spec/examples/digitalglobe-sample.json
+++ b/json-spec/examples/digitalglobe-sample.json
@@ -84,14 +84,14 @@
     "provider": "DigitalGlobe",
     "license": "(C) COPYRIGHT 2016 DigitalGlobe, Inc., Longmont CO USA 80503"
   },
-   "links": [
-      {
+   "links": {
+      "self": {
         "rel": "self",
         "href": "https://s3.amazonaws.com/digitalglobe-static-catalog/collections/dg_worldview02_LV1B/103001004B316600_P002_MUL"
       },
-      {
+      "collection": {
         "rel": "collection",
         "href": "https://s3.amazonaws.com/digitalglobe-static-catalog/collections/dg_worldview02_LV1B.json"
       }
-    ]
+    }
 }

--- a/json-spec/examples/landsat8-sample.json
+++ b/json-spec/examples/landsat8-sample.json
@@ -37,7 +37,8 @@
     "datetime": "2014-06-02T09:22:02Z",
     "provider": "USGS",
     "license": "PDDL-1.0",
-    "eo:collection": "L1T",
+    "collection": "L1T",
+    "description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "eo:gsd": 30.0,
     "eo:cloud_cover" : 10,
     "eo:off_nadir" : 0.000,
@@ -57,12 +58,12 @@
     "landsat:image_quality_oli": 9
   },
 
-  "links": [
-    { "rel":"self", "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00.json"},
-    { "rel":"alternate", "href": "https://landsatonaws.com/L8/153/025/LC81530252014153LGN00", "type": "html"},
-    { "rel":"catalog", "href":  "http://landsat-pds.s3.amazonaws.com/L8/catalog.json"}
-    { "rel":"collection", "href": "http://landsat-pds.s3.amazonaws.com/L8/L1T-collection.json"}
-  ],
+  "links": {
+    "self": { "rel":"self", "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00.json"},
+    "alternate": { "rel":"alternate", "href": "https://landsatonaws.com/L8/153/025/LC81530252014153LGN00", "type": "html"},
+    "catalog": { "rel":"catalog", "href":  "http://landsat-pds.s3.amazonaws.com/L8/catalog.json"},
+    "collection": { "rel":"collection", "href": "http://landsat-pds.s3.amazonaws.com/L8/L1T-collection.json"}
+  },
 
   "assets" :{
     "thumbnail": {

--- a/json-spec/examples/naip-sample.json
+++ b/json-spec/examples/naip-sample.json
@@ -47,10 +47,9 @@
 
     },
 
-    "links": [
-        { "rel": "self", "href": "http://naip.org/catalog/al/2013/1m/30087/m_3008718_sw_16_1_20130805.json" }
-
-    ],
+    "links": {
+        "self": { "rel": "self", "href": "http://naip.org/catalog/al/2013/1m/30087/m_3008718_sw_16_1_20130805.json" }
+    },
 
     "assets": {
       "metadata": {

--- a/json-spec/examples/planet-sample.json
+++ b/json-spec/examples/planet-sample.json
@@ -1,8 +1,8 @@
 {
-  "links": [
-    { "rel":"self", "href": "https://api.planet.com/data/v1/item-types/PSScene4Band/items/20171110_121030_1013"},
-    { "rel":"full-assets", "href": "https://api.planet.com/data/v1/item-types/PSScene4Band/items/20171110_121030_1013/assets/"}
-  ],
+  "links": {
+    "self": { "rel":"self", "href": "https://api.planet.com/data/v1/item-types/PSScene4Band/items/20171110_121030_1013"},
+    "full-assets": { "rel":"full-assets", "href": "https://api.planet.com/data/v1/item-types/PSScene4Band/items/20171110_121030_1013/assets/"}
+  },
   "bbox": [
       -38.9237469532665,
       -13.169235186077524,

--- a/json-spec/json-schema/stac-item.json
+++ b/json-spec/json-schema/stac-item.json
@@ -48,28 +48,22 @@
             "links": {
               "title": "Item links",
               "description": "Links to item relations",
-              "type": "array",
+              "type": "object",
               "items": {
                 "$ref": "#/definitions/link"
               },
               "minItems": 1,
-              "contains": {
-                "type": "object",
-                "required": [
-                  "rel",
-                  "href"
-                ],
-                "properties": {
-                  "rel": {
-                    "type": "string",
-                    "pattern": "^self$"
-                  },
-                  "href": {
-                    "type": "string",
-                    "format": "uri"
-                  }
+              "properties": {
+                "self": {
+                  "title": "self",
+                  "description": "Link to self",
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/link"
+                    }
+                  ]
                 }
-              }
             },
             "assets": {
               "title": "Asset links",

--- a/json-spec/json-spec.md
+++ b/json-spec/json-spec.md
@@ -29,8 +29,8 @@ your feedback will be directly incorporated.
 | id              | string          | Provider ID                | Provider ID for the item                       													| 
 | geometry        | geojson         | Geometry                   | Bounding Box + Footprint of the item in lat/long (EPSG 4326)										|
 | datetime 		  | date and time   | Date and Time 	         | The searchable date/time of the assets, in UTC (Formatted in RFC 3339)    						| 
-| links           | array           | Resource Links             | Array of link objects to resources and related URLs (self required) 								|
-| assets          | array           | Assets            	   	 | Dict of asset objects that can be be download (at least one required, thumbnail strong recommended)		|
+| links           | dictionary           | Resource Links             | Dictionary of link objects to resources and related URLs (self required), each with a unique key								|
+| assets          | dictionary           | Assets            	   	 | Dict of asset objects that can be be download (at least one required, thumbnail strong recommended), each with a unique key |
 | provider        | string          | Provider     (optional)    | Provider name  																					|
 | license         | string          | Data License (optional)    | Item's license name based on SPDX License List or following guidelines for non-SPDX licenses 	|
 
@@ -60,14 +60,13 @@ for this purpose keep in mind the STAC spec is primarily searching for data, so 
 a user to search for. STAC content profiles may further specify the meaning of the main `datetime` field, and many will also add 
 more datetime fields.
 
-**links** are used primarily to represent relationships with other entities, relying on the [rel](https://www.w3schools.com/tags/att_link_rel.asp) 
-attribute on links to describe relationships. Link objects require an 'href' to provide the actual link - relative and
-absolute links are both allowed. And they also require a 'rel' field, which describes the relationship of the link. 
-This can be filled with any string, and best practices are emerging and will be defined in the future. Implementors are
+**links** are used primarily to represent relationships with other entities, relying on the key (equivalent to a ['rel' relation'](https://www.w3schools.com/tags/att_link_rel.asp) 
+attribute on links to describe relationships. A `link` dictionary item require an 'href' to provide the actual link - relative and
+absolute links are both allowed. Data providers are
 advised to be liberal with the links section, to describe things like the catalog an item is in, related items, parent or 
 child items (modeled in different ways, like an 'acquisition' or derived data). The `self` link is required, to represent the 
 location that the `Item` can be found online. This is particularly useful when in a download package that includes `Item` 
-metadata, so that the downstream user can know where the data has come from. The `self` link *must* be an absolute url, not 
+metadata, so that the downstream user can know where the data has come from. The `self` href field *must* be an absolute url, not 
 relative, to communicate the canonical location of the `Item`. 
 
 **assets** is an array of keyed objects that contain of links to data associated with the `Item` that can be downloaded. This should include the main asset, as well

--- a/json-spec/sample-full.json
+++ b/json-spec/sample-full.json
@@ -32,12 +32,12 @@
     "cs:sat_id": "CS3",
     "cs:product_level": "LV1B"
   },
-  "links": [
-    { "rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"},
-    { "rel": "thumbnail", "href":"thumbnail.png"},
-    { "rel": "catalog", "href": "http://cool-sat.com/catalog/"},
-    { "rel": "acquisition", "href": "http://cool-sat.com/catalog/acquisitions/20160503_56"}
-  ],
+  "links": {
+    "self": {"rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"},
+    "thumbnail": {"rel": "thumbnail", "href":"thumbnail.png"},
+    "catalog": {"rel": "catalog", "href": "http://cool-sat.com/catalog/"},
+    "acquisition": {"rel": "acquisition", "href": "http://cool-sat.com/catalog/acquisitions/20160503_56"}
+  },
   "assets": {
     "analytic": {
       "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/analytic.tif",

--- a/json-spec/sample.json
+++ b/json-spec/sample.json
@@ -21,9 +21,9 @@
     "provider": "http://www.cool-sat.com",
     "license": "CC-BY-4.0"
   },
-  "links": [
-    { "rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"}
-  ],
+  "links": {
+    "self": { "rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"}
+  },
   "assets": {
       "analytic": {
         "href": "relative-path/to/analytic.tif",

--- a/static-catalog/json-schema/catalog.json
+++ b/static-catalog/json-schema/catalog.json
@@ -20,15 +20,23 @@
     },
     "link": {
       "type": "object",
-      "properties": {
-        "uri": {
-          "type": "string",
-          "format": "uri"
+      "allOf": [
+        {
+          "$ref": "asset.json#/definitions/core"
         },
-        "properties": {
-          "$ref": "#/definitions/catalog"
+        {
+          "properties": {
+            "rel": {
+              "type": "string",
+              "format": "uri"
+            },
+            "href": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
         }
-      }
+      ]
     },
     "catalog": {
       "title": "Catalog",


### PR DESCRIPTION
Update links to be a dictionary, like assets.

The JSON schemas need to be updated, but they are out of date on a few other things so it would be good if someone could open up a PR for an updated schema.

Francesco Bartoli suggested that each links item should still contain the 'rel' attribute. I'm just concerned that will end up being the same as the key in the dictionary in which case it would be redundant. Thoughts?