### PR TITLE
Media types once again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
-- Changed GeoTIFF type from `image/vnd.stac.geotiff` to `image/tiff; application=geotiff`
+- Changed GeoTIFF media type from `image/vnd.stac.geotiff` to `image/tiff; application=geotiff`, changed Cloud-optimized GeoTiff media type from `image/vnd.stac.geotiff; cloud-optimized=true` to `image/tiff; application=geotiff; profile=cloud-optimized`.
 
 ### Fixed
 - [Label extension](extensions/label/README.md): moved label:classes to be a list of Class Objects from a single Class Object in spec markdown and json schema (matching previous example JSON).

--- a/extensions/eo/README.md
+++ b/extensions/eo/README.md
@@ -232,7 +232,7 @@ Planet example:
     "analytic": {
       "href": "https://api.planet.com/data/v1/assets/eyJpIjogIjIwMTcxMTEwXzEyMTAxMF8xMDEzIiwgImMiOiAiUFNTY2VuZTRCYW5kIiwgInQiOiAiYW5hbHl0aWMiLCAiY3QiOiAiaXRlbS10eXBlIn0",
       "title": "PSScene4Band GeoTIFF (COG)",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "eo:bands": [0,1,2,3]
     }
   }

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
@@ -1102,7 +1102,7 @@
     "raster": {
       "title": "AOI_2_Vegas_img2636_previewcog",
       "href": "https://spacenet-dataset.s3.amazonaws.com/AOI_2_Vegas/srcData/rasterData/AOI_2_Vegas_MUL-PanSharpen_Cloud.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     }
   },
   "properties": {

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
@@ -1506,7 +1506,7 @@
     "raster": {
       "title": "AOI_3_Paris_img1648_previewcog",
       "href": "https://spacenet-dataset.s3.amazonaws.com/AOI_3_Paris/srcData/rasterData/AOI_3_Paris_MUL-PanSharpen_Cloud.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     }
   },
   "properties": {

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
@@ -686,7 +686,7 @@
     "raster": {
       "title": "AOI_4_Shanghai_img3344_previewcog",
       "href": "https://spacenet-dataset.s3.amazonaws.com/AOI_4_Shanghai/srcData/rasterData/AOI_4_Shanghai_MUL-PanSharpen_Cloud.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     }
   },
   "properties": {

--- a/extensions/label/examples/multidataset/zanzibar/znz001.json
+++ b/extensions/label/examples/multidataset/zanzibar/znz001.json
@@ -167650,7 +167650,7 @@
     "raster": {
       "title": "znz001_previewcog",
       "href": "https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     },
     "thumbnail": {
       "title": "znz001_thumbnail",

--- a/extensions/label/examples/multidataset/zanzibar/znz029.json
+++ b/extensions/label/examples/multidataset/zanzibar/znz029.json
@@ -48910,7 +48910,7 @@
     "raster": {
       "title": "znz029_previewcog",
       "href": "https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true"
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     },
     "thumbnail": {
       "title": "znz029_thumbnail",

--- a/item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json
+++ b/item-spec/examples/CBERS_4_MUX_20181029_177_106_L4.json
@@ -78,28 +78,28 @@
     },
     "B5": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND5.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "eo:bands": [
         0
       ]
     },
     "B6": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND6.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "eo:bands": [
         1
       ]
     },
     "B7": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND7.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "eo:bands": [
         2
       ]
     },
     "B8": {
       "href": "s3://cbers-pds/CBERS4/MUX/177/106/CBERS_4_MUX_20181029_177_106_L4/CBERS_4_MUX_20181029_177_106_L4_BAND8.tif",
-      "type": "image/tiff; application=geotiff; cloud-optimized=true",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "eo:bands": [
         3
       ]

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -191,24 +191,24 @@ would be appropriate; if it is an XML, then `text/xml` is appropriate.
 
 Common STAC Item Media Types:
 
-| Media Type                       | Description                                                                             |
-| -------------------------------- | --------------------------------------------------------------------------------------- |
-| `image/tiff; application=geotiff`| GeoTIFF with standardized georeferencing metadata                               |
-| `image/tiff; application=geotiff; cloud-optimized=true` | Cloud Optimized GeoTIFF                                                   |
-| `image/jp2`                      | JPEG 2000                                                                               |
-| `image/png`                      | Visual PNGs (e.g. thumbnails)                                                           |
-| `image/jpeg`                     | Visual JPEGs (e.g. thumbnails, oblique)                                                 |
-| `text/xml` or `application/xml`  | XML metadata [RFC 7303](https://www.ietf.org/rfc/rfc7303.txt)                           |
-| `application/json`               | JSON metadata                                                                           |
-| `text/plain`                     | Plain text metadata                                                                     |
-| `application/geo+json`           | GeoJSON                                                                                 |
-| `application/geopackage+sqlite3` | GeoPackage                                                                              |
-| `application/x-hdf5`             | Hierarchical Data Format version 5                                                      |
-| `application/x-hdf`              | Hierarchical Data Format versions 4 and earlier.                                        |
+| Media Type                                              | Description                                                  |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| `image/tiff; application=geotiff`                       | GeoTIFF with standardized georeferencing metadata            |
+| `image/tiff; application=geotiff; cloud-optimized=true` | Cloud Optimized GeoTIFF (unofficial). Once there is an [official media type](http://osgeo-org.1560.x6.nabble.com/Media-type-tc5411498.html) it will be added and the proprietary media type here will be deprecated. |
+| `image/jp2`                                             | JPEG 2000                                                    |
+| `image/png`                                             | Visual PNGs (e.g. thumbnails)                                |
+| `image/jpeg`                                            | Visual JPEGs (e.g. thumbnails, oblique)                      |
+| `text/xml` or `application/xml`                         | XML metadata [RFC 7303](https://www.ietf.org/rfc/rfc7303.txt) |
+| `application/json`                                      | JSON metadata                                                |
+| `text/plain`                                            | Plain text metadata                                          |
+| `application/geo+json`                                  | GeoJSON                                                      |
+| `application/geopackage+sqlite3`                        | GeoPackage                                                   |
+| `application/x-hdf5`                                    | Hierarchical Data Format version 5                           |
+| `application/x-hdf`                                     | Hierarchical Data Format versions 4 and earlier.             |
 
-Note: should Cloud Optimized GeoTIFF become an IANA-registered type in the future this will be added as a recommended 
-media type and `image/tiff; application=geotiff; cloud-optimized=true` will be deprecated.
-[Cloud Optimized GeoTiffs](http://osgeo-org.1560.x6.nabble.com/Media-type-tc5411498.html).
+Deprecation notice: GeoTiff previously used the media type `image/vnd.stac.geotiff` and
+Cloud Optimized GeoTiffs used `image/vnd.stac.geotiff; cloud-optimized=true`.
+Both can still appear in old catalogues, but are deprecated and should be replaced.
 
 ## Extensions
 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -194,7 +194,7 @@ Common STAC Item Media Types:
 | Media Type                                              | Description                                                  |
 | ------------------------------------------------------- | ------------------------------------------------------------ |
 | `image/tiff; application=geotiff`                       | GeoTIFF with standardized georeferencing metadata            |
-| `image/tiff; application=geotiff; cloud-optimized=true` | Cloud Optimized GeoTIFF (unofficial). Once there is an [official media type](http://osgeo-org.1560.x6.nabble.com/Media-type-tc5411498.html) it will be added and the proprietary media type here will be deprecated. |
+| `image/tiff; application=geotiff; profile=cloud-optimized` | Cloud Optimized GeoTIFF (unofficial). Once there is an [official media type](http://osgeo-org.1560.x6.nabble.com/Media-type-tc5411498.html) it will be added and the proprietary media type here will be deprecated. |
 | `image/jp2`                                             | JPEG 2000                                                    |
 | `image/png`                                             | Visual PNGs (e.g. thumbnails)                                |
 | `image/jpeg`                                            | Visual JPEGs (e.g. thumbnails, oblique)                      |
@@ -207,7 +207,7 @@ Common STAC Item Media Types:
 | `application/x-hdf`                                     | Hierarchical Data Format versions 4 and earlier.             |
 
 Deprecation notice: GeoTiff previously used the media type `image/vnd.stac.geotiff` and
-Cloud Optimized GeoTiffs used `image/vnd.stac.geotiff; cloud-optimized=true`.
+Cloud Optimized GeoTiffs used `image/vnd.stac.geotiff; profile=cloud-optimized`.
 Both can still appear in old catalogues, but are deprecated and should be replaced.
 
 ## Extensions


### PR DESCRIPTION
**Related Issue(s):** #594, #535 


**Proposed Changes:**

1. I think PR #594 was missing a deprecation notice containing the old media types.
2. Also, in the COG mailing list discussion it seemed that people were not super happy with a boolean flag, but rather would prefer it being a profile. Therefore proposing to changing from `cloud-optimized=true` to `profile=cloud-optimized`.

I think we should definitely merge point 1. Point 2 is open for discussions and I can revert that if nobody likes it.

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).