### PR TITLE
Fixed label extension examples and re-generated OpenAPI files

### DIFF
--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -837,6 +837,9 @@ components:
                   title:
                     type: string
     itemCollection:
+      description: >-
+        A GeoJSON FeatureCollection augmented with foreign members that contain
+        values relevant to a STAC entity
       type: object
       required:
         - features
@@ -853,6 +856,9 @@ components:
         links:
           $ref: '#/components/schemas/itemCollectionLinks'
     item:
+      description: >-
+        A GeoJSON Feature augmented with foreign members that contain values
+        relevant to a STAC entity
       type: object
       required:
         - id
@@ -981,9 +987,11 @@ components:
       example:
         'eo:cloud_cover':
           lt: 50
-        providers: Planet
+        providers:
+          eq: Planet
         published:
-          date: '2018-02-12T00:00:00Z/2018-03-18T12:31:12Z'
+          gt: '2018-02-12T00:00:00Z'
+          lte: '2018-03-18T12:31:12Z'
         'pl:item_type':
           startsWith: PSScene
         product:
@@ -1048,8 +1056,6 @@ components:
               description: >-
                 Find items with a property that matches one of the specified
                 strings. A case-insensitive comparison must be performed.
-            time:
-              $ref: '#/components/schemas/time'
     sortFilter:
       type: object
       description: Sort the results

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -972,7 +972,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/query/gasd312fsaeg/ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
     queryFilter:
       type: object
       description: Allows users to query properties for specific values

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -806,6 +806,9 @@ components:
                   title:
                     type: string
     itemCollection:
+      description: >-
+        A GeoJSON FeatureCollection augmented with foreign members that contain
+        values relevant to a STAC entity
       type: object
       required:
         - features
@@ -822,6 +825,9 @@ components:
         links:
           $ref: '#/components/schemas/itemCollectionLinks'
     item:
+      description: >-
+        A GeoJSON Feature augmented with foreign members that contain values
+        relevant to a STAC entity
       type: object
       required:
         - id
@@ -928,13 +934,14 @@ components:
     itemCollectionLinks:
       type: array
       description: >-
-        An array of links to resources related to this collection.
+        An array of links. Can be used for pagination, e.g. by providing a link
+        with the `next` relation type.
       items:
         $ref: '#/components/schemas/link'
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/query/gasd312fsaeg/ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
 servers:
   - url: 'http://dev.cool-sat.com'
     description: Development server

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -941,7 +941,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/query/gasd312fsaeg/ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
 servers:
   - url: 'http://dev.cool-sat.com'
     description: Development server

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -608,7 +608,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/query/gasd312fsaeg/ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
 tags:
   - name: STAC
     description: Extension to WFS3 Core to support STAC metadata model and search API

--- a/extensions/label/examples/multidataset/catalog.json
+++ b/extensions/label/examples/multidataset/catalog.json
@@ -2,7 +2,7 @@
     "id": "label_extension_demo",
     "title": "label extension demo",
     "description": "Sample ML training data labels in the STAC format",
-    "stac_version": "0.7",
+    "stac_version": "0.7.0",
     "links":
     [
         {

--- a/extensions/label/examples/multidataset/spacenet-buildings/catalog.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/catalog.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "0.7",
+  "stac_version": "0.7.0",
   "id": "spacenet-buildings-collection",
   "title": "spacenet-buildings AoI",
   "description": "Collection of training labels for spacenet-buildings",

--- a/extensions/label/examples/multidataset/zanzibar/catalog.json
+++ b/extensions/label/examples/multidataset/zanzibar/catalog.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "0.7",
+  "stac_version": "0.7.0",
   "id": "zanzibar-collection",
   "title": "zanzibar AoI",
   "description": "Collection of training labels for zanzibar",

--- a/extensions/label/examples/spacenet-roads/roads_item.json
+++ b/extensions/label/examples/spacenet-roads/roads_item.json
@@ -72,8 +72,8 @@
           {
             "name": 6,
             "count": 4
-          },
-        ],
+          }
+        ]
       },
       {
         "property_key": "lane_number",


### PR DESCRIPTION
Two fixes:
1. Fixed issues in the label extension examples 
    - Invalid version numbers
    - Commas after last element in array
2. Re-generated the STAC API files as they seem to be outdated (seems a PR missed to run `npm run generate-all`)