### PR TITLE
Data cube extension: Better JSON Schema and vertical dimensions better described

### DIFF
--- a/extensions/datacube/README.md
+++ b/extensions/datacube/README.md
@@ -11,33 +11,42 @@ Data cube related metadata, especially to describe their dimensions.
 
 | Field Name      | Type                                                         | Description |
 | --------------- | ------------------------------------------------------------ | ----------- |
-| cube:dimensions | Map<string, Dimension Object\|Temporal Dimension Object\|Spatial Dimension Object> | Uniquely named dimensions of the data cube. |
+| cube:dimensions | Map<string, \*> | Uniquely named dimensions of the data cube. |
 
-### Dimension Object
+\* = One of the objects defined below:
 
-| Field Name       | Type             | Description                                                  |
-| ---------------- | ---------------- | ------------------------------------------------------------ |
-| type             | string           | **REQUIRED.** Custom type of the dimension.                  |
-| values           | [number\|string] | If the dimension consists of [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values, a set of all potential values. |
-| extent           | [number\|null]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
-| step             | number\|null     | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
-| unit             | string           | The unit of measurement for the data, preferably the symbols from [SI](https://physics.nist.gov/cuu/Units/units.html) or [UDUNITS](https://ncics.org/portfolio/other-resources/udunits2/). |
-| reference_system | string           | The reference system for the data.                           |
+### Horizontal Spatial Dimension Object
 
-A Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both.
-
-### Spatial Dimension Object
-
-This object inherits the fields from the Dimension Object, but restricts or changes the definition of the following fields:
+A spatial dimension in one of the horizontal (x or y) directions.
 
 | Field Name       | Type           | Description                                                  |
 | ---------------- | -------------- | ------------------------------------------------------------ |
 | type             | string         | **REQUIRED.** Type of the dimension, always `spatial`.       |
-| axis             | string         | **REQUIRED.** Axis of the spatial dimension (`x`, `y` or `z`). |
+| axis             | string         | **REQUIRED.** Axis of the spatial dimension (`x`, `y`).      |
 | extent           | [number]       | **REQUIRED.** Extent (lower and upper bounds) of the dimension as two-dimensional array. Open intervals with `null` are not allowed. |
+| values           | [number]       | Optionally, a set of all potential values.                   |
+| step             | number\|null   | The space between the values. Use `null` for irregularly spaced steps. |
 | reference_system | string\|number | The spatial reference system for the data, specified as [EPSG code](http://www.epsg-registry.org/) or [PROJ definition](https://proj4.org/operations/projections/index.html). Defaults to EPSG code 4326. |
 
+### Vertical Spatial Dimension Object
+
+A spatial dimension in vertical (z) direction.
+
+| Field Name       | Type             | Description                                                  |
+| ---------------- | ---------------- | ------------------------------------------------------------ |
+| type             | string           | **REQUIRED.** Type of the dimension, always `spatial`.       |
+| axis             | string           | **REQUIRED.** Axis of the spatial dimension, always `z`.     |
+| extent           | [number\|null]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
+| values           | [number\|string] | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
+| step             | number\|null     | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
+| unit             | string           | The unit of measurement for the data, preferably the symbols from [SI](https://physics.nist.gov/cuu/Units/units.html) or [UDUNITS](https://ncics.org/portfolio/other-resources/udunits2/). |
+| reference_system | string\|number   | The spatial reference system for the data, specified as [EPSG code](http://www.epsg-registry.org/) or [PROJ definition](https://proj4.org/operations/projections/index.html). Defaults to EPSG code 4326. |
+
+An Vertical Spatial Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both.
+
 ### Temporal Dimension Object
+
+A temporal dimension based on the ISO 8601 standard. The temporal reference system for the data is expected to be ISO 8601 compliant (Gregorian calendar / UTC). Data not compliant with ISO 8601 can be represented as an *Additional Dimension Object* with `type` set to `temporal`.
 
 | Field Name | Type           | Description                                                  |
 | ---------- | -------------- | ------------------------------------------------------------ |
@@ -46,7 +55,20 @@ This object inherits the fields from the Dimension Object, but restricts or chan
 | values     | [string]       | If the dimension consists of set of specific values they can be listed here. The dates and/or times must be strings compliant to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601). |
 | step       | string\|null   | The space between the temporal instances as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `P1D`. Use `null` for irregularly spaced steps. |
 
-The temporal reference system for the data is expected to be ISO 8601 compliant (Gregorian calendar / UTC). Data not compliant with ISO 8601 can be represented as a *Dimension Object* and the `type` also set to `temporal`.
+### Additional Dimension Object
+
+An additional dimension that is not `spatial`.
+
+| Field Name       | Type             | Description                                                  |
+| ---------------- | ---------------- | ------------------------------------------------------------ |
+| type             | string           | **REQUIRED.** Custom type of the dimension, never `spatial`. |
+| extent           | [number\|null]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
+| values           | [number\|string] | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
+| step             | number\|null     | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
+| unit             | string           | The unit of measurement for the data, preferably the symbols from [SI](https://physics.nist.gov/cuu/Units/units.html) or [UDUNITS](https://ncics.org/portfolio/other-resources/udunits2/). |
+| reference_system | string           | The reference system for the data.                           |
+
+An Additional Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both.
 
 ## Implementations
 

--- a/extensions/datacube/example.json
+++ b/extensions/datacube/example.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "0.7.0",
+  "stac_version": "0.6.2",
   "id": "datacube",
   "description": "Multi-dimensional data cube in a STAC collection.",
   "links": [

--- a/extensions/datacube/example.json
+++ b/extensions/datacube/example.json
@@ -13,59 +13,36 @@
       "x": {
         "type": "spatial",
         "axis": "x",
-        "extent": [
-          -180,
-          180
-        ],
+        "extent": [-180,180],
         "reference_system": 3857
       },
       "y": {
         "type": "spatial",
         "axis": "y",
-        "extent": [
-          -85,
-          85
-        ],
+        "extent": [-85,85],
         "reference_system": 3857
       },
       "pressure_levels": {
         "type": "spatial",
         "axis": "z",
-        "extent": [
-          0,
-          1000
-        ],
+        "extent": [0,1000],
         "step": 100,
         "unit": "Pa"
       },
       "metered_levels": {
         "type": "spatial",
         "axis": "z",
-        "values": [
-          0,
-          10,
-          25,
-          50,
-          100,
-          1000
-        ],
+        "values": [0,10,25,50,100,1000],
         "unit": "m"
       },
       "time": {
         "type": "temporal",
-        "extent": [
-          "2015-01-01T00:00:00Z",
-          "2018-12-31T00:00:00Z"
-        ],
+        "extent": ["2015-01-01T00:00:00Z","2018-12-31T00:00:00Z"],
         "step": "P1D"
       },
       "spectral": {
         "type": "bands",
-        "values": [
-          "red",
-          "green",
-          "blue"
-        ]
+        "values": ["red","green","blue"]
       }
     }
   }

--- a/extensions/datacube/schema.json
+++ b/extensions/datacube/schema.json
@@ -23,10 +23,13 @@
               "additionalProperties": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/objects/dimension"
+                    "$ref": "#/definitions/objects/additional_dimension"
                   },
                   {
-                    "$ref": "#/definitions/objects/spatial_dimension"
+                    "$ref": "#/definitions/objects/horizontal_spatial_dimension"
+                  },
+                  {
+                    "$ref": "#/definitions/objects/vertical_spatial_dimension"
                   },
                   {
                     "$ref": "#/definitions/objects/temporal_dimension"
@@ -39,29 +42,42 @@
       }
     },
     "objects": {
-      "dimension": {
-        "title": "Dimension Object",
+      "additional_dimension": {
+        "title": "Additional Dimension Object",
         "type": "object",
-        "required": [
-          "type"
+        "anyOf": [
+          {
+            "required": [
+              "type",
+              "extent"
+            ]
+          },
+          {
+            "required": [
+              "type",
+              "values"
+            ]
+          }
         ],
         "properties": {
           "type": {
-            "type": "string"
+            "allOf": [
+              {
+                "type": "string"
+              },
+              {
+                "not": {
+                  "type": "string",
+                  "const": "spatial"
+                }
+              }
+            ]
+          },
+          "extent": {
+            "$ref": "#/definitions/fields/extent_open"
           },
           "values": {
             "$ref": "#/definitions/fields/values"
-          },
-          "extent": {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "items": {
-              "type": [
-                "number",
-                "null"
-              ]
-            }
           },
           "step": {
             "$ref": "#/definitions/fields/step"
@@ -74,8 +90,8 @@
           }
         }
       },
-      "spatial_dimension": {
-        "title": "Spatial Dimension Object",
+      "horizontal_spatial_dimension": {
+        "title": "Horizontal Spatial Dimension Object",
         "type": "object",
         "required": [
           "type",
@@ -84,29 +100,56 @@
         ],
         "properties": {
           "type": {
-            "type": "string",
-            "const": "spatial"
+            "$ref": "#/definitions/fields/type_spatial"
           },
           "axis": {
-            "type": "string",
-            "enum": [
-              "x",
-              "y",
-              "z"
+            "$ref": "#/definitions/fields/axis_xy"
+          },
+          "extent": {
+            "$ref": "#/definitions/fields/extent_closed"
+          },
+          "values": {
+            "$ref": "#/definitions/fields/values_numeric"
+          },
+          "step": {
+            "$ref": "#/definitions/fields/step"
+          },
+          "reference_system": {
+            "$ref": "#/definitions/fields/reference_system_spatial"
+          }
+        }
+      },
+      "vertical_spatial_dimension": {
+        "title": "Vertical Spatial Dimension Object",
+        "type": "object",
+        "anyOf": [
+          {
+            "required": [
+              "type",
+              "axis",
+              "extent"
             ]
+          },
+          {
+            "required": [
+              "type",
+              "axis",
+              "values"
+            ]
+          }
+        ],
+        "properties": {
+          "type": {
+            "$ref": "#/definitions/fields/type_spatial"
+          },
+          "axis": {
+            "$ref": "#/definitions/fields/axis_z"
+          },
+          "extent": {
+            "$ref": "#/definitions/fields/extent_open"
           },
           "values": {
             "$ref": "#/definitions/fields/values"
-          },
-          "extent": {
-            "type": "array",
-            "minItems": 2,
-            "maxItems": 2,
-            "items": {
-              "type": [
-                "number"
-              ]
-            }
           },
           "step": {
             "$ref": "#/definitions/fields/step"
@@ -115,11 +158,7 @@
             "$ref": "#/definitions/fields/unit"
           },
           "reference_system": {
-            "type": [
-              "string",
-              "number"
-            ],
-            "default": 4326
+            "$ref": "#/definitions/fields/reference_system_spatial"
           }
         }
       },
@@ -127,7 +166,8 @@
         "title": "Temporal Dimension Object",
         "type": "object",
         "required": [
-          "type"
+          "type",
+          "extent"
         ],
         "properties": {
           "type": {
@@ -157,14 +197,52 @@
               "string",
               "null"
             ]
-          },
-          "unit": {
-            "$ref": "#/definitions/fields/unit"
           }
         }
       }
     },
     "fields": {
+      "type_spatial": {
+        "type": "string",
+        "const": "spatial"
+      },
+      "axis_xy": {
+        "type": "string",
+        "enum": [
+          "x",
+          "y"
+        ]
+      },
+      "axis_z": {
+        "type": "string",
+        "const": "z"
+      },
+      "extent_closed": {
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 2,
+        "items": {
+          "type": "number"
+        }
+      },
+      "extent_open": {
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 2,
+        "items": {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "values_numeric": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "number"
+        }
+      },
       "values": {
         "type": "array",
         "minItems": 1,
@@ -187,6 +265,13 @@
       },
       "unit": {
         "type": "string"
+      },
+      "reference_system_spatial": {
+        "type": [
+          "string",
+          "number"
+        ],
+        "default": 4326
       }
     }
   }

--- a/extensions/datacube/schema.json
+++ b/extensions/datacube/schema.json
@@ -59,6 +59,9 @@
             ]
           }
         ],
+        "not": {
+          "required": ["axis"]
+        },
         "properties": {
           "type": {
             "allOf": [
@@ -169,6 +172,9 @@
           "type",
           "extent"
         ],
+        "not": {
+          "required": ["axis"]
+        },
         "properties": {
           "type": {
             "type": "string",


### PR DESCRIPTION
I had some back and forth with myself in the last days how to best describe the vertical dimensions. The previous draft was not very strict in enforcing several aspects such as the axis only used for spatial dimensions. Now it is clearly defined and strictly checked in the JSON schema. In the meantime the other PR was already merged so we need another iteration, sorry for the inconvenience. Should have communicated that in the other PR.