### PR TITLE
Added scientific extension for STAC catalogs

### DIFF
--- a/extensions/scientific/README.md
+++ b/extensions/scientific/README.md
@@ -12,7 +12,7 @@ These are fields that extend the `Catalog` object:
 | Element                  | Type   | Name                      | Description                                                  |
 | ------------------------ | ------ | ------------------------- | ------------------------------------------------------------ |
 | sci:doi                  | string | Dataset DOI               | [DOI](https://www.doi.org/) of the dataset.                  |
-| sci:citiation            | string | Proposed Dataset Citation | The proposed citation for the dataset.                       |
+| sci:citation             | string | Proposed Dataset Citation | The proposed citation for the dataset.                       |
 | sci:publication_doi      | string | Publication DOI           | [DOI](https://www.doi.org/) of the publication referencing this dataset. |
 | sci:publication_citation | string | Publication Citation      | Citation of the publication referencing this dataset.        |
 

--- a/extensions/scientific/README.md
+++ b/extensions/scientific/README.md
@@ -9,25 +9,31 @@ This document explains the fields of the STAC Scientific (sci) Profile to a STAC
 
 These are fields that extend the `Catalog` object:
 
-| Element                  | Type   | Name                      | Description                                                  |
-| ------------------------ | ------ | ------------------------- | ------------------------------------------------------------ |
-| sci:doi                  | string | Dataset DOI               | [DOI](https://www.doi.org/) of the dataset.                  |
-| sci:citation             | string | Proposed Dataset Citation | The proposed citation for the dataset.                       |
-| sci:publication_doi      | string | Publication DOI           | [DOI](https://www.doi.org/) of the publication referencing this dataset. |
-| sci:publication_citation | string | Publication Citation      | Citation of the publication referencing this dataset.        |
-
-## `Catalog` Field Descriptions
+| Element          | Type                 | Name                      | Description                                                  |
+| ---------------- | -------------------- | ------------------------- | ------------------------------------------------------------ |
+| sci:doi          | string               | Dataset DOI               | [DOI](https://www.doi.org/) of the dataset.                  |
+| sci:citation     | string               | Proposed Dataset Citation | The proposed citation for the dataset.                       |
+| sci:publications | [Publication Object] | Publications              | List of relevant publications referencing and describing this dataset. |
 
 **sci:doi**: The [DOI](https://www.doi.org/) name of the dataset, e.g. `10.1000/xyz123`. This MUST NOT be a DOIs link. See the DOI section for more information about DOI links.
 
 **sci:citation**: The recommended human-readable reference (citation) to be used by publications citing this dataset. No specific citation style is suggested, but the citation should contain all information required to find the publication distinctively.
 
-**sci:publication_doi**: The [DOI](https://www.doi.org/) name of the publication from which the dataset originates. This publication should include more information about the dataset and how it was processed. This MUST NOT be a DOI link. See the DOIs section for more information about DOI links.
+**sci:publications**: List of relevant publications referencing and describing this dataset. Can contain a DOI and a citation, see chapter *Publication Object*.
 
-**sci:publication_citation**: Human-readable reference (citation) to the publication from which the dataset originates. This publication should include more information about the dataset and how it was processed. No specific citation style is suggested, but a citation should contain all information required to find the publication distinctively.
+### Publication Object
+
+| Element  | Type   | Name                 | Description                                                  |
+| -------- | ------ | -------------------- | ------------------------------------------------------------ |
+| doi      | string | Publication DOI      | [DOI](https://www.doi.org/) of the publication referencing this dataset. |
+| citation | string | Publication Citation | Citation of the publication referencing this dataset.        |
+
+**doi**: The [DOI](https://www.doi.org/) name of a publication which describes and references the dataset. The publications should include more information about the dataset and how it was processed. This MUST NOT be a DOI link. See the DOIs section for more information about DOI links.
+
+**citation**: Human-readable reference (citation) of a publication which describes and references the dataset. The publications should include more information about the dataset and how it was processed. No specific citation style is suggested, but a citation should contain all information required to find the publication distinctively.
 
 ## DOIs
 
 DOIs are persistent digital interoperable identifier that uniquely identify for digital publications. They can be registered at registration agencies affiliated with the International DOI Foundation.
 
-DOI links SHOULD be added to the links section of the catalog with the `rel` type `cite-as` (see the [IETF draft](https://tools.ietf.org/id/draft-vandesompel-citeas-03.html)).
+For all DOI names respective DOI links SHOULD be added to the links section of the catalog with the `rel` type `cite-as` (see the [IETF draft](https://tools.ietf.org/id/draft-vandesompel-citeas-03.html)).

--- a/extensions/scientific/README.md
+++ b/extensions/scientific/README.md
@@ -1,0 +1,27 @@
+# STAC Scientific Profile Spec
+
+This document explains the fields of the STAC Scientific (sci) Profile to a STAC `Catalog`. Scientific metadata is considered to be data that indicate from which publication a dataset originates and how the dataset itself should be cited or referenced. Overall, it helps to increase reproducibility and citability.
+
+* [Example](example-merraclim.json)
+* [JSON Schema](schema.json)
+
+## Scientific Profile Description
+
+These are fields that extend the `Catalog` object:
+
+| Element                  | Type   | Name                      | Description                                                  |
+| ------------------------ | ------ | ------------------------- | ------------------------------------------------------------ |
+| sci:doi                  | string | Dataset DOI               | [DOI](https://www.doi.org/) of the dataset.                  |
+| sci:citiation            | string | Proposed Dataset Citation | The proposed citation for the dataset.                       |
+| sci:publication_doi      | string | Publication DOI           | [DOI](https://www.doi.org/) of the publication referencing this dataset. |
+| sci:publication_citation | string | Publication Citation      | Citation of the publication referencing this dataset.        |
+
+## `Catalog` Field Descriptions
+
+**sci:doi**: The [DOI](https://www.doi.org/) name of the dataset, e.g. `10.1000/xyz123`. This MUST NOT be a DOI link, e.g. `https://doi.org/10.1000/xyz123`. DOIs are persistent digital interoperable identifier that uniquely identify for digital publications. They can be registered at registration agencies affiliated with the International DOI Foundation.
+
+**sci:citation**: The recommended human-readable reference (citation) to be used by publications citing this dataset. No specific citation style is suggested, but the citation should contain all information required to find the publication distinctively.
+
+**sci:publication_doi**: The [DOI](https://www.doi.org/) name (not the DOI link) of the publication from which the dataset originates. This publication should include more information about the dataset and how it was processed. For more information on DOIs see `sci:doi`.
+
+**sci:publication_citation**: Human-readable reference (citation) to the publication from which the dataset originates. This publication should include more information about the dataset and how it was processed. No specific citation style is suggested, but a citation should contain all information required to find the publication distinctively.

--- a/extensions/scientific/README.md
+++ b/extensions/scientific/README.md
@@ -18,10 +18,16 @@ These are fields that extend the `Catalog` object:
 
 ## `Catalog` Field Descriptions
 
-**sci:doi**: The [DOI](https://www.doi.org/) name of the dataset, e.g. `10.1000/xyz123`. This MUST NOT be a DOI link, e.g. `https://doi.org/10.1000/xyz123`. DOIs are persistent digital interoperable identifier that uniquely identify for digital publications. They can be registered at registration agencies affiliated with the International DOI Foundation.
+**sci:doi**: The [DOI](https://www.doi.org/) name of the dataset, e.g. `10.1000/xyz123`. This MUST NOT be a DOIs link. See the DOI section for more information about DOI links.
 
 **sci:citation**: The recommended human-readable reference (citation) to be used by publications citing this dataset. No specific citation style is suggested, but the citation should contain all information required to find the publication distinctively.
 
-**sci:publication_doi**: The [DOI](https://www.doi.org/) name (not the DOI link) of the publication from which the dataset originates. This publication should include more information about the dataset and how it was processed. For more information on DOIs see `sci:doi`.
+**sci:publication_doi**: The [DOI](https://www.doi.org/) name of the publication from which the dataset originates. This publication should include more information about the dataset and how it was processed. This MUST NOT be a DOI link. See the DOIs section for more information about DOI links.
 
 **sci:publication_citation**: Human-readable reference (citation) to the publication from which the dataset originates. This publication should include more information about the dataset and how it was processed. No specific citation style is suggested, but a citation should contain all information required to find the publication distinctively.
+
+## DOIs
+
+DOIs are persistent digital interoperable identifier that uniquely identify for digital publications. They can be registered at registration agencies affiliated with the International DOI Foundation.
+
+DOI links SHOULD be added to the links section of the catalog with the `rel` type `cite-as` (see the [IETF draft](https://tools.ietf.org/id/draft-vandesompel-citeas-03.html)).

--- a/extensions/scientific/example-merraclim.json
+++ b/extensions/scientific/example-merraclim.json
@@ -16,6 +16,14 @@
     {
       "rel": "root",
       "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/catalog.json"
+    },
+    {
+      "rel": "cite-as",
+      "href": "https://doi.org/0.5061/dryad.s2v81.2"
+    },
+    {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.1038/sdata.2017.78"
     }
   ],
   "sci:doi": "10.5061/dryad.s2v81.2",

--- a/extensions/scientific/example-merraclim.json
+++ b/extensions/scientific/example-merraclim.json
@@ -1,0 +1,25 @@
+{
+  "name": "MERRAclim",
+  "description": "MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
+  "keywords": [
+    "bioclimatic",
+    "MERRAclim",
+    "macroecology",
+    "biogeography"
+  ],
+  "homepage": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81",
+  "links": [
+    {
+      "rel": "self",
+      "href": "catalog.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/catalog.json"
+    }
+  ],
+  "sci:doi": "10.5061/dryad.s2v81.2",
+  "sci:citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) Data from: MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Dryad Digital Repository. ",
+  "sci:publication_doi": "10.1038/sdata.2017.78",
+  "sci:publication_citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Scientific Data 4: 170078. "
+}

--- a/extensions/scientific/example-merraclim.json
+++ b/extensions/scientific/example-merraclim.json
@@ -27,7 +27,11 @@
     }
   ],
   "sci:doi": "10.5061/dryad.s2v81.2",
-  "sci:citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) Data from: MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Dryad Digital Repository. ",
-  "sci:publication_doi": "10.1038/sdata.2017.78",
-  "sci:publication_citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Scientific Data 4: 170078. "
+  "sci:citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) Data from: MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Dryad Digital Repository.",
+  "sci:publications": [
+    {
+      "doi": "10.1038/sdata.2017.78",
+      "citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Scientific Data 4: 170078."
+    }
+  ]
 }

--- a/extensions/scientific/schema.json
+++ b/extensions/scientific/schema.json
@@ -11,15 +11,24 @@
     "sci:citation": {
       "type": "string", 
       "title": "Proposed Dataset Citation"
-    }, 
-    "sci:publication_doi": {
-      "type": "string",
-      "title": "Publication DOI",
-      "pattern": "^(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![%\"#? ])\\S)+)$"
-    }, 
-    "sci:publication_citation": { 
-      "type": "string", 
-      "title": "Publication Citation"
+    },
+    "sci:publications": {
+      "type": "array",
+      "title": "Publications",
+      "items": {
+        "type": "object",
+        "properties": {
+          "doi": {
+            "type": "string",
+            "title": "Publication DOI",
+            "pattern": "^(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![%\"#? ])\\S)+)$"
+          }, 
+          "citation": { 
+            "type": "string", 
+            "title": "Publication Citation"
+          }
+        }
+      }
     }
   }
 }

--- a/extensions/scientific/schema.json
+++ b/extensions/scientific/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#", 
+  "type": "object", 
+  "title": "STAC Scientific Profile Spec",
+  "properties": {
+    "sci:doi": {
+      "type": "string",
+      "title": "Dataset DOI",
+      "pattern": "^(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![%\"#? ])\\S)+)$"
+    }, 
+    "sci:citation": {
+      "type": "string", 
+      "title": "Proposed Dataset Citation"
+    }, 
+    "sci:publication_doi": {
+      "type": "string",
+      "title": "Publication DOI",
+      "pattern": "^(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![%\"#? ])\\S)+)$"
+    }, 
+    "sci:publication_citation": { 
+      "type": "string", 
+      "title": "Publication Citation"
+    }
+  }
+}


### PR DESCRIPTION
Originally defined by the dataset group during the STAC sprint 3. Added in advance of the dataset spec as I think this can already be useful and tested before-hand for catalogs and later be adopted by/to the dataset spec.

Includes README, JSON schema and an example.