### PR TITLE
eo:crs to epsg

### DIFF
--- a/extensions/examples/L1T-collection.json
+++ b/extensions/examples/L1T-collection.json
@@ -1,93 +1,90 @@
-
 {
-
-
-    "properties": {
-        "collection": "L1T",
-        "description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
-        "provider": "USGS",
-        "license": "PDDL-1.0",
-        "eo:gsd" : 30,
-        "eo:platform": "landsat-8",
-        "eo:instrument": "OLI_TIRS",
+  "properties": {
+      "collection": "L1T",
+      "description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
+      "provider": "USGS",
+      "license": "PDDL-1.0",
+      "eo:gsd" : 30,
+      "eo:platform": "landsat-8",
+      "eo:instrument": "OLI_TIRS"
+  },
+  "eo:bands": {
+    "1": {
+      "common_name": "coastal",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 0.44,
+      "fwhm": 0.02
     },
-
-    "eo:bands": {
-      "1": {
-        "common_name": "coastal",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 0.44,
-        "fwhm": 0.02
-      },
-      "2": {
-        "common_name": "blue",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 0.48,
-        "fwhm": 0.06
-      },
-      "3": {
-        "common_name": "green",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 0.56,
-        "fwhm": 0.06
-      },
-      "4": {
-        "common_name": "red",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 0.65,
-        "fwhm": 0.04
-      },
-      "5": {
-        "common_name": "nir",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 0.86,
-        "fwhm": 0.03
-      },
-      "6": {
-        "common_name": "swir16",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 1.6,
-        "fwhm": 0.08
-      },
-      "7": {
-        "common_name": "swir22",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 2.2,
-        "fwhm": 0.2
-      },
-      "8": {
-        "common_name": "pan",
-        "gsd": 15.0,
-        "accuracy": null,
-        "wavelength": 0.59,
-        "fwhm": 0.18
-      },
-      "9": {
-        "common_name": "cirrus",
-        "gsd": 30.0,
-        "accuracy": null,
-        "wavelength": 1.37,
-        "fwhm": 0.02
-      },
-      "10": {
-        "common_name": "lwir11",
-        "gsd": 100.0,
-        "accuracy": null,
-        "wavelength": 10.9,
-        "fwhm": 0.8
-      },
-      "11": {
-        "common_name": "lwir12",
-        "gsd": 100.0,
-        "accuracy": null,
-        "wavelength": 12.0,
-        "fwhm": 1.0
-      }
+    "2": {
+      "common_name": "blue",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 0.48,
+      "fwhm": 0.06
+    },
+    "3": {
+      "common_name": "green",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 0.56,
+      "fwhm": 0.06
+    },
+    "4": {
+      "common_name": "red",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 0.65,
+      "fwhm": 0.04
+    },
+    "5": {
+      "common_name": "nir",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 0.86,
+      "fwhm": 0.03
+    },
+    "6": {
+      "common_name": "swir16",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 1.6,
+      "fwhm": 0.08
+    },
+    "7": {
+      "common_name": "swir22",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 2.2,
+      "fwhm": 0.2
+    },
+    "8": {
+      "common_name": "pan",
+      "gsd": 15.0,
+      "accuracy": null,
+      "wavelength": 0.59,
+      "fwhm": 0.18
+    },
+    "9": {
+      "common_name": "cirrus",
+      "gsd": 30.0,
+      "accuracy": null,
+      "wavelength": 1.37,
+      "fwhm": 0.02
+    },
+    "10": {
+      "common_name": "lwir11",
+      "gsd": 100.0,
+      "accuracy": null,
+      "wavelength": 10.9,
+      "fwhm": 0.8
+    },
+    "11": {
+      "common_name": "lwir12",
+      "gsd": 100.0,
+      "accuracy": null,
+      "wavelength": 12.0,
+      "fwhm": 1.0
     }
+  }
+}

--- a/extensions/examples/landsat8-merged.json
+++ b/extensions/examples/landsat8-merged.json
@@ -42,6 +42,7 @@
     "eo:platform": "landsat-8",
     "eo:instrument": "OLI_TIRS",
     "eo:gsd": 30.0,
+    "eo:epsg": 32643,
     "eo:cloud_cover" : 10,
     "eo:off_nadir" : 0.000,
     "eo:azimuth": 0.00,

--- a/extensions/examples/landsat8-sample.json
+++ b/extensions/examples/landsat8-sample.json
@@ -40,6 +40,7 @@
     "collection": "L1T",
     "description": "Landat 8 imagery that is radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "eo:gsd": 30.0,
+    "eo:epsg": 32643,
     "eo:cloud_cover" : 10,
     "eo:off_nadir" : 0.000,
     "eo:azimuth": 0.00,

--- a/extensions/stac-eo-spec.md
+++ b/extensions/stac-eo-spec.md
@@ -16,7 +16,7 @@ These are fields that extend the `Item` object
 | eo:platform*            | string                      | Unique name of platform | Specific name of the platform (e.g., landsat-8, sentinel-2A, larrysdrone) | 
 | eo:instrument*        | string                      | Instrument used     | Name of instrument or sensor (e.g., MODIS, ASTER, OLI, Canon F-1) |
 | eo:bands*  | dictionary    | Band Info | Band specific metadata (see below)
-| eo:crs     | string    | ref system             | CRS of the datasource in full WKT format. null if no crs |
+| eo:epsg     | unsigned int    | EPSG code             | EPSG code of the datasource, null if no EPSG code |
 | eo:cloud_cover     | integer (optional)   | Cloud Cover Pct    | Percent of cloud cover (1-100) | 
 | eo:off_nadir      | float (optional)   | Off nadir    | Viewing angle. 0-90 degrees, measured from nadir
 | eo:azimuth      | float (optional)   | Azimuth    | Viewing azimuth angle. 0-360 degrees, measured clockwise from north
@@ -33,7 +33,7 @@ These are fields that extend the `Item` object
 
 **eo:bands** This is a dictionary of band information where each key in the dictionary is an identifier for the band (e.g., "B01", "B02", "B1", "B5", "QA"). See below for more information on band metadata.
 
-**eo:crs**: The Coordinate Reference System (CRS) is the native reference system (sometimes called a 'projection') used by the data, provided in [Well-Known Text (WKT) format](https://en.wikipedia.org/wiki/Well-known_text). This field is required. If the data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points, eo:crs should be set to null.
+**eo:epsg**: A Coordinate Reference System (CRS) is the native reference system (sometimes called a 'projection') used by the data, and can usually be referenced using an [EPSG code](http://epsg.io). If the data does not have a CRS, such as in the case of non-rectified imagery with Ground Control Points, eo:epsg should be set to null. It should also be set to null if a CRS exists, but for which there is no valid EPSG code.
 
 **eo:cloud_cover**: An estimate of cloud cover as a percentage of the entire scene. If not available the field should not be provided.
 

--- a/json-spec/examples/digitalglobe-sample.json
+++ b/json-spec/examples/digitalglobe-sample.json
@@ -73,7 +73,7 @@
     "eo:platform": "WORLDVIEW02",
     "eo:sun_elevation": 33.4,
     "eo:gsd": 2.047,
-    "eo:crs": null,
+    "eo:epsg": null,
     "dg:catalog_id": "103001004B316600",
     "dg:soli": "056823192",
     "dg:part": 2,


### PR DESCRIPTION
This removes the eo:crs field from the EO extension and replaces it with eo:epsg 

Examples are updated, but the JSON schemas have not been (and are outdated due to other recent changes as well).