### PR TITLE
#302: Provider type to roles, string to array, added licensor, added descripion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
--
+- Provider Object in collections: added a `description` field., renamed `type` to `roles`, change `roles` from string to array and added a `licensor` role.
 
 ## [v0.6.0-rc1] - 2018-10-16
 

--- a/api-spec/WFS3core+STAC.yaml
+++ b/api-spec/WFS3core+STAC.yaml
@@ -800,6 +800,10 @@ components:
                 title: Organization name
                 type: string
                 example: Big Building Corp
+              description:
+                title: Provider description
+                type: string
+                example: No further processing applied.
               roles:
                 title: Organization roles
                 type: array

--- a/api-spec/WFS3core+STAC.yaml
+++ b/api-spec/WFS3core+STAC.yaml
@@ -800,14 +800,19 @@ components:
                 title: Organization name
                 type: string
                 example: Big Building Corp
-              type:
-                title: Organization type
-                type: string
-                enum:
+              roles:
+                title: Organization roles
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - producer
+                    - licensor
+                    - processor
+                    - host
+                example:
                   - producer
-                  - processor
-                  - host
-                example: producer
+                  - licensor
               url:
                 title: Organization homepage
                 type: string

--- a/api-spec/definitions/STAC-collections.fragment.yaml
+++ b/api-spec/definitions/STAC-collections.fragment.yaml
@@ -41,6 +41,10 @@ components:
                 title: Organization name
                 type: string
                 example: Big Building Corp
+              description:
+                title: Provider description
+                type: string
+                example: "No further processing applied."
               roles:
                 title: Organization roles
                 type: array

--- a/api-spec/definitions/STAC-collections.fragment.yaml
+++ b/api-spec/definitions/STAC-collections.fragment.yaml
@@ -41,14 +41,19 @@ components:
                 title: Organization name
                 type: string
                 example: Big Building Corp
-              type:
-                title: Organization type
-                type: string
-                enum:
+              roles:
+                title: Organization roles
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - producer
+                    - licensor
+                    - processor
+                    - host
+                example: 
                   - producer
-                  - processor
-                  - host
-                example: producer
+                  - licensor
               url:
                 title: Organization homepage
                 type: string

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -62,11 +62,12 @@ The coordinate reference system of the values is WGS84 longitude/latitude.
 
 The object provides information about a provider. A provider is any of the organizations that captured or processed the content of the collection and therefore influenced the data offered by this collection. May also include information about the final storage provider hosting the data.
 
-| Field Name | Type      | Description                                                  |
-| ---------- | --------- | ------------------------------------------------------------ |
-| name       | string    | **REQUIRED.** The name of the organization or the individual. |
-| roles      | [string]  | Roles of the provider. Any of `licensor`, `producer`, `processor` or `host`. |
-| url        | string | Homepage on which the provider describes the dataset and publishes contact information. |
+| Field Name  | Type      | Description                                                  |
+| ----------- | --------- | ------------------------------------------------------------ |
+| name        | string    | **REQUIRED.** The name of the organization or the individual. |
+| description | string    | Multi-line description to add further provider information such as processing details for processors and producers, hosting details for hosts or basic contact information. [CommonMark 0.28](http://commonmark.org/) syntax MAY be used for rich text representation. |
+| roles       | [string]  | Roles of the provider. Any of `licensor`, `producer`, `processor` or `host`. |
+| url         | string    | Homepage on which the provider describes the dataset and publishes contact information. |
 
 **type**: The type of the provider can be one of the following elements:
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -62,11 +62,11 @@ The coordinate reference system of the values is WGS84 longitude/latitude.
 
 The object provides information about a provider. A provider is any of the organizations that captured or processed the content of the collection and therefore influenced the data offered by this collection. May also include information about the final storage provider hosting the data.
 
-| Field Name | Type   | Description                                                  |
-| ---------- | ------ | ------------------------------------------------------------ |
-| name       | string | **REQUIRED.** The name of the organization or the individual. |
-| type       | string | The type of provider. Any of `producer`, `processor` or `host`. |
-| url        | string | Homepage of the provider.                                    |
+| Field Name | Type      | Description                                                  |
+| ---------- | --------- | ------------------------------------------------------------ |
+| name       | string    | **REQUIRED.** The name of the organization or the individual. |
+| type       | [string]  | Roles of the provider. Any of `licensor`, `producer`, `processor` or `host`. |
+| url        | string    | Homepage of the provider. |
 
 **type**: The type of the provider can be one of the following elements:
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -71,6 +71,7 @@ The object provides information about a provider. A provider is any of the organ
 
 **type**: The type of the provider can be one of the following elements:
 
+* *licensor*: The organization that is licensing the dataset under the license specified in the collection's `license` field.
 * *producer*: The producer of the data is the provider that initially captured and processed the source data, e.g. ESA for Sentinel-2 data.
 * *processor*: A processor is any provider who processed data to a derived product.
 * *host*: The host is the actual provider offering the data on their storage. There should be no more than one host, specified as last element of the list. 

--- a/collection-spec/examples/sentinel2.json
+++ b/collection-spec/examples/sentinel2.json
@@ -15,7 +15,10 @@
   "providers": [
     {
       "name": "European Union/ESA/Copernicus",
-      "type": "producer",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
       "url": "https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi"
     }
   ],

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -53,14 +53,18 @@
             "title": "Organization name",
             "type": "string"
           },
-          "type": {
-            "title": "Organization type",
-            "type": "string",
-            "enum": [
-              "producer",
-              "processor",
-              "host"
-            ]
+          "roles": {
+            "title": "Organization roles",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "producer",
+                "licensor",
+                "processor",
+                "host"
+              ]
+            }
           },
           "url": {
             "title": "Organization homepage",

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -53,6 +53,10 @@
             "title": "Organization name",
             "type": "string"
           },
+          "description": {
+            "title": "Provider description",
+            "type": "string"
+          },
           "roles": {
             "title": "Organization roles",
             "type": "array",

--- a/extensions/commons/examples/landsat-collection.json
+++ b/extensions/commons/examples/landsat-collection.json
@@ -21,22 +21,22 @@
         {
             "name": "USGS",
             "url": "https://landsat.usgs.gov/",
-            "type": "producer"
+            "roles": ["producer", "licensor"]
         },
         {
             "name": "Planet Labs",
             "url": "https://github.com/landsat-pds/landsat_ingestor",
-            "type": "processor"
+            "roles": ["processor"]
         },
         {
             "name": "AWS",
             "url": "https://landsatonaws.com/",
-            "type": "host"
+            "roles": ["host"]
         },
         {
             "name": "Development Seed",
             "url": "https://developmentseed.org/",
-            "type": "processor"
+            "roles": ["processor"]
         }
     ],
     "license": "PDDL-1.0",

--- a/extensions/transaction/WFS3core+STAC+extensions.yaml
+++ b/extensions/transaction/WFS3core+STAC+extensions.yaml
@@ -932,14 +932,19 @@ components:
                 title: Organization name
                 type: string
                 example: Big Building Corp
-              type:
-                title: Organization type
-                type: string
-                enum:
+              roles:
+                title: Organization roles
+                type: array
+                items:
+                  type: string
+                  enum:
+                    - producer
+                    - licensor
+                    - processor
+                    - host
+                example:
                   - producer
-                  - processor
-                  - host
-                example: producer
+                  - licensor
               url:
                 title: Organization homepage
                 type: string

--- a/extensions/transaction/WFS3core+STAC+extensions.yaml
+++ b/extensions/transaction/WFS3core+STAC+extensions.yaml
@@ -932,6 +932,10 @@ components:
                 title: Organization name
                 type: string
                 example: Big Building Corp
+              description:
+                title: Provider description
+                type: string
+                example: No further processing applied.
               roles:
                 title: Organization roles
                 type: array


### PR DESCRIPTION
As discussed on Gitter and GitHub (#302).

We mostly agreed on type => role and the other changes are a proposal by me based on feedback from @mojodna that asks to allow specifying the licensor. And also, string was already flawed before, because a provider could be everything from the list of options.