### PR TITLE
Ensure uniformity of jsonspec standards

### DIFF
--- a/item-spec/json-schema/geojson.json
+++ b/item-spec/json-schema/geojson.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "id": "geojson.json#",
   "title": "GeoJSON Object",
   "type": "object",


### PR DESCRIPTION
Brings the geojson stac spec schema reference up to draft-06, to the same version of the other stac schemas. Used to minimize hangups with third-party software. Based off of a conversation in gitter with @cholmes 

The resulting JSON standard file was checked against https://www.jsonschemavalidator.net/ to ensure validity with json-spec draft-06.