### PR TITLE
Improve JSON Schema for Items

### DIFF
--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -146,7 +146,7 @@
                   }
                 },
                 "created": {
-                  "title": "Metadata updated at",
+                  "title": "Metadata created at",
                   "type": "string",
                   "format": "date-time"
                 },

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -21,8 +21,6 @@
           "required": [
             "stac_version",
             "id",
-            "type",
-            "geometry",
             "links",
             "assets",
             "bbox",
@@ -66,6 +64,13 @@
               "title": "Provider ID",
               "description": "Provider item ID",
               "type": "string"
+            },
+            "bbox": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "number"
+              }
             },
             "links": {
               "title": "Item links",

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -14,11 +14,7 @@
     "core": {
       "allOf": [
         {
-          "oneOf": [
-            {
-              "$ref": "https://geojson.org/schema/Feature.json"
-            }
-          ]
+          "$ref": "https://geojson.org/schema/Feature.json"
         },
         {
           "type": "object",


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. It's not a bug, but the oneOf is not needed in the schema. Therefore removed it for simplicity.
2. Removed the "geometry" and "type" as required property as it is already required in the GeoJSON Feature schema (and we do not redefine it in the schema, therefore it is referring to a non-existing property anyway).
3. Added "bbox" as property so that the "require" flag really works.
4. Fixed a typo: "updated"->"created" 

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).