### PR TITLE
Use STAC vendor prefixed GeoTIFF media type

### DIFF
--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -155,8 +155,8 @@ Common STAC Item Media Types:
 
 | Media Type                      | Description                                                                              |
 | ------------------------------ | ----------------------------------------------------------------------------------------- |
-| `image/tiff` or `image/x.geotiff`     | GeoTIFF TIFF file with standardized georeferencing metadata                        |
-| `image/tiff` or `image/x.cloud-optimized-geotiff` | Cloud Optimized GeoTIFF                                                |
+| `image/tiff` or `image/vnd.stac.geotiff` | GeoTIFF with standardized georeferencing metadata                               |
+| `image/vnd.stac.geotiff; cloud-optimized=true` | Cloud Optimized GeoTIFF                                                   |
 | `image/jp2`                      | JPEG 2000                                                                               |
 | `image/png`                      | Visual PNGs (e.g. thumbnails)                                                           |
 | `image/jpeg`                     | Visual JPEGs (e.g. thumbnails, oblique)                                                 |


### PR DESCRIPTION
Using the STAC vendor prefix allows us to define "GeoTIFF" in a way that's intended for use with STAC and doesn't force our interpretation on other users of a similar media type.

See #251 for additional context.

This was not specified in 0.5.x and differs from 0.6.0rc1, but seems like it belongs in 0.7.0.