### PR TITLE
Added pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
-**Related issue(s):** #
+**Related Issue(s):** #
 
 
-**Changes proposed in this pull request:**
+**Proposed Changes:**
 
 1. 
 2. 
 
 
-**Mandatory PR check list:**
+**PR Checklist:**
 
 - [ ] This PR has breaking changes.
 - [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md).
-- [ ] API only: I have updated the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions) by executing `npm run generate-all`.
+- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+**Related issue(s):** #
+
+
+**Changes proposed in this pull request:**
+
+1. 
+2. 
+
+
+**Mandatory PR check list:**
+
+- [ ] This PR has breaking changes.
+- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md).
+- [ ] API only: I have updated the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions) by executing `npm run generate-all`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,6 @@
 
 **PR Checklist:**
 
-- [ ] This PR has breaking changes.
+- [ ] This PR has **no** breaking changes.
 - [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
 - [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,8 @@
 1. 
 2. 
 
-
 **PR Checklist:**
 
 - [ ] This PR has breaking changes.
-- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md).
+- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
 - [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).


### PR DESCRIPTION
**Related issue(s):** None


**Changes proposed in this pull request:**

1. As discussed yesterday in the STAC meeting, here's a pull request template to remind users to add a CHANGELOG entry. I also added a general structure and two more check boxes for users to tick. It seemed useful to remind about the API generation and ask whether it's a breaking change.

As templates must be stored in the default branch, this PR is intentionally for master. See https://help.github.com/en/articles/about-issue-and-pull-request-templates

This PR uses the template.

**Mandatory PR check list:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have updated the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions) by executing `npm run generate-all`.