### PR TITLE
update CHANGELOG with older commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 	- WFS links have additional fields `hreflang` and `length`.
 	- WFS Collections have additional fields `crs` and `itemType`.
 - Clarified meaning of SAR and EO platform, constellation, and instrument
+- Numerous typos, clarification and general word-smithing
+- The API intersects parameter now accepts a GeoJSON Geometry (any type) *instead* of a GeoJSON Feature.
+- `time` API parameter changed to `datetime` (changed in WFS3)
+- Clarification on `include` and `exclude` parameters in the field extension and notes on default values.
+- API queries should contain either `bbox` or `intersects`.
 
 ### Added
 - **stac_version**: Each Item must specify the STAC version.
 - **stac_extensions**: Introduced this field for Items, Catalogs and Collections.
 - Property `summaries` have been added to catalogs and collections.
 - API Transaction extension supports optimistic locking through use of the ETag header.
-
+- [Label extension](extensions/label/README.md) added with additional fields for describing labeled data, such as used for training data or from the output of a classification
+- Timestamp fields added to `Item`: `created` and `updated` to refer to the datetime the metadata file was created or updated.
+- Added Search Metadata API extension which adds fields to a response from a STAC API such as the number of items found and how many were returned.
+- ItemCollection class added to spec that is a GeoJSON FeatureCollection of Items, such as what would be returned from a search. Located in item directory.
+- `in` operator added to the query extension (to check if value is in a list of values)
 
 ## [v0.7.0] - 2019-05-06
 


### PR DESCRIPTION
**Related Issue(s):** #545 


**Proposed Changes:**

1. Update CHANGELOG with older commits that weren't yet in the CHANGELOG

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).