### PR TITLE
update schema to point to hosted copy of geojson schema

### DIFF
--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -1061,7 +1061,7 @@ components:
           - geometry
           - properties.datetime
 servers:
-  - url: 'http://dev.cool-sat.com/'
+  - url: 'http://dev.cool-sat.com'
     description: Development server
   - url: 'http://www.cool-sat.com'
     description: Production server

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -133,7 +133,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: 'http://geojson.org/schema/FeatureCollection.json'
+                $ref: 'https://stacspec.org/assets/FeatureCollection.json'
             text/html:
               schema:
                 type: string
@@ -161,7 +161,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: 'http://geojson.org/schema/Feature.json'
+                $ref: 'https://stacspec.org/assets/Feature.json'
             text/html:
               schema:
                 type: string

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -901,7 +901,7 @@ components:
           href: >-
             http://api.cool-sat.com/query/gasd312fsaeg/ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
 servers:
-  - url: 'http://dev.cool-sat.com/'
+  - url: 'http://dev.cool-sat.com'
     description: Development server
   - url: 'http://www.cool-sat.com'
     description: Production server

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -133,7 +133,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: 'http://geojson.org/schema/FeatureCollection.json'
+                $ref: 'https://stacspec.org/assets/FeatureCollection.json'
             text/html:
               schema:
                 type: string
@@ -161,7 +161,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: 'http://geojson.org/schema/Feature.json'
+                $ref: 'https://stacspec.org/assets/Feature.json'
             text/html:
               schema:
                 type: string

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -15,7 +15,7 @@ info:
     name: Apache License 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0'
 servers:
-  - url: 'http://dev.cool-sat.com/'
+  - url: 'http://dev.cool-sat.com'
     description: Development server
   - url: 'http://www.cool-sat.com'
     description: Production server

--- a/api-spec/openapi/WFS3.yaml
+++ b/api-spec/openapi/WFS3.yaml
@@ -120,7 +120,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: 'http://geojson.org/schema/FeatureCollection.json'
+                $ref: 'https://stacspec.org/assets/FeatureCollection.json'
             text/html:
               schema:
                 type: string
@@ -148,7 +148,7 @@ paths:
           content:
             application/geo+json:
               schema:
-                $ref: 'http://geojson.org/schema/Feature.json'
+                $ref: 'https://stacspec.org/assets/Feature.json'
             text/html:
               schema:
                 type: string


### PR DESCRIPTION
interim solution for https://github.com/geojson/schema/issues/7

use hosted copies of geojson schemas from here: https://github.com/radiantearth/stac-site/tree/master/assets