### PR TITLE
Enforce the actual version number for stac_version.

### DIFF
--- a/catalog-spec/json-schema/catalog.json
+++ b/catalog-spec/json-schema/catalog.json
@@ -39,7 +39,8 @@
       "properties": {
         "stac_version": {
           "title": "STAC version",
-          "type": "string"
+          "type": "string",
+          "const": "0.6.1"
         },
         "id": {
           "title": "Identifier",

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -16,7 +16,8 @@
   "properties": {
     "stac_version": {
       "title": "STAC version",
-      "type": "string"
+      "type": "string",
+      "const": "0.6.1"
     },
     "id": {
       "title": "Identifier",


### PR DESCRIPTION
Enforce the actual version number for stac_version. Otherwise you could add anything, but we actually want the specific version number in there. This also helps to enforce non-mixed catalogs, which is a requirement in the spec.