### PR TITLE
Spell out FWHM to match eo:bands field descriptions

### DIFF
--- a/extensions/examples/L1T-collection.json
+++ b/extensions/examples/L1T-collection.json
@@ -14,77 +14,77 @@
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 0.44,
-      "fwhm": 0.02
+      "full_width_half_max": 0.02
     },
     "2": {
       "common_name": "blue",
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 0.48,
-      "fwhm": 0.06
+      "full_width_half_max": 0.06
     },
     "3": {
       "common_name": "green",
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 0.56,
-      "fwhm": 0.06
+      "full_width_half_max": 0.06
     },
     "4": {
       "common_name": "red",
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 0.65,
-      "fwhm": 0.04
+      "full_width_half_max": 0.04
     },
     "5": {
       "common_name": "nir",
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 0.86,
-      "fwhm": 0.03
+      "full_width_half_max": 0.03
     },
     "6": {
       "common_name": "swir16",
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 1.6,
-      "fwhm": 0.08
+      "full_width_half_max": 0.08
     },
     "7": {
       "common_name": "swir22",
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 2.2,
-      "fwhm": 0.2
+      "full_width_half_max": 0.2
     },
     "8": {
       "common_name": "pan",
       "gsd": 15.0,
       "accuracy": null,
       "wavelength": 0.59,
-      "fwhm": 0.18
+      "full_width_half_max": 0.18
     },
     "9": {
       "common_name": "cirrus",
       "gsd": 30.0,
       "accuracy": null,
       "wavelength": 1.37,
-      "fwhm": 0.02
+      "full_width_half_max": 0.02
     },
     "10": {
       "common_name": "lwir11",
       "gsd": 100.0,
       "accuracy": null,
       "wavelength": 10.9,
-      "fwhm": 0.8
+      "full_width_half_max": 0.8
     },
     "11": {
       "common_name": "lwir12",
       "gsd": 100.0,
       "accuracy": null,
       "wavelength": 12.0,
-      "fwhm": 1.0
+      "full_width_half_max": 1.0
     }
   }
 }

--- a/extensions/examples/landsat8-merged.json
+++ b/extensions/examples/landsat8-merged.json
@@ -152,77 +152,77 @@
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.44,
-        "fwhm": 0.02
+        "full_width_half_max": 0.02
       },
       "2": {
         "common_name": "blue",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.48,
-        "fwhm": 0.06
+        "full_width_half_max": 0.06
       },
       "3": {
         "common_name": "green",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.56,
-        "fwhm": 0.06
+        "full_width_half_max": 0.06
       },
       "4": {
         "common_name": "red",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.65,
-        "fwhm": 0.04
+        "full_width_half_max": 0.04
       },
       "5": {
         "common_name": "nir",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.86,
-        "fwhm": 0.03
+        "full_width_half_max": 0.03
       },
       "6": {
         "common_name": "swir16",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 1.6,
-        "fwhm": 0.08
+        "full_width_half_max": 0.08
       },
       "7": {
         "common_name": "swir22",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 2.2,
-        "fwhm": 0.2
+        "full_width_half_max": 0.2
       },
       "8": {
         "common_name": "pan",
         "gsd": 15.0,
         "accuracy": null,
         "wavelength": 0.59,
-        "fwhm": 0.18
+        "full_width_half_max": 0.18
       },
       "9": {
         "common_name": "cirrus",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 1.37,
-        "fwhm": 0.02
+        "full_width_half_max": 0.02
       },
       "10": {
         "common_name": "lwir11",
         "gsd": 100.0,
         "accuracy": null,
         "wavelength": 10.9,
-        "fwhm": 0.8
+        "full_width_half_max": 0.8
       },
       "11": {
         "common_name": "lwir12",
         "gsd": 100.0,
         "accuracy": null,
         "wavelength": 12.0,
-        "fwhm": 1.0
+        "full_width_half_max": 1.0
       }
     }
 

--- a/extensions/stac-collection-spec.md
+++ b/extensions/stac-collection-spec.md
@@ -116,77 +116,77 @@ This is an example `Collection` for Landsat-8 imagery and uses the [EO extension
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.44,
-        "fwhm": 0.02
+        "full_width_half_max": 0.02
       },
       "2": {
         "common_name": "blue",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.48,
-        "fwhm": 0.06
+        "full_width_half_max": 0.06
       },
       "3": {
         "common_name": "green",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.56,
-        "fwhm": 0.06
+        "full_width_half_max": 0.06
       },
       "4": {
         "common_name": "red",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.65,
-        "fwhm": 0.04
+        "full_width_half_max": 0.04
       },
       "5": {
         "common_name": "nir",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 0.86,
-        "fwhm": 0.03
+        "full_width_half_max": 0.03
       },
       "6": {
         "common_name": "swir16",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 1.6,
-        "fwhm": 0.08
+        "full_width_half_max": 0.08
       },
       "7": {
         "common_name": "swir22",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 2.2,
-        "fwhm": 0.2
+        "full_width_half_max": 0.2
       },
       "8": {
         "common_name": "pan",
         "gsd": 15.0,
         "accuracy": null,
         "wavelength": 0.59,
-        "fwhm": 0.18
+        "full_width_half_max": 0.18
       },
       "9": {
         "common_name": "cirrus",
         "gsd": 30.0,
         "accuracy": null,
         "wavelength": 1.37,
-        "fwhm": 0.02
+        "full_width_half_max": 0.02
       },
       "10": {
         "common_name": "lwir11",
         "gsd": 100.0,
         "accuracy": null,
         "wavelength": 10.9,
-        "fwhm": 0.8
+        "full_width_half_max": 0.8
       },
       "11": {
         "common_name": "lwir12",
         "gsd": 100.0,
         "accuracy": null,
         "wavelength": 12.0,
-        "fwhm": 1.0
+        "full_width_half_max": 1.0
       }
     }
 ```


### PR DESCRIPTION
This PR changes the extensions examples to match the field descriptions in https://github.com/radiantearth/stac-spec/blob/master/extensions/stac-eo-spec.md
