### PR TITLE
Polygon geojson ref fix

### DIFF
--- a/api-spec/STAC-query.yaml
+++ b/api-spec/STAC-query.yaml
@@ -320,51 +320,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: '#/components/schemas/polygon'
-    polygon:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - polygon
-        coordinates:
-          $ref: '#/components/schemas/polygon2D'
-      required:
-        - type
-        - coordinates
-    polygon2D:
-      type: array
-      minItems: 1
-      items:
-        $ref: '#/components/schemas/linearRing2D'
-    linearRing2D:
-      type: array
-      minItems: 4
-      items:
-        $ref: '#/components/schemas/point2D'
-      example:
-        - - -104
-          - 35
-        - - -103
-          - 35
-        - - -103
-          - 34
-        - - -104
-          - 34
-        - - -104
-          - 35
-    point2D:
-      description: A 2d geojson point
-      type: array
-      minimum: 2
-      maximum: 2
-      items:
-        type: number
-        format: double
-      example:
-        - -104
-        - 35
+          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
     time:
       type: string
       description: >

--- a/api-spec/STAC-query.yaml
+++ b/api-spec/STAC-query.yaml
@@ -320,7 +320,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
+          $ref: 'http://geojson.org/schema/Geometry.json'
     time:
       type: string
       description: >
@@ -433,7 +433,7 @@ components:
         bbox:
           $ref: '#/components/schemas/bbox'
         geometry:
-          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
+          $ref: 'http://geojson.org/schema/Geometry.json'
         type:
           type: string
           description: The GeoJSON type

--- a/api-spec/STAC-standalone.yaml
+++ b/api-spec/STAC-standalone.yaml
@@ -289,51 +289,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: '#/components/schemas/polygon'
-    polygon:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - polygon
-        coordinates:
-          $ref: '#/components/schemas/polygon2D'
-      required:
-        - type
-        - coordinates
-    polygon2D:
-      type: array
-      minItems: 1
-      items:
-        $ref: '#/components/schemas/linearRing2D'
-    linearRing2D:
-      type: array
-      minItems: 4
-      items:
-        $ref: '#/components/schemas/point2D'
-      example:
-        - - -104
-          - 35
-        - - -103
-          - 35
-        - - -103
-          - 34
-        - - -104
-          - 34
-        - - -104
-          - 35
-    point2D:
-      description: A 2d geojson point
-      type: array
-      minimum: 2
-      maximum: 2
-      items:
-        type: number
-        format: double
-      example:
-        - -104
-        - 35
+          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
     time:
       type: string
       description: >

--- a/api-spec/STAC-standalone.yaml
+++ b/api-spec/STAC-standalone.yaml
@@ -289,7 +289,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
+          $ref: 'http://geojson.org/schema/Geometry.json'
     time:
       type: string
       description: >
@@ -402,7 +402,7 @@ components:
         bbox:
           $ref: '#/components/schemas/bbox'
         geometry:
-          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
+          $ref: 'http://geojson.org/schema/Geometry.json'
         type:
           type: string
           description: The GeoJSON type

--- a/api-spec/WFS3core+STAC.yaml
+++ b/api-spec/WFS3core+STAC.yaml
@@ -241,7 +241,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: '#/components/schemas/featureGeoJSON'
+                $ref: 'http://geojson.org/schema/Feature.json'
             text/html:
               schema:
                 type: string

--- a/api-spec/WFS3core+STAC.yaml
+++ b/api-spec/WFS3core+STAC.yaml
@@ -213,7 +213,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: '#/components/schemas/featureCollectionGeoJSON'
+                $ref: 'http://geojson.org/schema/FeatureCollection.json'
             text/html:
               schema:
                 type: string
@@ -448,51 +448,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: '#/components/schemas/polygon'
-    polygon:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - polygon
-        coordinates:
-          $ref: '#/components/schemas/polygon2D'
-      required:
-        - type
-        - coordinates
-    polygon2D:
-      type: array
-      minItems: 1
-      items:
-        $ref: '#/components/schemas/linearRing2D'
-    linearRing2D:
-      type: array
-      minItems: 4
-      items:
-        $ref: '#/components/schemas/point2D'
-      example:
-        - - -104
-          - 35
-        - - -103
-          - 35
-        - - -103
-          - 34
-        - - -104
-          - 34
-        - - -104
-          - 35
-    point2D:
-      description: A 2d geojson point
-      type: array
-      minimum: 2
-      maximum: 2
-      items:
-        type: number
-        format: double
-      example:
-        - -104
-        - 35
+          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
     time:
       type: string
       description: >
@@ -866,50 +822,6 @@ components:
           example:
             - '2011-11-11T12:22:11Z'
             - '2012-11-24T12:32:43Z'
-    featureCollectionGeoJSON:
-      type: object
-      required:
-        - features
-      properties:
-        features:
-          type: array
-          items:
-            $ref: '#/components/schemas/featureGeoJSON'
-    featureGeoJSON:
-      type: object
-      required:
-        - type
-        - geometry
-        - properties
-      properties:
-        type:
-          type: string
-          enum:
-            - Feature
-        geometry:
-          $ref: '#/components/schemas/geometryGeoJSON'
-        properties:
-          type: object
-          nullable: true
-        id:
-          oneOf:
-            - type: string
-            - type: integer
-    geometryGeoJSON:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - Point
-            - MultiPoint
-            - LineString
-            - MultiLineString
-            - Polygon
-            - MultiPolygon
-            - GeometryCollection
 tags:
   - name: STAC
     description: Extension to WFS3 Core to support STAC metadata model and search API

--- a/api-spec/WFS3core+STAC.yaml
+++ b/api-spec/WFS3core+STAC.yaml
@@ -448,7 +448,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
+          $ref: 'http://geojson.org/schema/Geometry.json'
     time:
       type: string
       description: >
@@ -561,7 +561,7 @@ components:
         bbox:
           $ref: '#/components/schemas/bbox'
         geometry:
-          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
+          $ref: 'http://geojson.org/schema/Geometry.json'
         type:
           type: string
           description: The GeoJSON type

--- a/api-spec/definitions/STAC-standalone.yaml
+++ b/api-spec/definitions/STAC-standalone.yaml
@@ -290,7 +290,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
+          $ref: 'http://geojson.org/schema/Geometry.json'
     time:
       type: string
       description: >
@@ -403,7 +403,7 @@ components:
         bbox:
           $ref: '#/components/schemas/bbox'
         geometry:
-          $ref: "http://json.schemastore.org/geojson.json#/definitions/geometry"
+          $ref: 'http://geojson.org/schema/Geometry.json'
         type:
           type: string
           description: The GeoJSON type

--- a/api-spec/definitions/STAC-standalone.yaml
+++ b/api-spec/definitions/STAC-standalone.yaml
@@ -290,51 +290,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: '#/components/schemas/polygon'
-    polygon:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - polygon
-        coordinates:
-          $ref: '#/components/schemas/polygon2D'
-      required:
-        - type
-        - coordinates
-    polygon2D:
-      type: array
-      minItems: 1
-      items:
-        $ref: '#/components/schemas/linearRing2D'
-    linearRing2D:
-      type: array
-      minItems: 4
-      items:
-        $ref: '#/components/schemas/point2D'
-      example:
-        - - -104
-          - 35
-        - - -103
-          - 35
-        - - -103
-          - 34
-        - - -104
-          - 34
-        - - -104
-          - 35
-    point2D:
-      description: A 2d geojson point
-      type: array
-      minimum: 2
-      maximum: 2
-      items:
-        type: number
-        format: double
-      example:
-        - -104
-        - 35
+          $ref: 'http://json.schemastore.org/geojson.json#/definitions/geometry'
     time:
       type: string
       description: >

--- a/api-spec/definitions/WFS3core.fragment.yaml
+++ b/api-spec/definitions/WFS3core.fragment.yaml
@@ -145,7 +145,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: '#/components/schemas/featureGeoJSON'
+                $ref: 'http://geojson.org/schema/Feature.json'
             text/html:
               schema:
                 type: string

--- a/api-spec/definitions/WFS3core.fragment.yaml
+++ b/api-spec/definitions/WFS3core.fragment.yaml
@@ -117,7 +117,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: '#/components/schemas/featureCollectionGeoJSON'
+                $ref: 'http://geojson.org/schema/FeatureCollection.json'
             text/html:
               schema:
                 type: string
@@ -339,47 +339,3 @@ components:
           example:
             - '2011-11-11T12:22:11Z'
             - '2012-11-24T12:32:43Z'
-    featureCollectionGeoJSON:
-      type: object
-      required:
-        - features
-      properties:
-        features:
-          type: array
-          items:
-            $ref: '#/components/schemas/featureGeoJSON'
-    featureGeoJSON:
-      type: object
-      required:
-        - type
-        - geometry
-        - properties
-      properties:
-        type:
-          type: string
-          enum:
-            - Feature
-        geometry:
-          $ref: '#/components/schemas/geometryGeoJSON'
-        properties:
-          type: object
-          nullable: true
-        id:
-          oneOf:
-            - type: string
-            - type: integer
-    geometryGeoJSON:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - Point
-            - MultiPoint
-            - LineString
-            - MultiLineString
-            - Polygon
-            - MultiPolygon
-            - GeometryCollection


### PR DESCRIPTION
This is to address #193 

I went with the geojson official schema references.

As a side note, the swagger editor doesn't handle remote ref's well, but swagger hub does, so our published swagger hub versions should be fine.