### PR TITLE
Fix link to Search Extension in ItemCollection spec

### DIFF
--- a/item-spec/itemcollection-spec.md
+++ b/item-spec/itemcollection-spec.md
@@ -37,5 +37,4 @@ This object describes a STAC ItemCollection. The fields `type` and `features` ar
 
 ## Extensions
 
-The [Search Extension](../extensions/search/README.md) adds additional fields to STAC ItemCollection relevant to their use as 
-search results.
+The [Search Extension](../api-spec/extensions/search/README.md) adds additional fields to STAC ItemCollection relevant to their use as search results.


### PR DESCRIPTION
**Related Issue(s):**

None

**Proposed Changes:**

Fix broken link to search extension in ItemCollection spec markdown document.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).