### PR TITLE
search + transaction extension added to STAC-extensions.yaml

### DIFF
--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: The SpatioTemporal Asset Catalog API
+  title: The SpatioTemporal Asset Catalog API + Extensions
   version: 0.7.0
   description: >-
     This is an OpenAPI definition of the core SpatioTemporal Asset Catalog API
@@ -146,6 +146,50 @@ paths:
             text/html:
               schema:
                 type: string
+    post:
+      summary: add a new feature to a collection
+      description: create a new feature in a specific collection
+      operationId: postFeature
+      tags:
+        - Transaction Extension
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/item'
+                - $ref: '#/components/schemas/itemCollection'
+      responses:
+        '201':
+          description: Status of the create request.
+          headers:
+            Location:
+              description: A link to the item
+              schema:
+                type: string
+                format: url
+          content:
+            application/geo+json:
+              schema:
+                type: string
+            text/html:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        5XX:
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          description: An error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
   '/collections/{collectionId}/items/{featureId}':
     get:
       summary: retrieve a feature; use content negotiation to request HTML or GeoJSON
@@ -165,6 +209,115 @@ paths:
             text/html:
               schema:
                 type: string
+        default:
+          description: An error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+    put:
+      summary: update an existing feature by Id with a complete item definition
+      description: >-
+        Use this method to update an existing feature. Requires the entire
+        GeoJSON  description be submitted.
+      operationId: putFeature
+      tags:
+        - Transaction Extension
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+        - $ref: '#/components/parameters/featureId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/item'
+      responses:
+        '200':
+          description: Status of the update request.
+          content:
+            text/html:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        5XX:
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          description: An error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+    patch:
+      summary: update an existing feature by Id with a partial item definition
+      description: >-
+        Use this method to update an existing feature. Requires a GeoJSON 
+        fragement (containing the fields to be updated) be submitted.
+      operationId: patchFeature
+      tags:
+        - Transaction Extension
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+        - $ref: '#/components/parameters/featureId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/partialItem'
+      responses:
+        '200':
+          description: Status of the update request.
+          content:
+            text/html:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        5XX:
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          description: An error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/exception'
+            text/html:
+              schema:
+                type: string
+    delete:
+      summary: delete an existing feature by Id
+      description: Use this method to delete an existing feature.
+      operationId: deleteFeature
+      tags:
+        - Transaction Extension
+      parameters:
+        - $ref: '#/components/parameters/collectionId'
+        - $ref: '#/components/parameters/featureId'
+      responses:
+        '204':
+          description: Status of the delete request.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        5XX:
+          $ref: '#/components/responses/InternalServerError'
         default:
           description: An error occurred.
           content:
@@ -1133,11 +1286,70 @@ components:
         exclude:
           - geometry
           - properties.datetime
+    partialItem:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/itemId'
+        bbox:
+          $ref: '#/components/schemas/bbox'
+        geometry:
+          $ref: 'https://geojson.org/schema/Geometry.json'
+        type:
+          $ref: '#/components/schemas/itemType'
+        properties:
+          $ref: '#/components/schemas/partialItemProperties'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+        assets:
+          $ref: '#/components/schemas/itemAssets'
+      example:
+        assets:
+          analytic:
+            title: 1-Band Analytic
+            href: >-
+              http://cool-sat.com/catalog/collections/cs/items/CS3-201605XX_132130_04/analytic-1.tif
+    partialItemProperties:
+      type: object
+      description: allows for partial collections of metadata fields
+      additionalProperties: true
+      properties:
+        datetime:
+          $ref: '#/components/schemas/time'
+  responses:
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+    BadRequest:
+      description: The request was malformed or semantically invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+    InternalServerError:
+      description: >-
+        The request was syntactically and semantically valid, but an error
+        occurred while trying to act upon it
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+tags:
+  - name: Capabilities
+  - name: Features
+  - name: STAC
+    description: Extension to WFS3 Core to support STAC metadata model and search API
+  - name: Transaction Extension
+    description: >-
+      STAC-specific operations to add, remove, and edit items within WFS3
+      collections.
 servers:
   - url: 'http://dev.cool-sat.com'
     description: Development server
   - url: 'http://www.cool-sat.com'
     description: Production server
-tags:
-  - name: STAC
-    description: Extension to WFS3 Core to support STAC metadata model and search API

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -855,6 +855,25 @@ components:
             $ref: '#/components/schemas/item'
         links:
           $ref: '#/components/schemas/itemCollectionLinks'
+        'search:metadata':
+          type: object
+          required:
+            - next
+            - returned
+          properties:
+            next:
+              type: string
+              nullable: true
+            limit:
+              type: integer
+              nullable: true
+              minimum: 0
+            matched:
+              type: integer
+              minimum: 0
+            returned:
+              type: integer
+              minimum: 0
     item:
       description: >-
         A GeoJSON Feature augmented with foreign members that contain values

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -942,11 +942,13 @@ components:
         - rel: next
           href: >-
             http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+tags:
+  - name: Capabilities
+  - name: Features
+  - name: STAC
+    description: Extension to WFS3 Core to support STAC metadata model and search API
 servers:
   - url: 'http://dev.cool-sat.com'
     description: Development server
   - url: 'http://www.cool-sat.com'
     description: Production server
-tags:
-  - name: STAC
-    description: Extension to WFS3 Core to support STAC metadata model and search API

--- a/api-spec/extensions/STAC-extensions.fragment.yaml
+++ b/api-spec/extensions/STAC-extensions.fragment.yaml
@@ -1,0 +1,3 @@
+openapi: 3.0.1
+info:
+  title: The SpatioTemporal Asset Catalog API + Extensions

--- a/api-spec/extensions/STAC-extensions.merge.yaml
+++ b/api-spec/extensions/STAC-extensions.merge.yaml
@@ -1,1 +1,1 @@
-!!files_merge_append ["STAC.yaml", "extensions/query/query.fragment.yaml", "extensions/sort/sort.fragment.yaml", "extensions/fields/fields.fragment.yaml", "extensions/search/search.fragment.yaml"]
+!!files_merge_append ["STAC.yaml", "extensions/STAC-extensions.fragment.yaml", "extensions/query/query.fragment.yaml", "extensions/sort/sort.fragment.yaml", "extensions/fields/fields.fragment.yaml", "extensions/search/search.fragment.yaml", "extensions/transaction/transaction.fragment.yaml"]

--- a/api-spec/extensions/STAC-extensions.merge.yaml
+++ b/api-spec/extensions/STAC-extensions.merge.yaml
@@ -1,1 +1,1 @@
-!!files_merge_append ["STAC.yaml", "extensions/query/query.fragment.yaml", "extensions/sort/sort.fragment.yaml", "extensions/fields/fields.fragment.yaml"]
+!!files_merge_append ["STAC.yaml", "extensions/query/query.fragment.yaml", "extensions/sort/sort.fragment.yaml", "extensions/fields/fields.fragment.yaml", "extensions/search/search.fragment.yaml"]

--- a/api-spec/extensions/search/search.fragment.yaml
+++ b/api-spec/extensions/search/search.fragment.yaml
@@ -1,0 +1,24 @@
+components:
+  schemas:
+    itemCollection:
+      type: object
+      properties:
+        'search:metadata':
+          type: object
+          required:
+            - next
+            - returned
+          properties:
+            next:
+              type: string
+              nullable: true
+            limit:
+              type: integer
+              nullable: true
+              minimum: 0
+            matched:
+              type: integer
+              minimum: 0
+            returned:
+              type: integer
+              minimum: 0

--- a/api-spec/extensions/transaction/transaction.fragment.yaml
+++ b/api-spec/extensions/transaction/transaction.fragment.yaml
@@ -1,7 +1,4 @@
 openapi: 3.0.1
-info:
-  title: The SpatioTemporal Asset Catalog API + WFS3 + Transaction extension
-  version: 0.7.0
 paths:
   '/collections/{collectionId}/items':
     post:
@@ -9,7 +6,7 @@ paths:
       description: create a new feature in a specific collection
       operationId: postFeature
       tags:
-        - Extensions
+        - Transaction Extension
       parameters:
         - $ref: '#/components/parameters/collectionId'
       requestBody:
@@ -56,7 +53,7 @@ paths:
         GeoJSON  description be submitted.
       operationId: putFeature
       tags:
-        - Extensions
+        - Transaction Extension
       parameters:
         - $ref: '#/components/parameters/collectionId'
         - $ref: '#/components/parameters/featureId'
@@ -97,7 +94,7 @@ paths:
         fragement (containing the fields to be updated) be submitted.
       operationId: patchFeature
       tags:
-        - Extensions
+        - Transaction Extension
       parameters:
         - $ref: '#/components/parameters/collectionId'
         - $ref: '#/components/parameters/featureId'
@@ -136,7 +133,7 @@ paths:
       description: Use this method to delete an existing feature.
       operationId: deleteFeature
       tags:
-        - Extensions
+        - Transaction Extension
       parameters:
         - $ref: '#/components/parameters/collectionId'
         - $ref: '#/components/parameters/featureId'
@@ -174,7 +171,9 @@ components:
         properties:
           $ref: '#/components/schemas/partialItemProperties'
         links:
-          $ref: '#/components/schemas/links'
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
         assets:
           $ref: '#/components/schemas/itemAssets'
       example:
@@ -189,7 +188,6 @@ components:
       properties:
         datetime:
           $ref: '#/components/schemas/time'
-
   responses:
     NotFound:
       description: The specified resource was not found
@@ -209,9 +207,8 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/exception'
-
 tags:
-  - name: Extensions
+  - name: Transaction Extension
     description: >-
       STAC-specific operations to add, remove, and edit items within WFS3
       collections.

--- a/api-spec/openapi/WFS3.yaml
+++ b/api-spec/openapi/WFS3.yaml
@@ -342,3 +342,6 @@ components:
           example:
             - '2011-11-11T12:22:11Z'
             - '2012-11-24T12:32:43Z'
+tags:
+  - name: Capabilities
+  - name: Features


### PR DESCRIPTION
Here's a YAML definition for the search extension as it was missing from STAC-extensions.yaml as of now.

In contrast to the JSON Schema, I did not make `search:metadata` required in the YAML. 

Also added the Transaction extension to the STAC-extensions.yaml.

Plus: Some fixes.