### PR TITLE
remove trailing bracket

### DIFF
--- a/json-spec/json-schema/stac-item.json
+++ b/json-spec/json-schema/stac-item.json
@@ -64,6 +64,7 @@
                     }
                   ]
                 }
+              }
             },
             "assets": {
               "title": "Asset links",


### PR DESCRIPTION
The JSON schema turned out to be mostly correct for the links, treating them as an object. Was just a syntax error with an extra trailing bracket.

Thanks to @abarciauskas-bgse for finding the error!