### PR TITLE
Improvements to the provider URL.

### DIFF
--- a/api-spec/WFS3core+STAC.yaml
+++ b/api-spec/WFS3core+STAC.yaml
@@ -809,7 +809,10 @@ components:
                   - host
                 example: producer
               url:
-                title: Organization homepage
+                title: Homepage
+                description: >-
+                  Homepage on which the provider describes the dataset and
+                  publishes contact information.
                 type: string
                 format: url
                 example: 'http://www.big-building.com'

--- a/api-spec/definitions/STAC-collections.fragment.yaml
+++ b/api-spec/definitions/STAC-collections.fragment.yaml
@@ -50,7 +50,10 @@ components:
                   - host
                 example: producer
               url:
-                title: Organization homepage
+                title: Homepage
+                description: >-
+                  Homepage on which the provider describes the dataset and
+                  publishes contact information.
                 type: string
                 format: url
                 example: http://www.big-building.com

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -66,7 +66,7 @@ The object provides information about a provider. A provider is any of the organ
 | ---------- | ------ | ------------------------------------------------------------ |
 | name       | string | **REQUIRED.** The name of the organization or the individual. |
 | type       | string | The type of provider. Any of `producer`, `processor` or `host`. |
-| url        | string | Homepage of the provider.                                    |
+| url        | string | Homepage on which the provider describes the dataset and publishes contact information. |
 
 **type**: The type of the provider can be one of the following elements:
 

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -63,7 +63,7 @@
             ]
           },
           "url": {
-            "title": "Organization homepage",
+            "title": "Homepage",
             "type": "string",
             "format": "url"
           }

--- a/extensions/transaction/WFS3core+STAC+extensions.yaml
+++ b/extensions/transaction/WFS3core+STAC+extensions.yaml
@@ -941,7 +941,10 @@ components:
                   - host
                 example: producer
               url:
-                title: Organization homepage
+                title: Homepage
+                description: >-
+                  Homepage on which the provider describes the dataset and
+                  publishes contact information.
                 type: string
                 format: url
                 example: 'http://www.big-building.com'


### PR DESCRIPTION
Slightly improved the description of provider[...].url as it seems more reasonable to link to a dataset page rather than the front page of a provider. Was suggested by @simonff in a private conversation.