### PR TITLE
EO Extension Readme Updates (Version 2)

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -102,18 +102,18 @@ evolve to make fully resolved namespacing an option.
 
 An example of this can be seen in a Landsat example:
 
-```json
+```
   "properties": {
-	"datetime":"2018-01-01T13:21:30Z",
+    "datetime":"2018-01-01T13:21:30Z",
 
     "dtr:start_datetime":"2018-01-01T13:21:30Z",
     "dtr:end_datetime":"2018-01-01T13:31:30Z",
 
-    "eo:off_nadir_angle": -0.001,
+    "eo:off_nadir": -0.001,
     "eo:cloud_cover": 10.31,
     "eo:sun_azimuth": 149.01607154,
     "eo:sun_elevation": 59.21424700,
-    "eo:resolution": 30,
+    "eo:gsd": 30,
 
     "l8:data_type": "L1T",
     "l8:wrs_path": 153,
@@ -127,7 +127,7 @@ An example of this can be seen in a Landsat example:
     "l8:geometric_rmse_model_y": 4.654,
     "l8:geometric_rmse_verify": 5.364,
     "l8:image_quality_oli": 9
-  },
+  }
 ```
 
 ### Directory Structure

--- a/extensions/eo/README.md
+++ b/extensions/eo/README.md
@@ -136,49 +136,63 @@ Asset definitions that contain band data should reference the band index. Each a
 | ---------- | -------- | -------------------------------------------- |
 | eo:bands   | [number] | Lists the band names available in the asset. |
 
-See [landsat8-merged.json](examples/landsat8-merged.json) for a full example.
+See [example-landsat8.json](examples/example-landsat8.json) for a full example.
 ```
 {
   "stac_version": "0.8.0",
   "stac_extensions": ["eo"],
-  "id": "LC81530252014153LGN00",
+  "id": "LC08_L1TP_107018_20181001_20181001_01_RT",
   "type": "Feature",
   ...
   "properties": {
     ...
+    "eo:bands": [
+      {
+        "name": "B1",
+        "common_name": "coastal",
+        "gsd": 30,
+        "center_wavelength": 0.44,
+        "full_width_half_max": 0.02
+      },
+      {
+        "name": "B2",
+        "common_name": "blue",
+        "gsd": 30,
+        "center_wavelength": 0.48,
+        "full_width_half_max": 0.06
+      },
+      {
+        "name": "B3",
+        "common_name": "green",
+        "gsd": 30,
+        "center_wavelength": 0.56,
+        "full_width_half_max": 0.06
+      },
+      ...
+    ]
   },
-
-  "assets" :{
+  "assets": {
     "B1": {
-      "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B1.TIF",
+      "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B1.TIF",
       "type": "image/vnd.stac.geotiff",
-      "eo:bands": [0]
+      "eo:bands": [0],
+      "title": "Band 1 (coastal)"
     },
     "B2": {
-      "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B2.TIF",
+      "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B2.TIF",
       "type": "image/vnd.stac.geotiff",
-      "eo:bands": [1]
+      "eo:bands": [1],
+      "title": "Band 2 (blue)"
+    },
+    "B3": {
+      "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B3.TIF",
+      "type": "image/vnd.stac.geotiff",
+      "eo:bands": [2],
+      "title": "Band 3 (green)"
     },
     ...
-  },
-  "eo:bands": [
-    {
-      "name": "B01",
-      "common_name": "coastal",
-      "gsd": 30.0,
-      "wavelength": 0.44,
-      "full_width_half_max": 0.02
-    },
-    {
-      "name": "B02",
-      "common_name": "blue",
-      "gsd": 30.0,
-      "wavelength": 0.48,
-      "full_width_half_max": 0.06
-    },
-    ...
-  ]
- }
+  }
+}
 ```
 Planet example:
 
@@ -188,42 +202,40 @@ Planet example:
   "stac_extensions": ["eo"],
   "id": "20171110_121030_1013",
   "type": "Feature",
+  ...
   "properties": {
     ...
+    "eo:bands": [
+      {
+        "full_width_half_max": 0.08,
+        "center_wavelength": 0.63,
+        "common_name": "red"
+      },
+      {
+        "full_width_half_max": 0.09,
+        "center_wavelength": 0.545,
+        "common_name": "green"
+      },
+      {
+        "full_width_half_max": 0.06,
+        "center_wavelength": 0.485,
+        "common_name": "blue"
+      },
+      {
+        "full_width_half_max": 0.08,
+        "center_wavelength": 0.82,
+        "common_name": "nir"
+      }
+    ]
   },
-  ...
   "assets": {
     "analytic": {
       "href": "https://api.planet.com/data/v1/assets/eyJpIjogIjIwMTcxMTEwXzEyMTAxMF8xMDEzIiwgImMiOiAiUFNTY2VuZTRCYW5kIiwgInQiOiAiYW5hbHl0aWMiLCAiY3QiOiAiaXRlbS10eXBlIn0",
-      "name": "PSScene4Band GeoTIFF (COG)",
-      "eo:bands":[0,1,2,3]
-      ...
+      "title": "PSScene4Band GeoTIFF (COG)",
+      "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+      "eo:bands": [0,1,2,3]
     }
-    ...
-
-  },
-  "eo:bands": [
-    {
-      "full_width_half_max": 0.08,
-      "center_wavelength": 0.63,
-      "common_name": "red"
-    },
-    {
-      "full_width_half_max": 0.09,
-      "center_wavelength": 0.545,
-      "common_name": "green"
-    },
-    {
-      "full_width_half_max": 0.06,
-      "center_wavelength": 0.485,
-      "common_name": "blue"
-    },
-    {
-      "full_width_half_max": 0.08,
-      "center_wavelength": 0.82,
-      "common_name": "nir"
-    }
-  ]
+  }
 }
 ```
 


### PR DESCRIPTION


**Related PR(s):** #567 (closed because the branch based on master and a fairly old fork)
Addresses issue raised in STAC/Lobby 

> The README here https://github.com/radiantearth/stac-spec/tree/dev/extensions, under the section “Prefixes”, makes it seem like extension prefixes (like eo) are for keys in the properties object of the Item (this is also how https://github.com/radiantearth/stac-spec/blob/dev/extensions/eo/examples/example-landsat8.json is set up). The examples in https://github.com/radiantearth/stac-spec/blob/dev/extensions/eo/README.md make it seem like they go direclty into the body of the Item object. Is this a misplacement in the latter? Is extension Item information explicitly supposed to go into the properties object of the Item?

**Proposed Changes:**

1. Modifies examples in Assets Object section of EO extension README to place eo:bands inside of item properties and corrects a linked example JSON.
1. Updates Prefixes section of extension README with eo:gsd in place of eo:resolution.
1. Includes changes from @m-mohr in the closed PR that improved consistency between EO examples and corrected another prefix  in the EO example table.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] ~~I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)~~ **or** a CHANGELOG entry is not required. Documentation changes only.
- [x] ~~API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).~~ Not API.