### PR TITLE
Resurrect Item 'license' and 'providers'

### DIFF
--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -64,6 +64,8 @@ custom fields.
 | Field Name | Type   | Description                                                  |
 | ---------- | ------ | ------------------------------------------------------------ |
 | datetime   | string | **REQUIRED.** The searchable date and time of the assets, in UTC. It is formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
+| license    | string | License(s) as a SPDX [License identifier](https://spdx.org/licenses/) or [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60) or `proprietary` if the license is not on the SPDX license list. Proprietary licensed data SHOULD add a link to the license text, see the `license` relation type. |
+| providers  | [Provider Object] | A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list. |
 
 **datetime** is likely the acquisition (in the case of single camera type captures) or the 'nominal'
 or representative time in the case of assets that are combined together. Though time can be a


### PR DESCRIPTION
These were previously scheduled to be dropped in 0.6.0. I propose retaining them until we have a better way to handle scenarios where `Item`s and `Collection`s are 1:1.

@cholmes:

> I'm thinking we should consider putting license and provider back in to Item for 0.6.0, since it is something we are actively taking away. I had thought that the collection would cover every use case, but having OAM provide a counter example gives me some pause.

Refs #307