### PR TITLE
Thumbnails are not meant to be in links

### DIFF
--- a/collection-spec/examples/sentinel2.json
+++ b/collection-spec/examples/sentinel2.json
@@ -49,7 +49,6 @@
       "min": "2015-06-23T00:00:00Z",
       "max": "2019-07-10T13:44:56Z"
     },
-    "license": ["proprietary"],
     "sci:citation": ["Copernicus Sentinel data [Year]"],
     "eo:gsd": [10,30,60],
     "eo:platform": ["sentinel-2a","sentinel-2b"],

--- a/item-spec/examples/itemcollection-sample-full.json
+++ b/item-spec/examples/itemcollection-sample-full.json
@@ -68,8 +68,7 @@
       "assets": {
         "analytic": {
           "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/analytic.tif",
-          "title": "4-Band Analytic",
-          "product": "http://cool-sat.com/catalog/products/analytic.json"
+          "title": "4-Band Analytic"
         },
         "thumbnail": {
           "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/thumbnail.png",

--- a/item-spec/examples/sample-full.json
+++ b/item-spec/examples/sample-full.json
@@ -50,7 +50,6 @@
   "collection": "CS3",
   "links": [
     {"rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"},
-    {"rel": "thumbnail", "href":"thumbnail.png"},
     {"rel": "root", "href": "http://cool-sat.com/catalog/catalog.json"},
     {"rel": "parent", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/catalog.json"},
     {"rel": "collection", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/catalog.json"},

--- a/item-spec/examples/sample-full.json
+++ b/item-spec/examples/sample-full.json
@@ -58,8 +58,7 @@
   "assets": {
     "analytic": {
       "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/analytic.tif",
-      "title": "4-Band Analytic",
-      "product": "http://cool-sat.com/catalog/products/analytic.json"
+      "title": "4-Band Analytic"
     },
     "thumbnail": {
       "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/thumbnail.png",
@@ -67,18 +66,15 @@
     },
     "udm": {
       "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/UDM.tif",
-      "title": "Unusable Data Mask",
-      "product": "http://cool-sat.com/catalog/products/udm.json"
+      "title": "Unusable Data Mask"
     },
     "json-metadata": {
       "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/extended-metadata.json",
-      "title": "Extended Metadata",
-      "product": "http://cool-sat.com/catalog/products/extended-metadata.json"
+      "title": "Extended Metadata"
     },
     "ephemeris": {
       "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/S3-20160503_132130_04.EPH",
-      "title": "Satellite Ephemeris Metadata",
-      "product": "http://cool-sat.com/catalog/products/satellite-ephemeris.json"
+      "title": "Satellite Ephemeris Metadata"
     }
   }
 

--- a/process.md
+++ b/process.md
@@ -73,7 +73,7 @@ with no changes to the spec - just updating the version numbers.
 
 ### Governance 
 
-The goal of STAC is to to have a Project Steering Committee of core contributors, representing diverse organizations and 
+The goal of STAC is to have a Project Steering Committee of core contributors, representing diverse organizations and 
 implementations. To bootstrap Chris Holmes is the Benevolent Dictator for 
 Life or until a PSC is formed, so we don't get stuck waiting for votes when there is not enough activity. 
 


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. Item example: There was a thumbnail link in links, which should be in assets.
2. Item examples: Removed the non-standardized "product" fields.
3. Fixed typo "to to" in chapter Governance.
4. Removed discouraged use of license in collection summaries.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).