### PR TITLE
Renamed STAC endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - The STAC API endpoint `/stac` has been merged with `/`
-- The STAC API endpoint `/stac/search` is now called `/items`
+- The STAC API endpoint `/stac/search` is now called `/search`
 
 ## [v0.8.1] - 2019-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- The STAC API endpoint `/stac` has been merged with `/`
+- The STAC API endpoint `/stac/search` is now called `/items`
+
 ## [v0.8.1] - 2019-11-01
 
 ### Changed

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -312,7 +312,7 @@ paths:
             text/html:
               schema:
                 type: string
-  /items:
+  /search:
     get:
       summary: Search STAC items with simple filtering.
       description: >-
@@ -320,7 +320,7 @@ paths:
         queries.
 
 
-        This method is optional, but you MUST implement `POST /items` if you
+        This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
       operationId: getSearchSTAC
       tags:
@@ -361,9 +361,9 @@ paths:
         query API.
 
 
-        This method is mandatory to implement if `GET /items` is implemented. If
-        this endpoint is implemented on a server, it is required to add a link
-        with `rel` set to `search` to the `links` array in `GET /stac` that
+        This method is mandatory to implement if `GET /search` is implemented.
+        If this endpoint is implemented on a server, it is required to add a
+        link with `rel` set to `search` to the `links` array in `GET /` that
         refers to this endpoint.
       operationId: postSearchSTAC
       tags:
@@ -1750,7 +1750,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/items?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
     queryFilter:
       type: object
       description: Allows users to query properties for specific values
@@ -1930,16 +1930,24 @@ components:
           $ref: '#/components/schemas/datetime'
   responses:
     LandingPage:
-      description: |-
+      description: >-
         The landing page provides links to the API definition
+
         (link relations `service-desc` and `service-doc`),
+
         the Conformance declaration (path `/conformance`,
+
         link relation `conformance`), and the Feature
+
         Collections (path `/collections`, link relation
+
         `data`).
 
-        A link to the search endpoint (path `/items`, link relation
-        `search`) is **required** to be specified if the API implements `/items`
+
+        A link to the search endpoint (path `/search`, link relation
+
+        `search`) is **required** to be specified if the API implements
+        `/search`
       content:
         application/json:
           schema:
@@ -1968,7 +1976,7 @@ components:
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: 'http://data.example.org/items'
+              - href: 'http://data.example.org/search'
                 rel: search
                 type: application/json
                 title: Search across feature collections

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -35,8 +35,13 @@ paths:
         - Capabilities
       summary: landing page
       description: |-
+        Returns the root STAC Catalog or STAC Collection that is the entry point
+        for users to browse with STAC Browser or for search engines to crawl.
+        This can either return a single STAC Collection or more commonly a STAC
+        catalog.
+
         The landing page provides links to the API definition, the conformance
-        statements and to the feature collections in this dataset.
+        statements, the collections and sub-catalogs.
       operationId: getLandingPage
       responses:
         '200':
@@ -307,25 +312,7 @@ paths:
             text/html:
               schema:
                 type: string
-  /stac:
-    get:
-      summary: Return the root catalog or collection.
-      description: >-
-        Returns the root STAC Catalog or STAC Collection that is the entry point
-        for users to browse with STAC Browser or for search engines to crawl.
-        This can either return a single STAC Collection or more commonly a STAC
-        catalog that usually lists sub-catalogs of STAC Collections, i.e. a
-        simple catalog that lists all collections available through the API.
-      tags:
-        - STAC
-      responses:
-        '200':
-          description: A catalog JSON definition. Used as an entry point for a crawler.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/catalogDefinition'
-  /stac/search:
+  /items:
     get:
       summary: Search STAC items with simple filtering.
       description: >-
@@ -333,8 +320,8 @@ paths:
         queries.
 
 
-        This method is optional, but you MUST implement `POST /stac/search` if
-        you want to implement this method.
+        This method is optional, but you MUST implement `POST /items` if you
+        want to implement this method.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -374,10 +361,10 @@ paths:
         query API.
 
 
-        This method is mandatory to implement if `GET /stac/search` is
-        implemented. If this endpoint is implemented on a server, it is required
-        to add a link with `rel` set to `search` to the `links` array in `GET
-        /stac` that refers to this endpoint.
+        This method is mandatory to implement if `GET /items` is implemented. If
+        this endpoint is implemented on a server, it is required to add a link
+        with `rel` set to `search` to the `links` array in `GET /stac` that
+        refers to this endpoint.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -1099,6 +1086,9 @@ components:
       type: object
       required:
         - links
+        - stac_version
+        - id
+        - description
       properties:
         title:
           type: string
@@ -1112,6 +1102,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/link'
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        id:
+          type: string
+        summaries:
+          $ref: '#/components/schemas/summaries'
     linestringGeoJSON:
       type: object
       required:
@@ -1562,55 +1560,6 @@ components:
                 anyOf:
                   - type: string
                   - type: number
-    catalogDefinition:
-      type: object
-      required:
-        - stac_version
-        - id
-        - description
-        - links
-      properties:
-        stac_version:
-          $ref: '#/components/schemas/stac_version'
-        stac_extensions:
-          $ref: '#/components/schemas/stac_extensions'
-        id:
-          type: string
-          example: naip
-        title:
-          type: string
-          example: NAIP Imagery
-        description:
-          type: string
-          example: Catalog of NAIP Imagery.
-        summaries:
-          $ref: '#/components/schemas/summaries'
-        links:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/link'
-              - title: Link to search endpoint
-                description: >-
-                  Link the search endpoint, which is **required** to be
-                  specified if the API implements `/stac/search`.
-                type: object
-                required:
-                  - href
-                  - rel
-                properties:
-                  href:
-                    type: string
-                    format: url
-                    example: 'http://www.cool-sat.com/stac/search'
-                  rel:
-                    type: string
-                    enum:
-                      - search
-                  type:
-                    type: string
-                  title:
-                    type: string
     itemCollection:
       description: >-
         A GeoJSON FeatureCollection augmented with foreign members that contain
@@ -1801,7 +1750,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/items?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
     queryFilter:
       type: object
       description: Allows users to query properties for specific values
@@ -1988,15 +1937,16 @@ components:
         link relation `conformance`), and the Feature
         Collections (path `/collections`, link relation
         `data`).
+
+        A link to the search endpoint (path `/items`, link relation
+        `search`) is **required** to be specified if the API implements `/items`
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/landingPage'
           example:
-            title: Buildings in Bonn
-            description: >-
-              Access to data about buildings in the city of Bonn via a Web API
-              that conforms to the OGC API Features specification.
+            title: NAIP Imagery
+            description: Catalog of NAIP Imagery.
             links:
               - href: 'http://data.example.org/'
                 rel: self
@@ -2018,6 +1968,12 @@ components:
                 rel: data
                 type: application/json
                 title: Information about the feature collections
+              - href: 'http://data.example.org/items'
+                rel: search
+                type: application/json
+                title: Search across feature collections
+            stac_version: 0.8.1
+            id: naip
         text/html:
           schema:
             type: string

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -133,7 +133,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  /items:
+  /search:
     get:
       summary: Search STAC items with simple filtering.
       description: >-
@@ -141,7 +141,7 @@ paths:
         queries.
 
 
-        This method is optional, but you MUST implement `POST /items` if you
+        This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
       operationId: getSearchSTAC
       tags:
@@ -179,9 +179,9 @@ paths:
         query API.
 
 
-        This method is mandatory to implement if `GET /items` is implemented. If
-        this endpoint is implemented on a server, it is required to add a link
-        with `rel` set to `search` to the `links` array in `GET /stac` that
+        This method is mandatory to implement if `GET /search` is implemented.
+        If this endpoint is implemented on a server, it is required to add a
+        link with `rel` set to `search` to the `links` array in `GET /` that
         refers to this endpoint.
       operationId: postSearchSTAC
       tags:
@@ -1504,19 +1504,27 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/items?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
   responses:
     LandingPage:
-      description: |-
+      description: >-
         The landing page provides links to the API definition
+
         (link relations `service-desc` and `service-doc`),
+
         the Conformance declaration (path `/conformance`,
+
         link relation `conformance`), and the Feature
+
         Collections (path `/collections`, link relation
+
         `data`).
 
-        A link to the search endpoint (path `/items`, link relation
-        `search`) is **required** to be specified if the API implements `/items`
+
+        A link to the search endpoint (path `/search`, link relation
+
+        `search`) is **required** to be specified if the API implements
+        `/search`
       content:
         application/json:
           schema:
@@ -1545,7 +1553,7 @@ components:
                 rel: data
                 type: application/json
                 title: Information about the feature collections
-              - href: 'http://data.example.org/items'
+              - href: 'http://data.example.org/search'
                 rel: search
                 type: application/json
                 title: Search across feature collections

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -31,8 +31,13 @@ paths:
         - Capabilities
       summary: landing page
       description: |-
+        Returns the root STAC Catalog or STAC Collection that is the entry point
+        for users to browse with STAC Browser or for search engines to crawl.
+        This can either return a single STAC Collection or more commonly a STAC
+        catalog.
+
         The landing page provides links to the API definition, the conformance
-        statements and to the feature collections in this dataset.
+        statements, the collections and sub-catalogs.
       operationId: getLandingPage
       responses:
         '200':
@@ -128,25 +133,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  /stac:
-    get:
-      summary: Return the root catalog or collection.
-      description: >-
-        Returns the root STAC Catalog or STAC Collection that is the entry point
-        for users to browse with STAC Browser or for search engines to crawl.
-        This can either return a single STAC Collection or more commonly a STAC
-        catalog that usually lists sub-catalogs of STAC Collections, i.e. a
-        simple catalog that lists all collections available through the API.
-      tags:
-        - STAC
-      responses:
-        '200':
-          description: A catalog JSON definition. Used as an entry point for a crawler.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/catalogDefinition'
-  /stac/search:
+  /items:
     get:
       summary: Search STAC items with simple filtering.
       description: >-
@@ -154,8 +141,8 @@ paths:
         queries.
 
 
-        This method is optional, but you MUST implement `POST /stac/search` if
-        you want to implement this method.
+        This method is optional, but you MUST implement `POST /items` if you
+        want to implement this method.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -192,10 +179,10 @@ paths:
         query API.
 
 
-        This method is mandatory to implement if `GET /stac/search` is
-        implemented. If this endpoint is implemented on a server, it is required
-        to add a link with `rel` set to `search` to the `links` array in `GET
-        /stac` that refers to this endpoint.
+        This method is mandatory to implement if `GET /items` is implemented. If
+        this endpoint is implemented on a server, it is required to add a link
+        with `rel` set to `search` to the `links` array in `GET /stac` that
+        refers to this endpoint.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -878,6 +865,9 @@ components:
       type: object
       required:
         - links
+        - stac_version
+        - id
+        - description
       properties:
         title:
           type: string
@@ -891,6 +881,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/link'
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        id:
+          type: string
+        summaries:
+          $ref: '#/components/schemas/summaries'
     linestringGeoJSON:
       type: object
       required:
@@ -1338,55 +1336,6 @@ components:
                 anyOf:
                   - type: string
                   - type: number
-    catalogDefinition:
-      type: object
-      required:
-        - stac_version
-        - id
-        - description
-        - links
-      properties:
-        stac_version:
-          $ref: '#/components/schemas/stac_version'
-        stac_extensions:
-          $ref: '#/components/schemas/stac_extensions'
-        id:
-          type: string
-          example: naip
-        title:
-          type: string
-          example: NAIP Imagery
-        description:
-          type: string
-          example: Catalog of NAIP Imagery.
-        summaries:
-          $ref: '#/components/schemas/summaries'
-        links:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/link'
-              - title: Link to search endpoint
-                description: >-
-                  Link the search endpoint, which is **required** to be
-                  specified if the API implements `/stac/search`.
-                type: object
-                required:
-                  - href
-                  - rel
-                properties:
-                  href:
-                    type: string
-                    format: url
-                    example: 'http://www.cool-sat.com/stac/search'
-                  rel:
-                    type: string
-                    enum:
-                      - search
-                  type:
-                    type: string
-                  title:
-                    type: string
     itemCollection:
       description: >-
         A GeoJSON FeatureCollection augmented with foreign members that contain
@@ -1555,7 +1504,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/items?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
   responses:
     LandingPage:
       description: |-
@@ -1565,15 +1514,16 @@ components:
         link relation `conformance`), and the Feature
         Collections (path `/collections`, link relation
         `data`).
+
+        A link to the search endpoint (path `/items`, link relation
+        `search`) is **required** to be specified if the API implements `/items`
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/landingPage'
           example:
-            title: Buildings in Bonn
-            description: >-
-              Access to data about buildings in the city of Bonn via a Web API
-              that conforms to the OGC API Features specification.
+            title: NAIP Imagery
+            description: Catalog of NAIP Imagery.
             links:
               - href: 'http://data.example.org/'
                 rel: self
@@ -1595,6 +1545,12 @@ components:
                 rel: data
                 type: application/json
                 title: Information about the feature collections
+              - href: 'http://data.example.org/items'
+                rel: search
+                type: application/json
+                title: Search across feature collections
+            stac_version: 0.8.1
+            id: naip
         text/html:
           schema:
             type: string

--- a/api-spec/api-spec.md
+++ b/api-spec/api-spec.md
@@ -15,7 +15,7 @@ The OAFeat and STAC APIs follow a RESTful model. A core principal of this is the
 1. **Required** GET (both OAFeat and STAC)
 2. **Recommended** POST `Content-Type: application/x-www-form-urlencoded` with the corresponding content body format.
 3. **Recommended** POST `Content-Type: multipart/form-data` with the corresponding content body format.
-4. **Optional** **STAC endpoint /items only** POST `Content-Type: application/json`, where the content body is a JSON object representing a filter, as defined in the [STAC API OpenAPI specification document](STAC.yaml).  
+4. **Optional** **STAC endpoint /search only** POST `Content-Type: application/json`, where the content body is a JSON object representing a filter, as defined in the [STAC API OpenAPI specification document](STAC.yaml).  
 5. **Prohibited** **OAFeat endpoints only** POST `Content-Type: application/json`, where the content body is a JSON object representing a filter. This is prohibited due to conflict with the [Transaction Extension](extensions/transaction/README.md), which defines a POST `Content-Type: application/json` operation to create an Item.
 
 ## OGC API - Features Endpoints
@@ -41,13 +41,13 @@ STAC provides some additional endpoints for the root Catalog itself, as well as 
 | Endpoint      | Returns | Description |
 | ------------- | ------- | ----------- |
 | /             | Catalog | Extends `/` from OAFeat to return a full STAC catalog. |
-| /items        | [ItemCollection](../item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
+| /search       | [ItemCollection](../item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
 
 The `/` endpoint should function as a complete `Catalog` representation of all the data contained in the API and linked to in some way from root through `Collections` and `Items`.
 
-The `/items` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OGC API - Features in that it accepts parameters for filtering, however it performs the filtering across all collections. The parameters accepted are the same as the Filter Parameters above, however the *[extensions](extensions/README.md)* also provide advanced querying parameters.
+The `/search` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OGC API - Features in that it accepts parameters for filtering, however it performs the filtering across all collections. The parameters accepted are the same as the Filter Parameters above, however the *[extensions](extensions/README.md)* also provide advanced querying parameters.
 
-If the `/items` endpoint is implemented, it is **required** to add a link with the `rel` type set to `search` to the `links` array in `/` that refers to the search endpoint in the `href` property.
+If the `/search` endpoint is implemented, it is **required** to add a link with the `rel` type set to `search` to the `links` array in `/` that refers to the search endpoint in the `href` property.
 
 ## Filter Parameters and Fields
 

--- a/api-spec/api-spec.md
+++ b/api-spec/api-spec.md
@@ -15,7 +15,7 @@ The OAFeat and STAC APIs follow a RESTful model. A core principal of this is the
 1. **Required** GET (both OAFeat and STAC)
 2. **Recommended** POST `Content-Type: application/x-www-form-urlencoded` with the corresponding content body format.
 3. **Recommended** POST `Content-Type: multipart/form-data` with the corresponding content body format.
-4. **Optional** **STAC endpoint /stac/search only** POST `Content-Type: application/json`, where the content body is a JSON object representing a filter, as defined in the [STAC API OpenAPI specification document](STAC.yaml).  
+4. **Optional** **STAC endpoint /items only** POST `Content-Type: application/json`, where the content body is a JSON object representing a filter, as defined in the [STAC API OpenAPI specification document](STAC.yaml).  
 5. **Prohibited** **OAFeat endpoints only** POST `Content-Type: application/json`, where the content body is a JSON object representing a filter. This is prohibited due to conflict with the [Transaction Extension](extensions/transaction/README.md), which defines a POST `Content-Type: application/json` operation to create an Item.
 
 ## OGC API - Features Endpoints
@@ -40,14 +40,14 @@ STAC provides some additional endpoints for the root Catalog itself, as well as 
 
 | Endpoint      | Returns | Description |
 | ------------- | ------- | ----------- |
-| /stac         | Catalog | Root catalog |
-| /stac/search  | [ItemCollection](../item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
+| /             | Catalog | Extends `/` from OAFeat to return a full STAC catalog. |
+| /items        | [ItemCollection](../item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
 
-The `/stac` endpoint should function as a complete `Catalog` representation of all the data contained in the API and linked to in some way from root through `Collections` and `Items`.
+The `/` endpoint should function as a complete `Catalog` representation of all the data contained in the API and linked to in some way from root through `Collections` and `Items`.
 
-The `/stac/search` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OGC API - Features in that it accepts parameters for filtering, however it performs the filtering across all collections. The parameters accepted are the same as the Filter Parameters above, however the *[extensions](extensions/README.md)* also provide advanced querying parameters.
+The `/items` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OGC API - Features in that it accepts parameters for filtering, however it performs the filtering across all collections. The parameters accepted are the same as the Filter Parameters above, however the *[extensions](extensions/README.md)* also provide advanced querying parameters.
 
-If the `/stac/search` endpoint is implemented, it is **required** to add a link with the `rel` type set to `search` to the `links` array in `GET /stac` that refers to the search endpoint in the `href` property.
+If the `/items` endpoint is implemented, it is **required** to add a link with the `rel` type set to `search` to the `links` array in `/` that refers to the search endpoint in the `href` property.
 
 ## Filter Parameters and Fields
 
@@ -77,21 +77,21 @@ should be returned.
  the syntax and semantics of an API Extension attached to that parameter.  If no API Extension for that parameter is 
  implemented by an API, then if that parameter has a non-empty value in the request a 400 Bad Request status code must 
  be returned. 
- 
+
 ### Fields Extension
- 
+
 These parameters and fields are reserved for the Fields extension.
- 
+
 | Parameter | Type              | APIs       | Description |
 | --------- | ----------------- | ---------- | ----------- |
 | fields    | string \| [Field] | Placeholder parameter for [API Fields Extension](extensions/fields/README.md). |
- 
+
 ### Sort Extension
- 
+
 These parameters and fields are reserved for the Sort extension.
- 
+
 | Parameter | Type             | APIs       | Description |
-| --------- | ---------------- | ---------- | ----------- | 
+| --------- | ---------------- | ---------- | ----------- |
 | sort      | string \| [Sort] | Placeholder parameter for [API Sort Extension](extensions/sort/README.md). |
 
 ### Query Extension

--- a/api-spec/examples.md
+++ b/api-spec/examples.md
@@ -1,7 +1,7 @@
 # STAC API Examples
 
 A typical OAFeat will have multiple collections, and each will just offer simple search for its particular collection at `GET /collections/{collectionId}/items`.
-Due to the limited parameter support in OGC API - Features, it is recommended to use the STAC API endpoint `POST /stac/search` for advanced queries.
+Due to the limited parameter support in OGC API - Features, it is recommended to use the STAC API endpoint `POST /items` for advanced queries.
 The filtering is made to be compatible between STAC API and OGC API - Features whenever feasible, and the two specs seek to share the general query and filtering patterns.
 The key difference is that the STAC API search endpoints will do cross collection search.
 
@@ -48,7 +48,7 @@ A STAC API supports both GET and POST requests. It is best to use POST when usin
 Use the *[Query](extensions/query/README.md)* extension to search for any data falling within a specific geometry collected between Jan 1st and May 1st, 2019:
 
 ```
-POST /stac/search
+POST /items
 ```
 
 Body:

--- a/api-spec/examples.md
+++ b/api-spec/examples.md
@@ -1,7 +1,7 @@
 # STAC API Examples
 
 A typical OAFeat will have multiple collections, and each will just offer simple search for its particular collection at `GET /collections/{collectionId}/items`.
-Due to the limited parameter support in OGC API - Features, it is recommended to use the STAC API endpoint `POST /items` for advanced queries.
+Due to the limited parameter support in OGC API - Features, it is recommended to use the STAC API endpoint `POST /search` for advanced queries.
 The filtering is made to be compatible between STAC API and OGC API - Features whenever feasible, and the two specs seek to share the general query and filtering patterns.
 The key difference is that the STAC API search endpoints will do cross collection search.
 
@@ -48,7 +48,7 @@ A STAC API supports both GET and POST requests. It is best to use POST when usin
 Use the *[Query](extensions/query/README.md)* extension to search for any data falling within a specific geometry collected between Jan 1st and May 1st, 2019:
 
 ```
-POST /items
+POST /search
 ```
 
 Body:

--- a/api-spec/extensions/fields/README.md
+++ b/api-spec/extensions/fields/README.md
@@ -2,11 +2,11 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-By default, the STAC search endpoint `/stac/search` returns all attributes of each Item, as there is no way to specify exactly those attributes that should be returned. The Fields API extension adds a new option that allows the user to explicitly define which fields in an Item should be included or excluded in the response. 
+By default, the STAC search endpoint `/items` returns all attributes of each Item, as there is no way to specify exactly those attributes that should be returned. The Fields API extension adds a new option that allows the user to explicitly define which fields in an Item should be included or excluded in the response. 
 
-When calling `/stac/search` using POST with`Content-Type: application/json`, this extension adds an attribute `fields` with an object value to the core JSON search request body. The `fields` object contains two attributes with string array values, `include` and `exclude`.
+When calling `/items` using POST with`Content-Type: application/json`, this extension adds an attribute `fields` with an object value to the core JSON search request body. The `fields` object contains two attributes with string array values, `include` and `exclude`.
 
-When calling `/stac/search` using GET or POST with `Content-Type: application/x-www-form-urlencoded` or `Content-Type: multipart/form-data`, the semantics are the same, except the syntax is a single parameter `fields` with a comma-separated list of attribute names, where `exclude` values are those prefixed by a `-` and `include` values are those with no prefix, e.g., `-geometry`, or `id,properties,-properties.proj:geometry`.
+When calling `/items` using GET or POST with `Content-Type: application/x-www-form-urlencoded` or `Content-Type: multipart/form-data`, the semantics are the same, except the syntax is a single parameter `fields` with a comma-separated list of attribute names, where `exclude` values are those prefixed by a `-` and `include` values are those with no prefix, e.g., `-geometry`, or `id,properties,-properties.proj:geometry`.
 
 It is recommended that implementations meet the `include` and `exclude` sets specified by the request, but this is not required. Implementations are still considered compliant if fields not specified as part of `include` are in the response or ones specified as part of `exclude` are.  Implementations may choose to always include simple string fields like `id` and `type` regardless of the `exclude` specification. However, it is recommended that implementations honor excludes for attributes with more complex and arbitrarily large values (e.g., `geometry`, `assets`).  For example, some Items may have a geometry with a simple 5 point polygon, but these polygons can be very large when reprojected to EPSG:4326, as in the case of a highly-decimated sinusoidal polygons.
 

--- a/api-spec/extensions/fields/README.md
+++ b/api-spec/extensions/fields/README.md
@@ -2,11 +2,11 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-By default, the STAC search endpoint `/items` returns all attributes of each Item, as there is no way to specify exactly those attributes that should be returned. The Fields API extension adds a new option that allows the user to explicitly define which fields in an Item should be included or excluded in the response. 
+By default, the STAC search endpoint `/search` returns all attributes of each Item, as there is no way to specify exactly those attributes that should be returned. The Fields API extension adds a new option that allows the user to explicitly define which fields in an Item should be included or excluded in the response. 
 
-When calling `/items` using POST with`Content-Type: application/json`, this extension adds an attribute `fields` with an object value to the core JSON search request body. The `fields` object contains two attributes with string array values, `include` and `exclude`.
+When calling `/search` using POST with`Content-Type: application/json`, this extension adds an attribute `fields` with an object value to the core JSON search request body. The `fields` object contains two attributes with string array values, `include` and `exclude`.
 
-When calling `/items` using GET or POST with `Content-Type: application/x-www-form-urlencoded` or `Content-Type: multipart/form-data`, the semantics are the same, except the syntax is a single parameter `fields` with a comma-separated list of attribute names, where `exclude` values are those prefixed by a `-` and `include` values are those with no prefix, e.g., `-geometry`, or `id,properties,-properties.proj:geometry`.
+When calling `/search` using GET or POST with `Content-Type: application/x-www-form-urlencoded` or `Content-Type: multipart/form-data`, the semantics are the same, except the syntax is a single parameter `fields` with a comma-separated list of attribute names, where `exclude` values are those prefixed by a `-` and `include` values are those with no prefix, e.g., `-geometry`, or `id,properties,-properties.proj:geometry`.
 
 It is recommended that implementations meet the `include` and `exclude` sets specified by the request, but this is not required. Implementations are still considered compliant if fields not specified as part of `include` are in the response or ones specified as part of `exclude` are.  Implementations may choose to always include simple string fields like `id` and `type` regardless of the `exclude` specification. However, it is recommended that implementations honor excludes for attributes with more complex and arbitrarily large values (e.g., `geometry`, `assets`).  For example, some Items may have a geometry with a simple 5 point polygon, but these polygons can be very large when reprojected to EPSG:4326, as in the case of a highly-decimated sinusoidal polygons.
 

--- a/api-spec/extensions/fields/fields.fragment.yaml
+++ b/api-spec/extensions/fields/fields.fragment.yaml
@@ -1,5 +1,5 @@
 paths:
-  /stac/search:
+  /items:
     get:
       parameters:
         - $ref: '#/components/parameters/fields'

--- a/api-spec/extensions/fields/fields.fragment.yaml
+++ b/api-spec/extensions/fields/fields.fragment.yaml
@@ -1,5 +1,5 @@
 paths:
-  /items:
+  /search:
     get:
       parameters:
         - $ref: '#/components/parameters/fields'

--- a/api-spec/extensions/query/README.md
+++ b/api-spec/extensions/query/README.md
@@ -2,7 +2,7 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-The STAC search endpoint, `/items`, by default only accepts the core filter parameters given in the *[api-spec](../../api-spec.md)*. The Query API extension adds additional filters for searching on the properties of Items.
+The STAC search endpoint, `/search`, by default only accepts the core filter parameters given in the *[api-spec](../../api-spec.md)*. The Query API extension adds additional filters for searching on the properties of Items.
 
 The syntax for the `query` filter is:
 

--- a/api-spec/extensions/query/README.md
+++ b/api-spec/extensions/query/README.md
@@ -2,7 +2,7 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-The STAC search endpoint, `/stac/search`, by default only accepts the core filter parameters given in the *[api-spec](../../api-spec.md)*. The Query API extension adds additional filters for searching on the properties of Items.
+The STAC search endpoint, `/items`, by default only accepts the core filter parameters given in the *[api-spec](../../api-spec.md)*. The Query API extension adds additional filters for searching on the properties of Items.
 
 The syntax for the `query` filter is:
 

--- a/api-spec/extensions/query/query.fragment.yaml
+++ b/api-spec/extensions/query/query.fragment.yaml
@@ -1,5 +1,5 @@
 paths:
-  /stac/search:
+  /items:
     get:
       parameters:
         - $ref: '#/components/parameters/query'

--- a/api-spec/extensions/query/query.fragment.yaml
+++ b/api-spec/extensions/query/query.fragment.yaml
@@ -1,5 +1,5 @@
 paths:
-  /items:
+  /search:
     get:
       parameters:
         - $ref: '#/components/parameters/query'

--- a/api-spec/extensions/search/README.md
+++ b/api-spec/extensions/search/README.md
@@ -3,7 +3,7 @@
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Proposal**
 
 This extension is intended to augment the core [ItemCollection](../../../item-spec/itemcollection-spec.md) object when the ItemCollection is the result of a 
-search, for example, from calling the `/stac/search` API endpoint.
+search, for example, from calling the `/items` API endpoint.
 
 - [Example](examples/example.json)
 - [JSON Schema](json-schema/schema.json)

--- a/api-spec/extensions/search/README.md
+++ b/api-spec/extensions/search/README.md
@@ -3,7 +3,7 @@
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Proposal**
 
 This extension is intended to augment the core [ItemCollection](../../../item-spec/itemcollection-spec.md) object when the ItemCollection is the result of a 
-search, for example, from calling the `/items` API endpoint.
+search, for example, from calling the `/search` API endpoint.
 
 - [Example](examples/example.json)
 - [JSON Schema](json-schema/schema.json)

--- a/api-spec/extensions/sort/README.md
+++ b/api-spec/extensions/sort/README.md
@@ -2,7 +2,7 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-The STAC search endpoint, `/stac/search`, by default returns results in descending order using the datetime property. The sort API extension adds a new parameter, `sort` that allows the user to define fields to sort results by. Only properties may be used to sort results. The syntax for the `sort` parameter is:
+The STAC search endpoint, `/items`, by default returns results in descending order using the datetime property. The sort API extension adds a new parameter, `sort` that allows the user to define fields to sort results by. Only properties may be used to sort results. The syntax for the `sort` parameter is:
 
 ```json
 {

--- a/api-spec/extensions/sort/README.md
+++ b/api-spec/extensions/sort/README.md
@@ -2,7 +2,7 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-The STAC search endpoint, `/items`, by default returns results in descending order using the datetime property. The sort API extension adds a new parameter, `sort` that allows the user to define fields to sort results by. Only properties may be used to sort results. The syntax for the `sort` parameter is:
+The STAC search endpoint, `/search`, by default returns results in descending order using the datetime property. The sort API extension adds a new parameter, `sort` that allows the user to define fields to sort results by. Only properties may be used to sort results. The syntax for the `sort` parameter is:
 
 ```json
 {

--- a/api-spec/extensions/sort/sort.fragment.yaml
+++ b/api-spec/extensions/sort/sort.fragment.yaml
@@ -1,6 +1,6 @@
 # Adds sorting parameter to the base STAC search.
 paths:
-  /stac/search:
+  /items:
     get:
       parameters:
         - $ref: '#/components/parameters/sort'

--- a/api-spec/extensions/sort/sort.fragment.yaml
+++ b/api-spec/extensions/sort/sort.fragment.yaml
@@ -1,6 +1,6 @@
 # Adds sorting parameter to the base STAC search.
 paths:
-  /items:
+  /search:
     get:
       parameters:
         - $ref: '#/components/parameters/sort'

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -20,25 +20,18 @@ servers:
   - url: 'http://www.cool-sat.com'
     description: Production server
 paths:
-  /stac:
+  '/':
     get:
-      summary: Return the root catalog or collection.
-      description: >-
+      # Overriding the OAFeat description for this endpoint
+      description: |-
         Returns the root STAC Catalog or STAC Collection that is the entry point
         for users to browse with STAC Browser or for search engines to crawl.
         This can either return a single STAC Collection or more commonly a STAC
-        catalog that usually lists sub-catalogs of STAC Collections, i.e. a
-        simple catalog that lists all collections available through the API.
-      tags:
-        - STAC
-      responses:
-        '200':
-          description: A catalog JSON definition. Used as an entry point for a crawler.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/catalogDefinition'
-  /stac/search:
+        catalog.
+
+        The landing page provides links to the API definition, the conformance
+        statements, the collections and sub-catalogs.
+  /items:
     get:
       summary: Search STAC items with simple filtering.
       description: >-
@@ -46,7 +39,7 @@ paths:
         queries.
         
 
-        This method is optional, but you MUST implement `POST /stac/search` if you want to implement this method.
+        This method is optional, but you MUST implement `POST /items` if you want to implement this method.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -85,7 +78,7 @@ paths:
         query API.
         
         
-        This method is mandatory to implement if `GET /stac/search` is implemented. If this endpoint is implemented on a server, it is required to add a link with `rel` set to `search` to the `links` array in `GET /stac` that refers to this endpoint.
+        This method is mandatory to implement if `GET /items` is implemented. If this endpoint is implemented on a server, it is required to add a link with `rel` set to `search` to the `links` array in `GET /stac` that refers to this endpoint.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -145,6 +138,30 @@ components:
         $ref: '#/components/schemas/collectionsArray'
       explode: false
   responses:
+    # This schema extends OAFeat.yaml#/components/responses/LandingPage.
+    LandingPage:
+      description: |-
+        The landing page provides links to the API definition
+        (link relations `service-desc` and `service-doc`),
+        the Conformance declaration (path `/conformance`,
+        link relation `conformance`), and the Feature
+        Collections (path `/collections`, link relation
+        `data`).
+
+        A link to the search endpoint (path `/items`, link relation
+        `search`) is **required** to be specified if the API implements `/items`
+      content:
+        application/json:
+          example:
+            stac_version: 0.8.1
+            id: naip
+            title: NAIP Imagery
+            description: Catalog of NAIP Imagery.
+            links:
+              - href: 'http://data.example.org/items'
+                rel: search
+                type: application/json
+                title: Search across feature collections
     # This schema extends OAFeat.yaml#/components/responses/Feature change the schema from featureGeoJson to item.
     Feature:
       content:
@@ -584,13 +601,13 @@ components:
                 anyOf:
                   - type: string
                   - type: number
-    catalogDefinition:
+    # This schema extends OAFeat.yaml#/components/schemas/landingPage to add and require additional fields.
+    landingPage:
       type: object
       required:
         - stac_version
         - id
         - description
-        - links
       properties:
         stac_version:
           $ref: '#/components/schemas/stac_version'
@@ -598,39 +615,8 @@ components:
           $ref: '#/components/schemas/stac_extensions'
         id:
           type: string
-          example: naip
-        title:
-          type: string
-          example: NAIP Imagery
-        description:
-          type: string
-          example: Catalog of NAIP Imagery.
         summaries:
           $ref: '#/components/schemas/summaries'
-        links:
-          type: array
-          items:
-            anyOf:
-            - $ref: '#/components/schemas/link'
-            - title: Link to search endpoint
-              description: Link the search endpoint, which is **required** to be specified if the API implements `/stac/search`.
-              type: object
-              required:
-                - href
-                - rel
-              properties:
-                href:
-                  type: string
-                  format: url
-                  example: 'http://www.cool-sat.com/stac/search'
-                rel:
-                  type: string
-                  enum:
-                    - search
-                type:
-                  type: string
-                title:
-                  type: string
     itemCollection:
       description: A GeoJSON FeatureCollection augmented with foreign members that contain values relevant to a STAC entity
       type: object
@@ -791,7 +777,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/items?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
 tags:
   - name: STAC
     description: Extension to OGC API - Features to support STAC metadata model and search API

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -31,7 +31,7 @@ paths:
 
         The landing page provides links to the API definition, the conformance
         statements, the collections and sub-catalogs.
-  /items:
+  /search:
     get:
       summary: Search STAC items with simple filtering.
       description: >-
@@ -39,7 +39,7 @@ paths:
         queries.
         
 
-        This method is optional, but you MUST implement `POST /items` if you want to implement this method.
+        This method is optional, but you MUST implement `POST /search` if you want to implement this method.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -78,7 +78,7 @@ paths:
         query API.
         
         
-        This method is mandatory to implement if `GET /items` is implemented. If this endpoint is implemented on a server, it is required to add a link with `rel` set to `search` to the `links` array in `GET /stac` that refers to this endpoint.
+        This method is mandatory to implement if `GET /search` is implemented. If this endpoint is implemented on a server, it is required to add a link with `rel` set to `search` to the `links` array in `GET /` that refers to this endpoint.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -148,8 +148,8 @@ components:
         Collections (path `/collections`, link relation
         `data`).
 
-        A link to the search endpoint (path `/items`, link relation
-        `search`) is **required** to be specified if the API implements `/items`
+        A link to the search endpoint (path `/search`, link relation
+        `search`) is **required** to be specified if the API implements `/search`
       content:
         application/json:
           example:
@@ -158,7 +158,7 @@ components:
             title: NAIP Imagery
             description: Catalog of NAIP Imagery.
             links:
-              - href: 'http://data.example.org/items'
+              - href: 'http://data.example.org/search'
                 rel: search
                 type: application/json
                 title: Search across feature collections
@@ -777,7 +777,7 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/items?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
 tags:
   - name: STAC
     description: Extension to OGC API - Features to support STAC metadata model and search API

--- a/best-practices.md
+++ b/best-practices.md
@@ -50,9 +50,9 @@ is to place the catalog file in namespaces "directories". For example:
 
 Dynamic STAC Catalogs are those that generate their JSON responses programmatically instead of relying on a set of
 already defined files. Typically a dynamic catalog implements the full [STAC API](api-spec/api-spec.md/) which enables 
-search of the Items indexed. But the `/stac/` endpoint returns the exact same `Catalog` and `Item` structures as a
+search of the Items indexed. The `/` endpoint returns the exact same STAC Catalog structure as a
 static catalog, enabling the same discovery from people browsing and search engines crawling. Dynamic API's that
-just seek to expose some data can also choose to only implement a Catalog the `/stac/` endpoint that returns dynamically.
+just seek to expose some data can also choose to not implement `/items` and only link to their data from the `/` endpoint.
 For example a Content Management Service like Drupal or an Open Data Catalog like CKAN could choose to expose its content
 as linked STAC Items by implementing a dynamic catalog. 
 
@@ -60,10 +60,6 @@ One benefit of a dynamic catalog is that it can generate various 'views' of the 
 different sub-catalog organization structures. For example one catalog could divide sub-catalogs by date and another by
 providers, and users could browse down to both. The leaf Items should just be linked to in a single canonical location
 (or at least use a `rel` link that indicates the location of the canonical one.
-
-The STAC API is also made to be compatible with OGC API - Features, which has a set structure for the canonical location of its features.
-STAC Items should use the OGC API - Features location as their canonical location, and then in the `/stac/` browse structure would just
-link to those locations. 
 
 ## Catalog Layout
 
@@ -207,7 +203,7 @@ traditional database could work fine too) and then generate the full STAC API re
 There are instances that have the API refer directly to the static STAC Items, but this only works well if the static STAC 
 catalog is an 'absolute published catalog'. So the recommendation is to always use absolute links - either in the static 
 published catalog, or to create new absolute links for the STAC search/ endpoint 
-responses, with the API's location at the base url. The /stac endpoint with the catalogs could either link directly
+responses, with the API's location at the base url. The `/` endpoint with the catalog could either link directly
 to the static catalog, or can follow the 'dynamic catalog layout' recommendations above with a new set of URL's.
 
 Ideally each `Item` would use its `links` to provide a reference back to the static location. The location of the static

--- a/best-practices.md
+++ b/best-practices.md
@@ -52,7 +52,7 @@ Dynamic STAC Catalogs are those that generate their JSON responses programmatica
 already defined files. Typically a dynamic catalog implements the full [STAC API](api-spec/api-spec.md/) which enables 
 search of the Items indexed. The `/` endpoint returns the exact same STAC Catalog structure as a
 static catalog, enabling the same discovery from people browsing and search engines crawling. Dynamic API's that
-just seek to expose some data can also choose to not implement `/items` and only link to their data from the `/` endpoint.
+just seek to expose some data can also choose to not implement `/search` and only link to their data from the `/` endpoint.
 For example a Content Management Service like Drupal or an Open Data Catalog like CKAN could choose to expose its content
 as linked STAC Items by implementing a dynamic catalog. 
 

--- a/catalog-spec/README.md
+++ b/catalog-spec/README.md
@@ -12,7 +12,7 @@ fields with Catalogs and therefore every Collection is also a valid Catalog.
 
 Catalogs are designed so that a simple file server on the web or object store like Amazon S3 can store JSON that defines a 
 full Catalog. More dynamic services can also return a Catalog structure, and the [STAC API](../api-spec/) folder contains 
-an OpenAPI definition of the standard way to do this, at the `/stac/` endpoint. 
+an OpenAPI definition of the standard way to do this, at the `/` endpoint. 
 
 ## In this directory
 

--- a/collection-spec/examples/landsat-item.json
+++ b/collection-spec/examples/landsat-item.json
@@ -165,7 +165,7 @@
     "links": [
         {
             "rel": "self",
-            "href": "https://<endpoint>/items?id=LC08_L1TP_107018_20181001_20181001_01_RT"
+            "href": "https://<endpoint>/search?id=LC08_L1TP_107018_20181001_20181001_01_RT"
         },
         {
             "rel": "parent",

--- a/collection-spec/examples/landsat-item.json
+++ b/collection-spec/examples/landsat-item.json
@@ -165,7 +165,7 @@
     "links": [
         {
             "rel": "self",
-            "href": "https://<endpoint>/stac/search?id=LC08_L1TP_107018_20181001_20181001_01_RT"
+            "href": "https://<endpoint>/items?id=LC08_L1TP_107018_20181001_20181001_01_RT"
         },
         {
             "rel": "parent",

--- a/extensions/eo/examples/example-landsat8.json
+++ b/extensions/eo/examples/example-landsat8.json
@@ -249,7 +249,7 @@
     "links": [
         {
             "rel": "self",
-            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/stac/search?id=LC08_L1TP_107018_20181001_20181001_01_RT"
+            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/items?id=LC08_L1TP_107018_20181001_20181001_01_RT"
         },
         {
             "rel": "parent",

--- a/extensions/eo/examples/example-landsat8.json
+++ b/extensions/eo/examples/example-landsat8.json
@@ -249,7 +249,7 @@
     "links": [
         {
             "rel": "self",
-            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/items?id=LC08_L1TP_107018_20181001_20181001_01_RT"
+            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/search?id=LC08_L1TP_107018_20181001_20181001_01_RT"
         },
         {
             "rel": "parent",

--- a/extensions/single-file-stac/examples/example-search.json
+++ b/extensions/single-file-stac/examples/example-search.json
@@ -582,11 +582,11 @@
                 },
                 {
                     "rel": "parent",
-                    "href": "https://n34f767n91.execute-api.us-east-1.amazonaws.com/prod/stac"
+                    "href": "https://n34f767n91.execute-api.us-east-1.amazonaws.com/prod"
                 },
                 {
                     "rel": "root",
-                    "href": "https://n34f767n91.execute-api.us-east-1.amazonaws.com/prod/stac"
+                    "href": "https://n34f767n91.execute-api.us-east-1.amazonaws.com/prod"
                 },
                 {
                     "rel": "items",

--- a/item-spec/README.md
+++ b/item-spec/README.md
@@ -4,7 +4,7 @@ The core of a SpatioTemporal Asset Catalog (STAC) is a set of JSON fields define
 [STAC Item spec](item-spec.md). These fields define an Item - the atomic units that contain 
 metadata for search as plus links to the actual assets that they represent. Their main function 
 is as the leaf nodes of a [Catalog](../catalog-spec/README.md), and are also returned from the search
-endpoints of a `/stac/search` endpoint.
+endpoints of a `/items` endpoint.
 
 ## In this directory
 

--- a/item-spec/README.md
+++ b/item-spec/README.md
@@ -4,7 +4,7 @@ The core of a SpatioTemporal Asset Catalog (STAC) is a set of JSON fields define
 [STAC Item spec](item-spec.md). These fields define an Item - the atomic units that contain 
 metadata for search as plus links to the actual assets that they represent. Their main function 
 is as the leaf nodes of a [Catalog](../catalog-spec/README.md), and are also returned from the search
-endpoints of a `/items` endpoint.
+endpoints of a `/search` endpoint.
 
 ## In this directory
 

--- a/item-spec/examples/itemcollection-sample-full.json
+++ b/item-spec/examples/itemcollection-sample-full.json
@@ -80,7 +80,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://stac.example.com/items?collection=CS3"
+      "href": "http://stac.example.com/search?collection=CS3"
     }
   ]
 }

--- a/item-spec/examples/itemcollection-sample-full.json
+++ b/item-spec/examples/itemcollection-sample-full.json
@@ -80,7 +80,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://stac.example.com/stac/search?collection=CS3"
+      "href": "http://stac.example.com/items?collection=CS3"
     }
   ]
 }

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -8,7 +8,7 @@ granular entity in a STAC, containing the core metadata that enables any client 
 online catalogs of spatial 'assets' - satellite imagery, derived data, DEM's, etc.
 
 The same Item definition is used in both [STAC catalogs](../catalog-spec/README.md) and
-the [`/stac/search`](../api-spec/README.md) endpoint. Catalogs are simply sets of items that are linked online,
+the [`/items`](../api-spec/README.md) endpoint. Catalogs are simply sets of items that are linked online,
 generally served by simple web servers and used for crawling data. The search endpoint enables dynamic
 queries, for example selecting all Items in Hawaii on June 3, 2015, but the results they return are
 FeatureCollections of items.

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -8,7 +8,7 @@ granular entity in a STAC, containing the core metadata that enables any client 
 online catalogs of spatial 'assets' - satellite imagery, derived data, DEM's, etc.
 
 The same Item definition is used in both [STAC catalogs](../catalog-spec/README.md) and
-the [`/items`](../api-spec/README.md) endpoint. Catalogs are simply sets of items that are linked online,
+the [`/search`](../api-spec/README.md) endpoint. Catalogs are simply sets of items that are linked online,
 generally served by simple web servers and used for crawling data. The search endpoint enables dynamic
 queries, for example selecting all Items in Hawaii on June 3, 2015, but the results they return are
 FeatureCollections of items.

--- a/item-spec/itemcollection-spec.md
+++ b/item-spec/itemcollection-spec.md
@@ -6,7 +6,7 @@ that is augmented with [foreign members](https://tools.ietf.org/html/rfc7946#sec
 
 Similary to the relationship between a GeoJSON Feature and a STAC Item, a STAC ItemCollection should be a valid GeoJSON FeatureCollection to allow interoperability with existing tools that support GeoJSON. 
 
-The same ItemCollection definition is currently only used by the [`/stac/search`](../api-spec/README.md) endpoint. 
+The same ItemCollection definition is currently only used by the [`/items`](../api-spec/README.md) endpoint. 
 The search endpoint enables dynamic
 queries, for example selecting all Items in Hawaii on June 3, 2015, but the results they return are an
 ItemCollection of Items.

--- a/item-spec/itemcollection-spec.md
+++ b/item-spec/itemcollection-spec.md
@@ -6,7 +6,7 @@ that is augmented with [foreign members](https://tools.ietf.org/html/rfc7946#sec
 
 Similary to the relationship between a GeoJSON Feature and a STAC Item, a STAC ItemCollection should be a valid GeoJSON FeatureCollection to allow interoperability with existing tools that support GeoJSON. 
 
-The same ItemCollection definition is currently only used by the [`/items`](../api-spec/README.md) endpoint. 
+The same ItemCollection definition is currently only used by the [`/search`](../api-spec/README.md) endpoint. 
 The search endpoint enables dynamic
 queries, for example selecting all Items in Hawaii on June 3, 2015, but the results they return are an
 ItemCollection of Items.


### PR DESCRIPTION
**Related Issue(s):** https://github.com/opengeospatial/ogcapi-features/issues/154


**Proposed Changes:**

- The STAC API endpoint `/stac` has been merged with `/`
- The STAC API endpoint `/stac/search` is now called `/items`

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).