### PR TITLE
Asset rel field for purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Added attribute `purpose` to Asset, to be used similarly to Link `rel`
+
+### Fixed
+
+n/a (yet)
+
 ## [v0.8.1] - 2019-11-01
 
 ### Changed

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -1779,6 +1779,10 @@ components:
             type: string
             description: Media type of the asset
             example: image/png
+          purpose:
+            type: string
+            description: Purpose of the asset
+            example: thumbnail
     itemProperties:
       type: object
       required:

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -1533,7 +1533,7 @@ components:
             type: string
             description: Media type of the asset
             example: image/png
-          purpose:
+          rel:
             type: string
             description: Purpose of the asset
             example: thumbnail

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -1533,6 +1533,10 @@ components:
             type: string
             description: Media type of the asset
             example: image/png
+          purpose:
+            type: string
+            description: Purpose of the asset
+            example: thumbnail
     itemProperties:
       type: object
       required:

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -771,7 +771,7 @@ components:
             type: string
             description: Media type of the asset
             example: image/png
-          purpose:
+          rel:
             type: string
             description: Purpose of the asset
             example: thumbnail

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -771,6 +771,10 @@ components:
             type: string
             description: Media type of the asset
             example: image/png
+          purpose:
+            type: string
+            description: Purpose of the asset
+            example: thumbnail
     itemProperties:
       type: object
       required:

--- a/item-spec/examples/sentinel2-sample.json
+++ b/item-spec/examples/sentinel2-sample.json
@@ -57,7 +57,8 @@
     "metadata": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/metadata.xml",
       "title": "Tile metadata",
-      "type": "application/xml"
+      "type": "application/xml",
+      "purpose": "metadata"
     },
     "tileInfo": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/tileInfo.json",
@@ -72,7 +73,8 @@
     "thumbnail": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/qi/L2A_PVI.jp2",
       "title": "True color thumbnail",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "purpose": "thumbnail"
     },
     "B02_10m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R10m/B02.jp2",
@@ -276,7 +278,8 @@
     "TCI_60m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/TCI.jp2",
       "title": "True Color Image (60m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "purpose": "overview"
     },
     "WVP_60m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/WVP.jp2",

--- a/item-spec/examples/sentinel2-sample.json
+++ b/item-spec/examples/sentinel2-sample.json
@@ -58,7 +58,7 @@
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/metadata.xml",
       "title": "Tile metadata",
       "type": "application/xml",
-      "purpose": "metadata"
+      "rel": "metadata"
     },
     "tileInfo": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/tileInfo.json",
@@ -74,7 +74,7 @@
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/qi/L2A_PVI.jp2",
       "title": "True color thumbnail",
       "type": "image/jp2",
-      "purpose": "thumbnail"
+      "rel": "thumbnail"
     },
     "B02_10m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R10m/B02.jp2",
@@ -279,7 +279,7 @@
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/TCI.jp2",
       "title": "True Color Image (60m)",
       "type": "image/jp2",
-      "purpose": "overview"
+      "rel": "overview"
     },
     "WVP_60m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/WVP.jp2",

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -167,6 +167,16 @@ or streamed. It is allowed to add additional fields.
 | href       | string | **REQUIRED.** Link to the asset object. Relative and absolute links are both allowed. |
 | title      | string | The displayed title for clients and users.                                            |
 | type       | string | [Media type](#media-types) of the asset.                                              |
+| purpose    | string | The purpose of the asset, for example `thumbnail`.                                    |
+
+**Purpose** is intended to be a tag that adds semantic usage information to an asset. Examples of this are:
+
+* **thumbnail** An asset that represents a thumbnail of the item, typically a true color image (for items with assets 
+in the visible wavelengths), lower-resolution (typically smaller 600x600 pixels), and typically a JPEG or PNG (suitable 
+for display in a web browser). Multiple assets may have this purpose, but it recommended that the `type` and `purpose` be unique tuple. 
+For example, Sentinel-2 L2A provides thumbnail images in both JPEG and JPEG2000 formats, and would be distinguished by their media types.
+* **overview** An asset that represents a larger view of the item, for example, a true color composite of multi-band data.
+* **metadata** A metadata sidecar file describing the data in this item, for example the Landsat-8 MTL file.
 
 #### Asset types
 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -167,9 +167,12 @@ or streamed. It is allowed to add additional fields.
 | href       | string | **REQUIRED.** Link to the asset object. Relative and absolute links are both allowed. |
 | title      | string | The displayed title for clients and users.                                            |
 | type       | string | [Media type](#media-types) of the asset.                                              |
-| purpose    | string | The purpose of the asset, for example `thumbnail`.                                    |
+| rel        | string | The purpose of the asset, for example `thumbnail`.                                    |
 
-**Purpose** is intended to be a tag that adds semantic usage information to an asset. Examples of this are:
+**rel** is intended to be a tag that adds semantic usage information to an asset, similarly to the use of `rel` in Link, even though it is not 
+really a relationship as the `rel` name implies.
+ 
+Examples of this are:
 
 * **thumbnail** An asset that represents a thumbnail of the item, typically a true color image (for items with assets 
 in the visible wavelengths), lower-resolution (typically smaller 600x600 pixels), and typically a JPEG or PNG (suitable 

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -209,7 +209,7 @@
           "title": "Asset type",
           "type": "string"
         },
-        "purpose": {
+        "rel": {
           "title": "Asset purpose",
           "type": "string"
         }

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -208,6 +208,10 @@
         "type": {
           "title": "Asset type",
           "type": "string"
+        },
+        "purpose": {
+          "title": "Asset purpose",
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
**Related Issue(s):**  n/a

**Proposed Changes:**

1. add a field `rel` to Asset to be used for the purpose of the asset, similarly to `rel` in Link

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [X] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).