### PR TITLE
make clear api should only have one of bbox or intersects

### DIFF
--- a/api-spec/api-spec.md
+++ b/api-spec/api-spec.md
@@ -67,4 +67,4 @@ Unless otherwise noted by **Path-only**, these filters are passed as query strin
 | ids | [string] | Array of Item ids to return. All other filter parameters that further restrict the number of search results (except `next` and `limit`) are ignored |
 | collections  | [string]         | STAC       | Array of Collection IDs to include in the search for items. Only Items in one of the provided Collections will be searched |
 
-In general, only one of **intersects** or **bbox** should be specified.  If both are specified, results should match both. 
+Only one of either **intersects** or **bbox** should be specified.  If both are specified, a Bad Request response should be returned. 


### PR DESCRIPTION
I added the original language, as there was no explicit statement about it.  In the API I maintain, we only allowed one or the other, as it was almost certainly an error if a client tried to submit both.  I think this should be the behavior of the STAC API. 