### PR TITLE
Collection: Fix type of interval array, should be string instead of number

### DIFF
--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -66,11 +66,15 @@ The object describes the spatial extents of the Collection.
 
 | Element | Type       | Description                                                         |
 | ------- | ---------- | ------------------------------------------------------------------- |
-| bbox    | [number] | **REQUIRED.** Potential *spatial extent* covered by the collection. |
+| bbox    | [[number]] | **REQUIRED.** Potential *spatial extent* covered by the collection. |
 
-**bbox**: Bounding Box of the assets represented by this collection using either 2D or 3D geometries. The length of the array must be 2*n where n is the number of dimensions. The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most extent is the minimum depth/height in meters and the elevation of the northeasterly most extent is the maximum.
+**bbox**: Bounding Box of the assets represented by this collection using either 2D or 3D geometries. 
 
-The coordinate reference system of the values is WGS 84 longitude/latitude. Example that covers the whole Earth: `[-180.0, -90.0, 180.0, 90.0]`.  Example that covers the whole earth with a depth of 100 meters to a height of 150 meters: `[-180.0, -90.0, -100.0, 180.0, 90.0, 150.0]`.
+This is a single-element array containing an array representing a single bounding box.  This is to potentially support multiple bounding boxes later or with an extension.
+
+The length of the inner array must be 2*n where n is the number of dimensions. The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most extent is the minimum depth/height in meters and the elevation of the northeasterly most extent is the maximum.
+
+The coordinate reference system of the values is WGS 84 longitude/latitude. Example that covers the whole Earth: `[[-180.0, -90.0, 180.0, 90.0]]`.  Example that covers the whole earth with a depth of 100 meters to a height of 150 meters: `[[-180.0, -90.0, -100.0, 180.0, 90.0, 150.0]]`.
 
 #### Temporal Extent Object
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -80,13 +80,9 @@ The object describes the temporal extents of the Collection.
 
 | Element  | Type             | Description                                                          |
 | -------- | ---------------- | -------------------------------------------------------------------- |
-| interval | [[number\|null]] | **REQUIRED.** Potential *temporal extent* covered by the collection. |
+| interval | [[string\|null]] | **REQUIRED.** Potential *temporal extent* covered by the collection. |
 
-**interval**: A list of two timestamps wrapped in a list. The timestamps MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Open date ranges are supported by setting either the start or the end time to `null`.
-
-The temporal reference system is the Gregorian calendar. Example for data from the beginning of 2019 until now: `[["2009-01-01T00:00:00Z", null]]`.
-
-The list of timestamps is wrapped in a list to potentially support multiple extents later or with an extension.
+**interval**: A list of a list of two datetimes. The wrapped list to potentially support multiple extents later or with an extension. The datetimes MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Open date ranges are supported by setting either the start or the end time to `null`. Example for data from the beginning of 2019 until now: `[["2009-01-01T00:00:00Z", null]]`. The temporal reference system is the Gregorian calendar. 
 
 ### Provider Object
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -82,7 +82,7 @@ The object describes the temporal extents of the Collection.
 | -------- | ---------------- | -------------------------------------------------------------------- |
 | interval | [[string\|null]] | **REQUIRED.** Potential *temporal extent* covered by the collection. |
 
-**interval**: A list of a list of two datetimes. The wrapped list to potentially support multiple extents later or with an extension. The datetimes MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Open date ranges are supported by setting either the start or the end time to `null`. Example for data from the beginning of 2019 until now: `[["2009-01-01T00:00:00Z", null]]`. The temporal reference system is the Gregorian calendar. 
+**interval**: A list of a list of two datetimes. The wrapped list is to potentially support multiple extents later or with an extension. The datetimes MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Open date ranges are supported by setting either the start or the end time to `null`. Example for data from the beginning of 2019 until now: `[["2009-01-01T00:00:00Z", null]]`. The temporal reference system is the Gregorian calendar. 
 
 ### Provider Object
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -72,8 +72,6 @@ The object describes the spatial extents of the Collection.
 
 The coordinate reference system of the values is WGS 84 longitude/latitude. Example that covers the whole Earth: `[-180.0, -90.0, 180.0, 90.0]`.  Example that covers the whole earth with a depth of 100 meters to a height of 150 meters: `[-180.0, -90.0, -100.0, 180.0, 90.0, 150.0]`.
 
-The list of numbers is wrapped in a list to potentially support multiple bounding boxes later or with an extension.
-
 #### Temporal Extent Object
 
 The object describes the temporal extents of the Collection.

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -66,7 +66,7 @@ The object describes the spatial extents of the Collection.
 
 | Element | Type       | Description                                                         |
 | ------- | ---------- | ------------------------------------------------------------------- |
-| bbox    | [[number]] | **REQUIRED.** Potential *spatial extent* covered by the collection. |
+| bbox    | [number] | **REQUIRED.** Potential *spatial extent* covered by the collection. |
 
 **bbox**: Bounding Box of the assets represented by this collection using either 2D or 3D geometries. The length of the array must be 2*n where n is the number of dimensions. The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most extent is the minimum depth/height in meters and the elevation of the northeasterly most extent is the maximum.
 


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

1. Update Collection Temporal Extent interval field definition to be a string rather than a number.  The description and all our examples are RFC3336 strings, but the type was number. Also replaced the confusing term "timestamp" with "datetime" per RFC3336 term. 

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).