### PR TITLE
Fixing two API issues (file paths, include/exclude data type)

### DIFF
--- a/api-spec/STAC+extensions.yaml
+++ b/api-spec/STAC+extensions.yaml
@@ -1006,9 +1006,11 @@ components:
             type: string
       example:
         include:
-          - 'id,properties.eo:cloud_cover'
+          - id
+          - 'properties.eo:cloud_cover'
         exclude:
-          - 'geometry,properties.datetime'
+          - geometry
+          - properties.datetime
 servers:
   - url: 'http://dev.cool-sat.com/'
     description: Development server

--- a/api-spec/extensions/fields/README.md
+++ b/api-spec/extensions/fields/README.md
@@ -9,7 +9,11 @@ To return just the `id`, `geometry`, and the property `eo:cloud_cover`:
 {
     "fields": [
         {
-            "include": "id,geometry,properties.eo:cloud_cover",
+            "include": [
+                "id",
+                "geometry",
+                "properties.eo:cloud_cover"
+            ]
         }
     ]
 }
@@ -21,7 +25,9 @@ To return the whole item without the geometry:
 {
     "fields": [
         {
-            "exclude": "geometry",
+            "exclude": [
+                "geometry"
+            ]
         }
     ]
 }

--- a/api-spec/extensions/fields/fields.fragment.yaml
+++ b/api-spec/extensions/fields/fields.fragment.yaml
@@ -43,7 +43,9 @@ components:
             type: string
       example:
         include:
-          - id,properties.eo:cloud_cover
+          - id
+          - 'properties.eo:cloud_cover'
         exclude:
-          - geometry,properties.datetime
+          - geometry
+          - properties.datetime
 

--- a/api-spec/openapi/STAC.merge.yaml
+++ b/api-spec/openapi/STAC.merge.yaml
@@ -1,1 +1,1 @@
-!!files_merge_append ["openapi-schema/WFS3.yaml", "openapi-schema/STAC.yaml"]
+!!files_merge_append ["openapi/WFS3.yaml", "openapi/STAC.yaml"]


### PR DESCRIPTION
I'm fixing two issues here, which I found when working on the other API PRs:
1. In one of the merge.yaml files, the path to the OpenAPI files was not correct: openapi-schema => openapi.
2. In the OpenAPI document it says, that exclude and include parameters are arrays. Throughout the examples comma-delimited strings were used instead. Changed to arrays. (Or we need to change the OpenAPI to comma-delimited, but that's not so easy, I guess.)