### PR TITLE
Allow null for eo:epsg in JSON schema

### DIFF
--- a/extensions/eo/schema.json
+++ b/extensions/eo/schema.json
@@ -82,7 +82,10 @@
                 },
                 "eo:epsg": {
                   "title": "EPSG code",
-                  "type": "integer"
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
                 "eo:cloud_cover": {
                   "title": "Cloud Cover",


### PR DESCRIPTION
The spec explicitly allows setting eo:epsg to null, but the JSON schema would report the null value as invalid as only integer is set as data type. Fixing this.

Resolves #330.