### PR TITLE
Fix for the broken CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,12 @@ jobs:
       - run:
           name: validate
           command: |
-            python ~/stac-validator/stac_validator.py catalog-spec/examples/catalog.json
-            python ~/stac-validator/stac_validator.py collection-spec/examples/sentinel2.json
-            python ~/stac-validator/stac_validator.py item-spec/examples/sample.json
-            python ~/stac-validator/stac_validator.py item-spec/examples/sample-full.json
-            python ~/stac-validator/stac_validator.py item-spec/examples/sentinel2-sample.json
-            python ~/stac-validator/stac_validator.py item-spec/examples/planet-sample.json
-            python ~/stac-validator/stac_validator.py item-spec/examples/landsat8-sample.json
-            python ~/stac-validator/stac_validator.py item-spec/examples/digitalglobe-sample.json
-            python ~/stac-validator/stac_validator.py item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json
+            stac_validator catalog-spec/examples/catalog.json
+            stac_validator collection-spec/examples/sentinel2.json
+            stac_validator item-spec/examples/sample.json
+            stac_validator item-spec/examples/sample-full.json
+            stac_validator item-spec/examples/sentinel2-sample.json
+            stac_validator item-spec/examples/planet-sample.json
+            stac_validator item-spec/examples/landsat8-sample.json
+            stac_validator item-spec/examples/digitalglobe-sample.json
+            stac_validator item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json


### PR DESCRIPTION
This PR changes the circle ci config to use the appropriate cli name
https://github.com/sparkgeo/stac-validator/pull/39