### PR TITLE
Document 'title' as a commonly-used property

### DIFF
--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -64,6 +64,7 @@ custom fields.
 | Field Name | Type   | Description                                                  |
 | ---------- | ------ | ------------------------------------------------------------ |
 | datetime   | string | **REQUIRED.** The searchable date and time of the assets, in UTC. It is formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
+| title      | string | A human readable title describing the item. |
 
 **datetime** is likely the acquisition (in the case of single camera type captures) or the 'nominal'
 or representative time in the case of assets that are combined together. Though time can be a


### PR DESCRIPTION
In some cases, `Item`s may have descriptive titles. This documents a key that _may_ be used for such purposes.

Refs #310