### PR TITLE
Single File STAC: Documentation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed GeoTIFF type from `image/vnd.stac.geotiff` to `image/tiff; application=geotiff`
 
 ### Fixed
+- Updated language, fixed typos and examples.
 - [Label extension](extensions/label/README.md): moved label:classes to be a list of Class Objects from a single Class Object in spec markdown and json schema (matching previous example JSON).
 - [Label extension](extensions/label/README.md): moved label:overview to be a list of Overview Objects from a single Overview Object in spec markdown and json schema (matching previous example JSON).
 

--- a/extensions/single-file-stac/README.md
+++ b/extensions/single-file-stac/README.md
@@ -17,15 +17,15 @@ A Single File STAC is an [ItemCollection Object](../../item-spec/itemcollection-
 
 | Field Name         | Type   | Description                                                  |
 | ------------------ | ------ | ------------------------------------------------------------ |
-| collections | [Collection](../../collection-spec/collection-spec.md#collection-fields)] | An array of Collections that are used by any of the Items in the ItemCollection.
+| collections | [[Collection](../../collection-spec/collection-spec.md#collection-fields)] | An array of Collections that are used by any of the Items in the ItemCollection. |
 | search | [Search Object](#search-object) | An optional field containing a search endpoint and parameters used to generate this Single File STAC |
 
 ## Search Object
 
 | Field Name         | Type   | Description                                                  |
 | ------------------ | ------ | ------------------------------------------------------------ |
-| endpoint | string | The root endpoint of a STAC API used for this search.
-| parameters | map<string, Object> | A dictionary of all the parameters used for the search |
+| endpoint | string | The root endpoint of a STAC API used for this search.                  |
+| parameters | Map<string, Object> | A dictionary of all the parameters used for the search. |
 
 ## Implementations
 


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. Found that there was a missing `[` in the collections data type.
2. Fixed the tables (for stricter Markdown readers).

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).