### PR TITLE
Updating CBERS example description

### DIFF
--- a/json-spec/examples/CBERS_4_MUX_20170528_090_084_L2.json
+++ b/json-spec/examples/CBERS_4_MUX_20170528_090_084_L2.json
@@ -1,11 +1,11 @@
 {
-  "id": "CBERS_4_MUX_20180622_090_084_L2",
+  "id": "CBERS_4_MUX_20170528_090_084_L2",
   "type": "Feature",
   "bbox": [
-    23.501111,
-    13.70101,
-    24.848708,
-    14.987979
+    23.465111,
+    13.700498,
+    24.812825,
+    14.98818
   ],
   "geometry": {
     "type": "MultiPolygon",
@@ -13,36 +13,36 @@
       [
         [
           [
-            23.499976,
-            13.891246
+            23.463987,
+            13.891487
           ],
           [
-            24.603838,
-            13.724193
+            24.567134,
+            13.723733
           ],
           [
-            24.847219,
-            14.787097
+            24.811268,
+            14.786396
           ],
           [
-            23.738252,
-            14.954887
+            23.703021,
+            14.95489
           ],
           [
-            23.499976,
-            13.891246
+            23.463987,
+            13.891487
           ]
         ]
       ]
     ]
   },
   "properties": {
-    "datetime": "2018-06-22T08:49:01Z",
+    "datetime": "2017-05-28T09:01:17Z",
     "provider": "INPE",
     "eo:collection": "default",
-    "eo:sun_azimuth": 64.4101,
-    "eo:sun_elevation": 66.0029,
-    "eo:off_nadir": -0.00805415,
+    "eo:sun_azimuth": 66.2923,
+    "eo:sun_elevation": 70.3079,
+    "eo:off_nadir": -0.00744884,
     "eo:epsg": 32627,
     "cbers:data_type": "L2",
     "cbers:path": 90,
@@ -51,55 +51,59 @@
   "links": {
     "self": {
       "rel": "self",
-      "href": "https://cbers-stac.s3.amazonaws.com/CBERS4/MUX/090/084/CBERS_4_MUX_20180622_090_084_L2.json"
+      "href": "https://cbers-stac.s3.amazonaws.com/CBERS4/MUX/090/084/CBERS_4_MUX_20170528_090_084_L2.json"
     },
     "catalog": {
       "rel": "catalog",
       "href": "https://cbers-stac.s3.amazonaws.com/CBERS4/MUX/090/catalog.json"
     },
-    "cx:collection": {
+    "collection": {
       "rel": "collection",
       "href": "https://cbers-stac.s3.amazonaws.com/collections/CBERS_4_MUX_L2_collection.json"
     }
   },
   "assets": {
     "thumbnail": {
-      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20180622_090_084_L2/CBERS_4_MUX_20180622_090_084.jpg",
+      "href": "https://s3.amazonaws.com/cbers-meta-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20170528_090_084_L2/CBERS_4_MUX_20170528_090_084.jpg",
       "required": true,
       "type": "jpeg"
     },
     "metadata": {
-      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20180622_090_084_L2/CBERS_4_MUX_20180622_090_084_L2_BAND6.xml",
+      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20170528_090_084_L2/CBERS_4_MUX_20170528_090_084_L2_BAND6.xml",
       "required": true,
       "type": "xml"
     },
     "B5": {
-      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20180622_090_084_L2/CBERS_4_MUX_20180622_090_084_L2_BAND5.tif",
+      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20170528_090_084_L2/CBERS_4_MUX_20170528_090_084_L2_BAND5.tif",
       "type": "GeoTIFF",
+      "format": "COG",
       "required": true,
       "eo_bands": [
         "5"
       ]
     },
     "B6": {
-      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20180622_090_084_L2/CBERS_4_MUX_20180622_090_084_L2_BAND6.tif",
+      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20170528_090_084_L2/CBERS_4_MUX_20170528_090_084_L2_BAND6.tif",
       "type": "GeoTIFF",
+      "format": "COG",
       "required": true,
       "eo_bands": [
         "6"
       ]
     },
     "B7": {
-      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20180622_090_084_L2/CBERS_4_MUX_20180622_090_084_L2_BAND7.tif",
+      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20170528_090_084_L2/CBERS_4_MUX_20170528_090_084_L2_BAND7.tif",
       "type": "GeoTIFF",
+      "format": "COG",
       "required": true,
       "eo_bands": [
         "7"
       ]
     },
     "B8": {
-      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20180622_090_084_L2/CBERS_4_MUX_20180622_090_084_L2_BAND8.tif",
+      "href": "s3://cbers-pds/CBERS4/MUX/090/084/CBERS_4_MUX_20170528_090_084_L2/CBERS_4_MUX_20170528_090_084_L2_BAND8.tif",
       "type": "GeoTIFF",
+      "format": "COG",
       "required": true,
       "eo_bands": [
         "8"

--- a/json-spec/examples/README.md
+++ b/json-spec/examples/README.md
@@ -18,13 +18,14 @@ stac-item specification.
 [Landsat on AWS](https://landsatonaws.com/) public data set could be a STAC static catalog. It includes the 'collection'
 concept, which is explained more in the [/extensions/examples/ folder](../extensions/examples/).
 
-**NAIP** The [NAIP sample](naip-sample.md) is a similar example to Landsat8, but focused on the NAIP dataset, which 
+**NAIP** The [NAIP sample](naip-sample.json) is a similar example to Landsat8, but focused on the NAIP dataset, which 
 is a bit different as it's aerial imagery instead of satellites. It demonstrates a few different patterns of how
 an implementation can be approached.
 
-**Planet** The [Planet sample](planet-sample.md) is an adaption of Planet's [Data API](https://www.planet.com/docs/reference/data-api/) 
+**Planet** The [Planet sample](planet-sample.json) is an adaption of Planet's [Data API](https://www.planet.com/docs/reference/data-api/) 
 returned JSON, with minor tweaks to have it fit in to a STAC Item.
 
+**CBERS** The [CBERS sample](CBERS_4_MUX_20170528_090_084_L2.json) is copied from [CBERS static STAC catalog](https://cbers-stac.s3.amazonaws.com/catalog.json).
 
 ## Example Discussion
 

--- a/static-catalog/examples.md
+++ b/static-catalog/examples.md
@@ -17,7 +17,7 @@ currently at version 0.5.0 of the spec.
 #### CBERS
 
 [CBERS](https://en.wikipedia.org/wiki/China%E2%80%93Brazil_Earth_Resources_Satellite_program) is maintaining 
-a full STAC Catalog, and keeping it up to date with the spec. It is currently at version 0.4.1.
+a full STAC Catalog, and keeping it up to date with the spec. It is currently at version 0.5.0.
 
 * Root Catalog.json at https://cbers-stac.s3.amazonaws.com/catalog.json
 * Browsable online version, powered by [stac-browser](https://github.com/radiantearth/stac-browser/) at http://cbers-stac.netlify.com/


### PR DESCRIPTION
Some minor broken links also fixed.
CBERS static STAC catalog will be reset to use 0.5.0 for the next scene ingestions, starting 07/03.
Maybe not in time for 0.5.0, but this could be part of a 0.5.1 minor.