### PR TITLE
Return links and assets to lists

### DIFF
--- a/json-spec/json-spec.md
+++ b/json-spec/json-spec.md
@@ -29,8 +29,8 @@ your feedback will be directly incorporated.
 | id              | string          | Provider ID                | Provider ID for the item                       													| 
 | geometry        | geojson         | Geometry                   | Bounding Box + Footprint of the item in lat/long (EPSG 4326)										|
 | datetime 		  | date and time   | Date and Time 	         | The searchable date/time of the assets, in UTC (Formatted in RFC 3339)    						| 
-| links           | dictionary           | Resource Links             | Dictionary of link objects to resources and related URLs (self required), each with a unique key								|
-| assets          | dictionary           | Assets            	   	 | Dict of asset objects that can be be download (at least one required, thumbnail strongly recommended), each with a unique key |
+| links           | list            | Resource Links             | List of link objects to resources and related URLs (self required), each with an optional, unique `id` attribute                                 |
+| assets          | list            | Assets            	   	 | List of asset objects that can be be download (at least one required, thumbnail strongly recommended), with an optional, unique `id` attribute |
 | provider        | string          | Provider     (optional)    | Provider name  																					|
 | license         | string          | Data License (optional)    | Item's license name based on SPDX License List or following guidelines for non-SPDX licenses 	|
 
@@ -60,9 +60,8 @@ for this purpose keep in mind the STAC spec is primarily searching for data, so 
 a user to search for. STAC content profiles may further specify the meaning of the main `datetime` field, and many will also add 
 more datetime fields.
 
-**links** are used primarily to represent relationships with other entities. The key of each object in `links` represents the 
-link 'type', a shorthand for the relationship described. In time different link types, along with the expected 'rel' values will
-be enumerated - for now the `self` type is the only one specified. A `link` dictionary item requires an 'href' to provide 
+**links** are used primarily to represent relationships with other entities. In time different link types, along with the expected 'rel' values will
+be enumerated - for now the `self` type is the only one specified. A `link` item requires an 'href' to provide 
 the actual link - relative and absolute links are both allowed. The actual 
 ['rel' relation'](https://www.w3schools.com/tags/att_link_rel.asp) is specified with a 'rel' attribute in the object, and is 
 also required. Data providers are advised to be liberal with the links section, to describe things like the catalog an item 
@@ -71,7 +70,7 @@ required, to represent the location that the `Item` can be found online. This is
 that includes `Item` metadata, so that the downstream user can know where the data has come from. The `self` href field 
 *must* be an absolute url, not relative, to communicate the canonical location of the `Item`. 
 
-**assets** is an set of keyed objects that contain of links to data associated with the `Item` that can be downloaded. This should include the main asset, as well
+**assets** is an set of objects that contain links to data associated with the `Item` that can be downloaded. This should include the main asset, as well
 as any 'sidecar' files that are related and help a client make sense of the data. Examples of this include extended metadata (in XML, 
 JSON, etc), unusable data masks, satellite ephemeris data, etc. Some assets (like Landsat data) are represented by multiple files - 
 all should be linked to. It is generally recommended that different processing levels or formats are not exhaustively listed in an

--- a/json-spec/sample.json
+++ b/json-spec/sample.json
@@ -21,18 +21,24 @@
     "provider": "http://www.cool-sat.com",
     "license": "CC-BY-4.0"
   },
-  "links": {
-    "self": { "rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"}
-  },
-  "assets": {
-      "analytic": {
+  "links": [
+    {
+      "rel": "self",
+      "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"
+    }
+  ],
+  "assets": [
+      {
+        "id": "analytic",
         "href": "relative-path/to/analytic.tif",
         "name": "4-Band Analytic"
-    },
-    "thumbnail": {
+      },
+      {
+        "id": "thumbnail",
         "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/thumbnail.png",
         "name": "Thumbnail"
-    }
+      }
+    ]
   }
   
 


### PR DESCRIPTION
I'd like to drop the use of lists-as-objects in favor of using vanilla JSON arrays for Item `links` and `assets` as well as catalog-level `links`. My feeling is that the former introduces application-specific "optimizations" into the core spec (in the form of facilitating lookups) while dirtying the semantics associated with those lists and actually _adding_ complexity:

* JSON objects have no inherent ordering (in practice, they do in most implementations, but that seems like a bad assumption to make); this means that the resulting lists won't necessarily be consistent across viewers
* a non-semantic element is introduced (the object key) that introduces ambiguity; some implementations will apply meaning to this (a `cog` key in an asset collection) in ways that potentially conflict with "better" resolution rules (`ref` / `rel` / `type`)
* a collection of things is inherently a list; to illustrate this, actions like "give me the first asset" (`jq .assets[0]`) become more difficult (`jq ".assets | to_entries | first | .value"`; I had a hard time figuring this out)
* since object keys are now required, STAC generators will need to produce them; most keys will be opaque strings (UUIDs, etc) with duplication needing to become a consideration (merging `links` collections from multiple catalogs becomes a non-trivial operation (in case keys overlap), especially if it's deemed important to try to retain object keys)

(This is an incomplete PR; additional references to lists-as-objects should be found in prose, JSON schema, and examples.)

Refs #127 
Refs #142 