### PR TITLE
Fixing typo

### DIFF
--- a/api-spec/extensions/search/README.md
+++ b/api-spec/extensions/search/README.md
@@ -19,7 +19,7 @@ search, for example, from calling the `/stac/search` API endpoint.
 | Element      | Type            | Description                                                  |
 | ------------ | --------------- | ------------------------------------------------------------ |
 | next         | string \| null  | **REQUIRED.** The value to set for the `next` query parameter in order to get the next page of results |
-| returned     | integer         | **REQUIRED*** The count of results returned by this response. equal to the cardinality of features array |
+| returned     | integer         | **REQUIRED** The count of results returned by this response. equal to the cardinality of features array |
 | limit        | integer \| null | The maximum number of results to which the result was limited |
 | matched        | integer         | The count of total number of results that match for this query, possibly estimated, particularly in the context of NoSQL data stores |
 


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. Just removing the third *, which was meant to make things bold, but only two * are required.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).