### PR TITLE
Absolute links changed to relative in JSON schemas (#528) and clean-up.

### DIFF
--- a/extensions/checksum/json-schema/schema.json
+++ b/extensions/checksum/json-schema/schema.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "stac-extension-checksum.json#",
-  "type": "object", 
   "title": "Checksum Extension Specification",
+  "description": "STAC Checksum Extension to a STAC Item",
   "allOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/json-schema/item.json#/definitions/core"
+      "$ref": "../../../item-spec/json-schema/item.json#/definitions/core"
     },
     {
       "$ref": "#/definitions/checksum"

--- a/extensions/datacube/json-schema/schema.json
+++ b/extensions/datacube/json-schema/schema.json
@@ -2,11 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "stac-extension-datacube.json#",
   "title": "Data Cube Extension",
-  "type": "object",
-  "description": "STAC Data Cube Extension",
+  "description": "STAC Data Cube Extension to a STAC Item",
   "allOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/json-schema/item.json#/definitions/core"
+      "$ref": "../../../item-spec/json-schema/item.json"
     },
     {
       "$ref": "#/definitions/datacube"

--- a/extensions/datetime-range/json-schema/schema.json
+++ b/extensions/datetime-range/json-schema/schema.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "stac-extension-datetime-range.json#",
-  "type": "object", 
-  "title": "STAC Datetime Range Extension Spec",
+  "title": "Datetime Range Extension",
+  "description": "STAC Datetime Range Extension Extension to a STAC Item.",
   "allOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/json-schema/item.json#/definitions/core"
+      "$ref": "../../../master/item-spec/json-schema/item.json"
     },
     {
       "$ref": "#/definitions/datetime-range"

--- a/extensions/eo/json-schema/schema.json
+++ b/extensions/eo/json-schema/schema.json
@@ -2,11 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "stac-extension-eo.json#",
   "title": "EO Extension",
-  "type": "object",
   "description": "STAC EO Extension to a STAC Item.",
   "allOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/json-schema/item.json#/definitions/core"
+      "$ref": "../../../item-spec/json-schema/item.json#/definitions/core"
     },
     {
       "$ref": "#/definitions/eo"

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -2,11 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "stac-extension-sar.json#",
   "title": "SAR Extension",
-  "type": "object",
-  "description": "STAC SAR Extension",
+  "description": "STAC SAR Extension to a STAC Item",
   "allOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/json-schema/item.json#/definitions/core"
+      "$ref": "../../../item-spec/json-schema/item.json#/definitions/core"
     },
     {
       "$ref": "#/definitions/sar"

--- a/extensions/scientific/json-schema/schema.json
+++ b/extensions/scientific/json-schema/schema.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "stac-extension-scientific.json#",
-  "type": "object", 
-  "title": "STAC Scientific Extension Spec",
+  "title": "Scientific Extension",
+  "description": "STAC Scientific Extension to a STAC Item.",
   "allOf": [
     {
-      "$ref": "https://raw.githubusercontent.com/radiantearth/stac-spec/master/item-spec/json-schema/item.json#/definitions/core"
+      "$ref": "../../../item-spec/json-schema/item.json#/definitions/core"
     },
     {
       "$ref": "#/definitions/scientific"


### PR DESCRIPTION
Two changes:
* Absolute links changed to relative in JSON schemas (#528) 
* Removed "type: object" as it is not necessary due to "allOf".

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all`. to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).