### PR TITLE
Fixed JSON schemas for extensions: `$id` field matches file name. #618

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+# Changed
 - Updated specification to base on OGC API - Features - Part 1: Core, v1.0.0 instead of OGC API - Features - Part 1: Core, v1.0.0-draft.2 (fka WFS3 draft 2).
+
+# Fixed
+- Fixed JSON schemas for extensions: `$id` field matches file name.
 
 ## [v0.8.0] - 2019-10-11
 

--- a/api-spec/extensions/search/schema.json
+++ b/api-spec/extensions/search/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-search-extension.json#",
+  "$id": "schema.json#",
   "title": "Search Extension",
   "type": "object",
   "description": "STAC Search Extension",

--- a/extensions/asset/json-schema/schema.json
+++ b/extensions/asset/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-extension-asset.json#",
+  "$id": "schema.json#",
   "title": "Asset Definition Extension Specification",
   "description": "STAC Asset Definition Extension to a STAC Collection",
   "allOf": [

--- a/extensions/checksum/json-schema/schema.json
+++ b/extensions/checksum/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-extension-checksum.json#",
+  "$id": "schema.json#",
   "title": "Checksum Extension Specification",
   "description": "STAC Checksum Extension to a STAC Item",
   "allOf": [

--- a/extensions/datacube/json-schema/schema.json
+++ b/extensions/datacube/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-extension-datacube.json#",
+  "$id": "schema.json#",
   "title": "Data Cube Extension",
   "description": "STAC Data Cube Extension to a STAC Item",
   "allOf": [

--- a/extensions/datetime-range/json-schema/schema.json
+++ b/extensions/datetime-range/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-extension-datetime-range.json#",
+  "$id": "schema.json#",
   "title": "Datetime Range Extension",
   "description": "STAC Datetime Range Extension Extension to a STAC Item.",
   "allOf": [

--- a/extensions/eo/json-schema/schema.json
+++ b/extensions/eo/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-extension-eo.json#",
+  "$id": "schema.json#",
   "title": "EO Extension",
   "description": "STAC EO Extension to a STAC Item.",
   "allOf": [

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-extension-sar.json#",
+  "$id": "schema.json#",
   "title": "SAR Extension",
   "description": "STAC SAR Extension to a STAC Item",
   "allOf": [

--- a/extensions/scientific/json-schema/schema.json
+++ b/extensions/scientific/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "stac-extension-scientific.json#",
+  "$id": "schema.json#",
   "title": "Scientific Extension",
   "description": "STAC Scientific Extension to STAC Items or STAC Collections.",
   "oneOf": [

--- a/extensions/single-file-stac/json-schema/schema.json
+++ b/extensions/single-file-stac/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "extension-single-file-stac.json#",
+  "$id": "schema.json#",
   "title": "Single File STAC Extension",
   "description": "Single File STAC Extension to combine Collections and Items in single file catalog",
   "allOf": [


### PR DESCRIPTION
**Related Issue(s):** #618


**Proposed Changes:**

1. Fixed JSON schemas for extensions: `$id` field matches file name.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).