### PR TITLE
Fix fields extension examples; introduce dot notation parameters for GET (#490)

### DIFF
--- a/api-spec/extensions/fields/README.md
+++ b/api-spec/extensions/fields/README.md
@@ -2,20 +2,20 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-The STAC search endpoint, `/stac/search`, by default returns entire Items. The fields API extension adds a new parameter, `fields` that allows the user to define fields in the items returned to be returned or excluded. If both include and exclude are specified, include takes precedence.
+The STAC search endpoint, `/stac/search`, by default returns entire Items. The fields API extension adds a new 
+parameter, `fields` that allows the user to define fields in the items returned to be returned or excluded. If both 
+include and exclude are specified, include takes precedence.
 
 To return just the `id`, `geometry`, and the property `eo:cloud_cover`:
 ```json
 {
-    "fields": [
-        {
-            "include": [
-                "id",
-                "geometry",
-                "properties.eo:cloud_cover"
-            ]
-        }
-    ]
+    "fields": {
+        "include": [
+            "id",
+            "geometry",
+            "properties.eo:cloud_cover"
+        ]
+    }
 }
 ```
 
@@ -23,12 +23,20 @@ To return the whole item without the geometry:
 
 ```json
 {
-    "fields": [
-        {
-            "exclude": [
-                "geometry"
-            ]
-        }
-    ]
+    "fields": {
+        "exclude": [
+            "geometry"
+        ]
+    }
 }
+```
+
+Optionally, for HTTP GET requests, instead of submitting a single `fields` URL request parameter containing a JSON 
+string, the request object fields may be represented using dot notation to define the include and exclude values:
+
+```
+GET /stac/search?fields.include=id,geometry,properties.eo:cloud_cover
+```
+```
+GET /stac/search?fields.exclude=geometry
 ```


### PR DESCRIPTION
The `fields` api extension readme had example requests that did not align with the spec yaml.  The examples were updated.  In addition, a new optional syntax was introduced for GET requests.  Instead of having to submit a JSON string as a value, eg:
```
GET /stac/search?fields={"include":["id","geometry","properties.eo:cloud_cover"]}
```
(along with additional encoding), users will be allowed to utilize the dot notation equivalents as request parameters, eg:
```
GET /stac/search?fields.include=id,geometry,properties.eo:cloud_Cover
```

Signed-off-by: Josh Fix <josh@federal.planet.com>