### PR TITLE
Removed duplicated field `schema` in the PC extension

### DIFF
--- a/extensions/pointcloud/README.md
+++ b/extensions/pointcloud/README.md
@@ -19,7 +19,6 @@ tools such as LiDAR or coincidence-matched imagery.
 | pc:encoding   | string              | **REQUIRED.** Content encoding or format of the data. |
 | pc:schema     | [Schema Object]     | **REQUIRED.** A sequential array of items that define the dimensions and their types. |
 | pc:density    | number              | Number of points per square unit area. |
-| pc:schema     | [Schema Object]     | A sequential array of items that define the dimensions and their types. |
 | pc:statistics | [Statistics Object] | A sequential array of items mapping to `pc:schema` defines per-channel statistics. |
 
 ### Schema Object

--- a/extensions/pointcloud/examples/example-autzen.json
+++ b/extensions/pointcloud/examples/example-autzen.json
@@ -44,8 +44,6 @@
   ],
   "properties": {
     "datetime": "2013-07-17T00:00:00-05:00Z",
-    "item:license": "LICENSE",
-    "item:provider": "USGS",
     "pc:count": 10653336,
     "pc:density": 0,
     "pc:encoding": "LASzip",


### PR DESCRIPTION
There was a duplicate of the field `schema` in the fields of the point cloud extension.

I guessed that it should be required... cc @hobu @adamsteer

In addition, removed the Single Item extension properties from the example as the extension was removed.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all`. to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).