### PR TITLE
Pluralized forms of fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed GeoTIFF type from `image/vnd.stac.geotiff` to `image/tiff; application=geotiff`
 
 ### Fixed
-- [Label extension](extensions/label/README.md): moved label:classes to be a list of Class Objects from a single Class Object in spec markdown and json schema (matching previous example JSON).
-- [Label extension](extensions/label/README.md): moved label:overview to be a list of Overview Objects from a single Overview Object in spec markdown and json schema (matching previous example JSON).
+- [Label extension](extensions/label/README.md):
+    - moved label:classes to be a list of Class Objects from a single Class Object in spec markdown and json schema (matching previous example JSON).
+    - moved label:overview to be a list of Overview Objects from a single Overview Object in spec markdown and json schema (matching previous example JSON).
+    - Renamed fields to use plural forms (`label:property` -> `label:properties`, `label:task` -> `label:tasks`, `label:method` -> `label:methods` and `label:overview` -> `label:overviews`)
+- Renamed `pc:schema` to `pc:schemas` in the Point Cloud extension.
 
 ## [v0.8.0-RC1] - 2019-08-23
 

--- a/extensions/label/README.md
+++ b/extensions/label/README.md
@@ -46,13 +46,13 @@ Some additional notes are given here for some of the core STAC Item fields and w
 ### New Item properties
 | element           | type info            | name                       | description       |
 |-------------------|----------------------|----------------------------|--------------------------------------------------------------------------------------------------|
-| label:property    | [string\|null]       | Name                       | **REQUIRED** These are the names of the property field(s) in each `Feature` of the label asset's `FeatureCollection` that contains the  classes (keywords from `label:classes` if the property defines classes). If labels are rasters, use `null`. |
-| label:classes     | [[Class Object](#class-object)] | Classes           | **REQUIRED** if using categorical data. A Class Object defining the list of possible class names for each `label:property`. (e.g., tree, building, car, hippo)|
+| label:properties  | [string\|null]       | Name                       | **REQUIRED** These are the names of the property field(s) in each `Feature` of the label asset's `FeatureCollection` that contains the  classes (keywords from `label:classes` if the property defines classes). If labels are rasters, use `null`. |
+| label:classes     | [[Class Object](#class-object)] | Classes           | **REQUIRED** if using categorical data. A Class Object defining the list of possible class names for each `label:properties`. (e.g., tree, building, car, hippo)|
 | label:description | string               | Description                | **REQUIRED** A description of the label, how it was created, and what it is recommended for |
 | label:type        | string               | Type                       | **REQUIRED** An ENUM of either `vector` label type or `raster` label type |
-| label:task        | [string]             | Task                       | Recommended to be a subset of 'regression', 'classification', 'detection', or 'segmentation', but may be an arbitrary value |
-| label:method      | [string]             | Method                     | Recommended to be a subset of 'automated' or 'manual', but may be an arbitrary value. |
-| label:overview    | [[Label Overview Object](#label-overview-object)] | Overview | An Object storing counts (for classification-type data) or summary statistics (for continuous numerical/regression data). |
+| label:tasks       | [string]             | Task                       | Recommended to be a subset of 'regression', 'classification', 'detection', or 'segmentation', but may be an arbitrary value |
+| label:methods     | [string]             | Method                     | Recommended to be a subset of 'automated' or 'manual', but may be an arbitrary value. |
+| label:overviews   | [[Label Overview Object](#label-overview-object)] | Overview | An Object storing counts (for classification-type data) or summary statistics (for continuous numerical/regression data). |
 
 #### Class Object
 | Field Name      | Type                 | name                       | description       |
@@ -68,7 +68,7 @@ Some additional notes are given here for some of the core STAC Item fields and w
 | counts          | [[Count Object](#count-object)] | Counts                     | An object containing counts for categorical data. |
 | statistics      | [[Stats Object](#stats-object)] | Statistics                 | An object containing statistics for regression/continuous numeric value data. |
 
-`label:overview ` generally won't have both counts and statistics, but one of the two.
+`label:overviews ` generally won't have both counts and statistics, but one of the two.
 
 #### Count Object
 
@@ -129,8 +129,8 @@ Some additional notes are given here for some of the core STAC Item fields and w
 The Label Extension requires at least one asset that uses the key "labels". The asset will contain a link to the actual label data. The asset has these requirements:
 
 - is a GeoJSON FeatureCollection
-- if `label:tasks` is tile_classification, object_detection, or segmentation, each feature should have one or more properties containing the label(s) for the class (one of `label:classes`). the name of the property can be anything (use "label" if making from scratch), but needs to be specified in the `Item` with the `label:property` field.
-- if `label:tasks` is tile_regression, each feature should have one or more properties defining the value for regression. the name of the property can be anything (use "label" if making from scratch), but needs to be specified in the `Item` with the `label:property` field.
+- if `label:taskss` is tile_classification, object_detection, or segmentation, each feature should have one or more properties containing the label(s) for the class (one of `label:classes`). the name of the property can be anything (use "label" if making from scratch), but needs to be specified in the `Item` with the `label:properties` field.
+- if `label:taskss` is tile_regression, each feature should have one or more properties defining the value for regression. the name of the property can be anything (use "label" if making from scratch), but needs to be specified in the `Item` with the `label:properties` field.
 
 ##### Raster Label Notes
 

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
@@ -1107,11 +1107,11 @@
   },
   "properties": {
     "datetime": "2016-08-26T22:41:55.000000Z",
-    "label:property": "[\"OBJECTID_1\"]",
+    "label:properties": "[\"OBJECTID_1\"]",
     "label:description": "building footprints manually labeled",
-    "label:task": "segmentation",
+    "label:tasks": "segmentation",
     "label:type": "vector",
-    "label:method": "manual",
+    "label:methods": "manual",
     "version": 1,
     "label:classes": [
       {
@@ -1121,7 +1121,7 @@
         ]
       }
     ],
-    "label:overview": {
+    "label:overviews": {
       "property_key": "OBJECTID_1",
       "counts": [
         {

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
@@ -1511,11 +1511,11 @@
   },
   "properties": {
     "datetime": "2016-08-26T22:41:55.000000Z",
-    "label:property": "[\"OBJECTID_1\"]",
+    "label:properties": "[\"OBJECTID_1\"]",
     "label:description": "building footprints manually labeled",
-    "label:task": "segmentation",
+    "label:tasks": "segmentation",
     "label:type": "vector",
-    "label:method": "manual",
+    "label:methods": "manual",
     "version": 1,
     "label:classes": [
       {
@@ -1525,7 +1525,7 @@
         ]
       }
     ],
-    "label:overview": {
+    "label:overviews": {
       "property_key": "OBJECTID_1",
       "counts": [
         {

--- a/extensions/label/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
+++ b/extensions/label/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
@@ -691,11 +691,11 @@
   },
   "properties": {
     "datetime": "2016-08-26T22:41:55.000000Z",
-    "label:property": "[\"OBJECTID_1\"]",
+    "label:properties": "[\"OBJECTID_1\"]",
     "label:description": "building footprints manually labeled",
-    "label:task": "segmentation",
+    "label:tasks": "segmentation",
     "label:type": "vector",
-    "label:method": "manual",
+    "label:methods": "manual",
     "version": 1,
     "label:classes": [
       {
@@ -705,7 +705,7 @@
         ]
       }
     ],
-    "label:overview": {
+    "label:overviews": {
       "property_key": "OBJECTID_1",
       "counts": [
         {

--- a/extensions/label/examples/multidataset/zanzibar/znz001.json
+++ b/extensions/label/examples/multidataset/zanzibar/znz001.json
@@ -167660,11 +167660,11 @@
   },
   "properties": {
     "datetime": "2019-04-23T00:00:00Z",
-    "label:property": "[building, condition]",
+    "label:properties": "[building, condition]",
     "label:description": "building footprints manually  labeled and classified according to building completion status",
-    "label:task": "segmentation",
+    "label:tasks": "segmentation",
     "label:type": "vector",
-    "label:method": "manual",
+    "label:methods": "manual",
     "version": 1,
     "label:classes": [
       {
@@ -167682,7 +167682,7 @@
         ]
       }
     ],
-    "label:overview": {
+    "label:overviews": {
       "property_key": "building",
       "counts": [
         {

--- a/extensions/label/examples/multidataset/zanzibar/znz029.json
+++ b/extensions/label/examples/multidataset/zanzibar/znz029.json
@@ -48920,11 +48920,11 @@
   },
   "properties": {
     "datetime": "2019-04-23T00:00:00Z",
-    "label:property": "[building, condition]",
+    "label:properties": "[building, condition]",
     "label:description": "building footprints manually  labeled and classified according to building completion status",
-    "label:task": "segmentation",
+    "label:tasks": "segmentation",
     "label:type": "vector",
-    "label:method": "manual",
+    "label:methods": "manual",
     "version": 1,
     "label:classes": [
       {
@@ -48942,7 +48942,7 @@
         ]
       }
     ],
-    "label:overview": {
+    "label:overviews": {
       "property_key": "building",
       "counts": [
         {

--- a/extensions/label/examples/spacenet-roads/roads_item.json
+++ b/extensions/label/examples/spacenet-roads/roads_item.json
@@ -27,7 +27,7 @@
   {
     "datetime": "2016-08-26T22:41:55.000000Z",
     "title": "AOI 3 Paris img101 road network labels",
-    "label:property": ["road_type", "lane_number", "paved"],
+    "label:properties": ["road_type", "lane_number", "paved"],
     "label:type": "vector",
     "label:description": "sample SpaceNet roads label",
     "label:classes":
@@ -45,10 +45,10 @@
         "classes": [0, 1]
       }
     ],
-    "label:task": ["segmentation"],
-    "label:method": ["manual"],
+    "label:tasks": ["segmentation"],
+    "label:methods": ["manual"],
     "version": 1,
-    "label:overview":
+    "label:overviews":
     [
       {
         "property_key": "road_type",

--- a/extensions/label/schema.json
+++ b/extensions/label/schema.json
@@ -7,12 +7,12 @@
       "properties": {
         "type": "object",
         "required": [
-          "label:property",
+          "label:properties",
           "label:classes",
           "label:description"
         ],
         "properties": {
-          "label:property": {
+          "label:properties": {
             "title": "Property",
             "type": "array",
             "items": {
@@ -55,14 +55,14 @@
               "vector"
             ]
           },
-          "label:task": {
+          "label:tasks": {
             "title": "Task",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
-          "label:method": {
+          "label:methods": {
             "title": "Method",
             "type": "array",
             "items": {
@@ -73,7 +73,7 @@
               ]
             }
           },
-          "label:overview": {
+          "label:overviews": {
             "title": "Overview",
             "type": "array",
             "items": {

--- a/extensions/pointcloud/README.md
+++ b/extensions/pointcloud/README.md
@@ -17,9 +17,9 @@ tools such as LiDAR or coincidence-matched imagery.
 | pc:count      | integer                           | **REQUIRED.** The number of points in the item. |
 | pc:type       | string                            | **REQUIRED.** Phenomenology type for the point cloud. Possible valid values might include `lidar`, `eopc`, `radar`, `sonar`, or `other` |
 | pc:encoding   | string                            | **REQUIRED.** Content encoding or format of the data. |
-| pc:schema     | [[Schema Object](#schema-object)] | **REQUIRED.** A sequential array of items that define the dimensions and their types. |
+| pc:schemas    | [[Schema Object](#schema-object)] | **REQUIRED.** A sequential array of items that define the dimensions and their types. |
 | pc:density    | number                            | Number of points per square unit area. |
-| pc:statistics | [[Stats Object](#stats-object)]   | A sequential array of items mapping to `pc:schema` defines per-channel statistics. |
+| pc:statistics | [[Stats Object](#stats-object)]   | A sequential array of items mapping to `pc:schemas` defines per-channel statistics. |
 
 ### Schema Object
 
@@ -34,7 +34,7 @@ the point cloud, their types, and their sizes (in full bytes).
 
 ### Stats Object
 
-A sequential array of items mapping to `pc:schema` defines per-channel statistics. All fields
+A sequential array of items mapping to `pc:schemas` defines per-channel statistics. All fields
 are optional.
 
 | Field Name | Type    | Description |

--- a/extensions/pointcloud/examples/example-autzen.json
+++ b/extensions/pointcloud/examples/example-autzen.json
@@ -51,7 +51,7 @@
     "pc:count": 10653336,
     "pc:density": 0,
     "pc:encoding": "LASzip",
-    "pc:schema": [
+    "pc:schemas": [
       {
         "name": "X",
         "size": 8,

--- a/extensions/pointcloud/pdal-to-stac.py
+++ b/extensions/pointcloud/pdal-to-stac.py
@@ -61,7 +61,7 @@ assets = {}
 #assets['thumbnail'] =
 properties = {}
 
-properties['pc:schema'] = j['schema']['dimensions']
+properties['pc:schemas'] = j['schema']['dimensions']
 properties['pc:statistics'] = j['stats']['statistic']
 properties['title'] = "USGS 3DEP LiDAR"
 properties['item:provider'] = "USGS"


### PR DESCRIPTION
**Related Issue(s):** #586


**Proposed Changes:**

1. Pluralized field names in label extension (see #586)
2. Pluralized field name (schema => schemas) in point cloud extension

I hope I found all fields that should have plural forms.

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).