### PR TITLE
Changed GeoTIFF type from `image/vnd.stac.geotiff` to `image/tiff; application=geotiff`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ typings/
 
 # next.js build output
 .next
+
+# IntelliJ IDEA files
+.idea/
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Changed GeoTIFF type from `image/vnd.stac.geotiff` to `image/tiff; application=geotiff`
+
 ### Fixed
 - [Label extension](extensions/label/README.md): moved label:classes to be a list of Class Objects from a single Class Object in spec markdown and json schema (matching previous example JSON).
 - [Label extension](extensions/label/README.md): moved label:overview to be a list of Overview Objects from a single Overview Object in spec markdown and json schema (matching previous example JSON).

--- a/collection-spec/examples/landsat-item.json
+++ b/collection-spec/examples/landsat-item.json
@@ -56,7 +56,7 @@
         },
         "B1": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B1.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 0
             ],
@@ -64,7 +64,7 @@
         },
         "B2": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B2.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 1
             ],
@@ -72,7 +72,7 @@
         },
         "B3": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B3.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 2
             ],
@@ -80,7 +80,7 @@
         },
         "B4": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B4.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 3
             ],
@@ -88,7 +88,7 @@
         },
         "B5": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B5.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 4
             ],
@@ -96,7 +96,7 @@
         },
         "B6": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B6.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 5
             ],
@@ -104,7 +104,7 @@
         },
         "B7": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B7.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 6
             ],
@@ -112,7 +112,7 @@
         },
         "B8": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B8.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 7
             ],
@@ -120,7 +120,7 @@
         },
         "B9": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B9.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 8
             ],
@@ -128,7 +128,7 @@
         },
         "B10": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B10.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 9
             ],
@@ -136,7 +136,7 @@
         },
         "B11": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B11.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 10
             ],
@@ -145,7 +145,7 @@
         "BQA": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_BQA.TIF",
             "title": "Band quality data",
-            "type": "image/vnd.stac.geotiff"
+            "type": "image/tiff; application=geotiff"
         },
         "MTL": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_MTL.txt",

--- a/extensions/asset/examples/example-landsat8.json
+++ b/extensions/asset/examples/example-landsat8.json
@@ -158,77 +158,77 @@
         "type": "image/jpeg"
       },
       "B1": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           0
         ],
         "title": "Band 1 (coastal)"
       },
       "B2": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           1
         ],
         "title": "Band 2 (blue)"
       },
       "B3": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           2
         ],
         "title": "Band 3 (green)"
       },
       "B4": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           3
         ],
         "title": "Band 4 (red)"
       },
       "B5": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           4
         ],
         "title": "Band 5 (nir)"
       },
       "B6": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           5
         ],
         "title": "Band 6 (swir16)"
       },
       "B7": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           6
         ],
         "title": "Band 7 (swir22)"
       },
       "B8": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           7
         ],
         "title": "Band 8 (pan)"
       },
       "B9": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           8
         ],
         "title": "Band 9 (cirrus)"
       },
       "B10": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           9
         ],
         "title": "Band 10 (lwir)"
       },
       "B11": {
-        "type": "image/vnd.stac.geotiff",
+        "type": "image/tiff; application=geotiff",
         "eo:bands": [
           10
         ],
@@ -244,7 +244,7 @@
       },
       "BQA": {
         "title": "Band quality data",
-        "type": "image/vnd.stac.geotiff"
+        "type": "image/tiff; application=geotiff"
       }
     },
     "links": []

--- a/extensions/eo/README.md
+++ b/extensions/eo/README.md
@@ -174,19 +174,19 @@ See [example-landsat8.json](examples/example-landsat8.json) for a full example.
   "assets": {
     "B1": {
       "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B1.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [0],
       "title": "Band 1 (coastal)"
     },
     "B2": {
       "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B2.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [1],
       "title": "Band 2 (blue)"
     },
     "B3": {
       "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B3.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [2],
       "title": "Band 3 (green)"
     },
@@ -232,7 +232,7 @@ Planet example:
     "analytic": {
       "href": "https://api.planet.com/data/v1/assets/eyJpIjogIjIwMTcxMTEwXzEyMTAxMF8xMDEzIiwgImMiOiAiUFNTY2VuZTRCYW5kIiwgInQiOiAiYW5hbHl0aWMiLCAiY3QiOiAiaXRlbS10eXBlIn0",
       "title": "PSScene4Band GeoTIFF (COG)",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; cloud-optimized=true",
       "eo:bands": [0,1,2,3]
     }
   }

--- a/extensions/eo/examples/example-landsat8.json
+++ b/extensions/eo/examples/example-landsat8.json
@@ -139,7 +139,7 @@
         },
         "B1": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B1.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 0
             ],
@@ -147,7 +147,7 @@
         },
         "B2": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B2.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 1
             ],
@@ -155,7 +155,7 @@
         },
         "B3": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B3.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 2
             ],
@@ -163,7 +163,7 @@
         },
         "B4": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B4.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 3
             ],
@@ -171,7 +171,7 @@
         },
         "B5": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B5.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 4
             ],
@@ -179,7 +179,7 @@
         },
         "B6": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B6.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 5
             ],
@@ -187,7 +187,7 @@
         },
         "B7": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B7.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 6
             ],
@@ -195,7 +195,7 @@
         },
         "B8": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B8.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 7
             ],
@@ -203,7 +203,7 @@
         },
         "B9": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B9.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 8
             ],
@@ -211,7 +211,7 @@
         },
         "B10": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B10.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 9
             ],
@@ -219,7 +219,7 @@
         },
         "B11": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B11.TIF",
-            "type": "image/vnd.stac.geotiff",
+            "type": "image/tiff; application=geotiff",
             "eo:bands": [
                 10
             ],
@@ -228,7 +228,7 @@
         "BQA": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_BQA.TIF",
             "title": "Band quality data",
-            "type": "image/vnd.stac.geotiff"
+            "type": "image/tiff; application=geotiff"
         },
         "MTL": {
             "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_MTL.txt",

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
@@ -1102,7 +1102,7 @@
     "raster": {
       "title": "AOI_2_Vegas_img2636_previewcog",
       "href": "https://spacenet-dataset.s3.amazonaws.com/AOI_2_Vegas/srcData/rasterData/AOI_2_Vegas_MUL-PanSharpen_Cloud.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; cloud-optimized=true"
     }
   },
   "properties": {

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
@@ -1506,7 +1506,7 @@
     "raster": {
       "title": "AOI_3_Paris_img1648_previewcog",
       "href": "https://spacenet-dataset.s3.amazonaws.com/AOI_3_Paris/srcData/rasterData/AOI_3_Paris_MUL-PanSharpen_Cloud.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; cloud-optimized=true"
     }
   },
   "properties": {

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
@@ -686,7 +686,7 @@
     "raster": {
       "title": "AOI_4_Shanghai_img3344_previewcog",
       "href": "https://spacenet-dataset.s3.amazonaws.com/AOI_4_Shanghai/srcData/rasterData/AOI_4_Shanghai_MUL-PanSharpen_Cloud.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; cloud-optimized=true"
     }
   },
   "properties": {

--- a/extensions/label/examples/multidataset/zanzibar/znz001.json
+++ b/extensions/label/examples/multidataset/zanzibar/znz001.json
@@ -167650,7 +167650,7 @@
     "raster": {
       "title": "znz001_previewcog",
       "href": "https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; cloud-optimized=true"
     },
     "thumbnail": {
       "title": "znz001_thumbnail",

--- a/extensions/label/examples/multidataset/zanzibar/znz029.json
+++ b/extensions/label/examples/multidataset/zanzibar/znz029.json
@@ -48910,7 +48910,7 @@
     "raster": {
       "title": "znz029_previewcog",
       "href": "https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; cloud-optimized=true"
     },
     "thumbnail": {
       "title": "znz029_thumbnail",

--- a/extensions/label/examples/spacenet-roads/roads_source.json
+++ b/extensions/label/examples/spacenet-roads/roads_source.json
@@ -21,22 +21,22 @@
     "rgb": {
       "title": "RGB Pan Sharpened (primary)",
       "href": "https://spacenet-dataset.s3.amazonaws.com/SpaceNet_Roads_Competition/Train/AOI_3_Paris_Roads_Train/RGB-PanSharpen/RGB-PanSharpen_AOI_3_Paris_img101.tif",
-      "type": "image/vnd.stac.geotiff"
+      "type": "image/tiff; application=geotiff"
     },
     "multi": {
       "title": "8 band multispectral",
       "href": "https://spacenet-dataset.s3.amazonaws.com/SpaceNet_Roads_Competition/Train/AOI_3_Paris_Roads_Train/MUL/MUL_AOI_3_Paris_img101.tif",
-      "type": "image/vnd.stac.geotiff"
+      "type": "image/tiff; application=geotiff"
     },
     "multi-pan": {
       "title": "8 band pan-sharpened multispectral",
       "href": "https://spacenet-dataset.s3.amazonaws.com/SpaceNet_Roads_Competition/Train/AOI_3_Paris_Roads_Train/MUL-PanSharpen/MUL-PanSharpen_AOI_3_Paris_img101.tif",
-      "type": "image/vnd.stac.geotiff"
+      "type": "image/tiff; application=geotiff"
     },
     "pan": {
       "title": "Single band panchromatic",
       "href": "https://spacenet-dataset.s3.amazonaws.com/SpaceNet_Roads_Competition/Train/AOI_3_Paris_Roads_Train/PAN/PAN_AOI_3_Paris_img101.tif",
-      "type": "image/vnd.stac.geotiff"
+      "type": "image/tiff; application=geotiff"
     }
   },
   "links": []

--- a/item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json
+++ b/item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json
@@ -78,28 +78,28 @@
     },
     "B5": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND5.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; cloud-optimized=true",
       "eo:bands": [
         0
       ]
     },
     "B6": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND6.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; cloud-optimized=true",
       "eo:bands": [
         1
       ]
     },
     "B7": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND7.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; cloud-optimized=true",
       "eo:bands": [
         2
       ]
     },
     "B8": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND8.tif",
-      "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; cloud-optimized=true",
       "eo:bands": [
         3
       ]

--- a/item-spec/examples/landsat8-sample.json
+++ b/item-spec/examples/landsat8-sample.json
@@ -75,57 +75,57 @@
     },
     "B1": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B1.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [0]
     },
     "B2": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B2.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [1]
     },
     "B3": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B3.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [2]
     },
     "B4": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B4.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [3]
     },
     "B5": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B5.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [4]
     },
     "B6": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B6.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [5]
     },
     "B7": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B7.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [6]
     },
     "B8": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B8.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [7]
     },
     "B9": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B9.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [8]
     },
     "B10": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B10.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [9]
     },
     "B11": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B11.TIF",
-      "type": "image/vnd.stac.geotiff",
+      "type": "image/tiff; application=geotiff",
       "eo:bands": [10]
     }
   }

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -232,5 +232,5 @@ There is a lot of metadata that is only of relevance to advanced processing algo
 It is recommended to have a complementary HTML version of each `Item` available for easy human consumption and search 
 engine crawlability. The exact nature of the HTML is not part of the specification, but it is recommended to use common
 ecosystem tools like [STAC Browser](https://github.com/radiantearth/stac-browser) to generate it. More information on creating 
-HTML versions of STAC can be found in the [STAC on the Web section](../best-practices.md#stac-on-the-web)  
-of the catalog best practices document.
+HTML versions of STAC can be found in the [STAC on the Web section](../best-practices.md#stac-on-the-web) of the catalog 
+best practices document.

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -193,8 +193,8 @@ Common STAC Item Media Types:
 
 | Media Type                       | Description                                                                             |
 | -------------------------------- | --------------------------------------------------------------------------------------- |
-| `image/tiff` or `image/vnd.stac.geotiff` | GeoTIFF with standardized georeferencing metadata                               |
-| `image/vnd.stac.geotiff; cloud-optimized=true` | Cloud Optimized GeoTIFF                                                   |
+| `image/tiff; application=geotiff`| GeoTIFF with standardized georeferencing metadata                               |
+| `image/tiff; application=geotiff; cloud-optimized=true` | Cloud Optimized GeoTIFF                                                   |
 | `image/jp2`                      | JPEG 2000                                                                               |
 | `image/png`                      | Visual PNGs (e.g. thumbnails)                                                           |
 | `image/jpeg`                     | Visual JPEGs (e.g. thumbnails, oblique)                                                 |
@@ -206,9 +206,9 @@ Common STAC Item Media Types:
 | `application/x-hdf5`             | Hierarchical Data Format version 5                                                      |
 | `application/x-hdf`              | Hierarchical Data Format versions 4 and earlier.                                        |
 
-Note: should GeoTIFF become an IANA-registered type in the future (e.g., [`image/tiff; application=geojson`](https://github.com/opengeospatial/geotiff/issues/34#issuecomment-514078289)),
-this will be added as a recommended media type and `image/vnd.stac.geotiff` will be deprecated.
-Same applies for [Cloud Optimized GeoTiffs](http://osgeo-org.1560.x6.nabble.com/Media-type-tc5411498.html).
+Note: should Cloud Optimized GeoTIFF become an IANA-registered type in the future this will be added as a recommended 
+media type and `image/tiff; application=geotiff; cloud-optimized=true` will be deprecated.
+[Cloud Optimized GeoTiffs](http://osgeo-org.1560.x6.nabble.com/Media-type-tc5411498.html).
 
 ## Extensions
 
@@ -232,5 +232,5 @@ There is a lot of metadata that is only of relevance to advanced processing algo
 It is recommended to have a complementary HTML version of each `Item` available for easy human consumption and search 
 engine crawlability. The exact nature of the HTML is not part of the specification, but it is recommended to use common
 ecosystem tools like [STAC Browser](https://github.com/radiantearth/stac-browser) to generate it. More information on creating 
-HTML versions of STAC can be found in the [STAC on the Web section](../best-practices.md#stac-on-the-web) 
+HTML versions of STAC can be found in the [STAC on the Web section](../best-practices.md#stac-on-the-web)  
 of the catalog best practices document.


### PR DESCRIPTION
**Related Issue(s):** 
https://github.com/radiantearth/stac-spec/issues/535

**Proposed Changes:**

1. Changed GeoTIFF type from `image/vnd.stac.geotiff` to `image/tiff; application=geotiff`

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).