### PR TITLE
Remove eogsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `version` field in STAC Collections. Use [Version Extension](extensions/version/README.md) instead
 - `summaries` field from Catalogs. Use Collections instead
 - Extensions:
-    - `gsd` from `eo:bands` in the [EO extension](extensions/eo/README.md)
+    - `gsd` and `accuracy` from `eo:bands` in the [EO extension](extensions/eo/README.md)
     - `eo:platform`, `eo:instrument`, `eo:constellation` from EO extension, and `sar:platform`, `sar:instrument`, `sar:constellation` from the [SAR extension](extensions/sar/README.md)
     - `sar:absolute_orbit` and `sar:center_wavelength` fields from the [SAR extension](extensions/sar/README.md)
     - `data_type` and `unit` from the `sar:bands` object in the [SAR extension](extensions/sar/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Query Extension - type restrictions on query predicates are more accurate, which may require additional implementation support. 
 
 ### Removed
-- Removed `version` field in STAC Collections. Use [Version Extension](extensions/version/README.md) instead
-- Removed `summaries` field from Catalogs. Use Collections instead
+- `version` field in STAC Collections. Use [Version Extension](extensions/version/README.md) instead
+- `summaries` field from Catalogs. Use Collections instead
 - Extensions:
-    - Removed `eo:platform`, `eo:instrument`, `eo:constellation` from EO extension, and `sar:platform`, `sar:instrument`, `sar:constellation` from the [SAR extension](extensions/sar/README.md)
-    - Removed `sar:absolute_orbit` and `sar:center_wavelength` fields from the [SAR extension](extensions/sar/README.md)
-    - Removed `data_type` and `unit` from the `sar:bands` object in the [SAR extension](extensions/sar/README.md)
-    - Removed `dtr` extension prefix from example and schema in [datetime-range extension](extensions/datetime-range/README.md)
+    - `gsd` from `eo:bands` in the [EO extension](extensions/eo/README.md)
+    - `eo:platform`, `eo:instrument`, `eo:constellation` from EO extension, and `sar:platform`, `sar:instrument`, `sar:constellation` from the [SAR extension](extensions/sar/README.md)
+    - `sar:absolute_orbit` and `sar:center_wavelength` fields from the [SAR extension](extensions/sar/README.md)
+    - `data_type` and `unit` from the `sar:bands` object in the [SAR extension](extensions/sar/README.md)
+    - `dtr` extension prefix from example and schema in [datetime-range extension](extensions/datetime-range/README.md)
 - Asset Types (pre-defined values for the keys of individual assets, *not* media types) in Items. Use the asset's `roles` instead.
 - `license` field doesn't allow SPDX expressions any longer. Use `various` and links instead.
 - STAC API:
-    - Removed "next" from the search metadata and query parameter, added POST body and headers to the links for paging support
+    - `next` from the search metadata and query parameter, added POST body and headers to the links for paging support
 - Removed from EO extension field `eo:epsg` in favor of `proj:epsg`
 
 ### Fixed

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -846,49 +846,36 @@ components:
             - - name: B1
                 common_name: coastal
                 center_wavelength: 4.439
-                gsd: 60
               - name: B2
                 common_name: blue
                 center_wavelength: 4.966
-                gsd: 10
               - name: B3
                 common_name: green
                 center_wavelength: 5.6
-                gsd: 10
               - name: B4
                 common_name: red
                 center_wavelength: 6.645
-                gsd: 10
               - name: B5
                 center_wavelength: 7.039
-                gsd: 20
               - name: B6
                 center_wavelength: 7.402
-                gsd: 20
               - name: B7
                 center_wavelength: 7.825
-                gsd: 20
               - name: B8
                 common_name: nir
                 center_wavelength: 8.351
-                gsd: 10
               - name: B8A
                 center_wavelength: 8.648
-                gsd: 20
               - name: B9
                 center_wavelength: 9.45
-                gsd: 60
               - name: B10
                 center_wavelength: 1.3735
-                gsd: 60
               - name: B11
                 common_name: swir16
                 center_wavelength: 1.6137
-                gsd: 20
               - name: B12
                 common_name: swir22
                 center_wavelength: 2.2024
-                gsd: 20
         links:
           - rel: self
             href: 'http://cool-sat.com/collections/Sentinel-2'

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -555,49 +555,36 @@ components:
             - - name: B1
                 common_name: coastal
                 center_wavelength: 4.439
-                gsd: 60
               - name: B2
                 common_name: blue
                 center_wavelength: 4.966
-                gsd: 10
               - name: B3
                 common_name: green
                 center_wavelength: 5.6
-                gsd: 10
               - name: B4
                 common_name: red
                 center_wavelength: 6.645
-                gsd: 10
               - name: B5
                 center_wavelength: 7.039
-                gsd: 20
               - name: B6
                 center_wavelength: 7.402
-                gsd: 20
               - name: B7
                 center_wavelength: 7.825
-                gsd: 20
               - name: B8
                 common_name: nir
                 center_wavelength: 8.351
-                gsd: 10
               - name: B8A
                 center_wavelength: 8.648
-                gsd: 20
               - name: B9
                 center_wavelength: 9.45
-                gsd: 60
               - name: B10
                 center_wavelength: 1.3735
-                gsd: 60
               - name: B11
                 common_name: swir16
                 center_wavelength: 1.6137
-                gsd: 20
               - name: B12
                 common_name: swir22
                 center_wavelength: 2.2024
-                gsd: 20
         links:
           - rel: self
             href: 'http://cool-sat.com/collections/Sentinel-2'

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -319,49 +319,36 @@ components:
             - - name: B1
                 common_name: coastal
                 center_wavelength: 4.439
-                gsd: 60
               - name: B2
                 common_name: blue
                 center_wavelength: 4.966
-                gsd: 10
               - name: B3
                 common_name: green
                 center_wavelength: 5.6
-                gsd: 10
               - name: B4
                 common_name: red
                 center_wavelength: 6.645
-                gsd: 10
               - name: B5
                 center_wavelength: 7.039
-                gsd: 20
               - name: B6
                 center_wavelength: 7.402
-                gsd: 20
               - name: B7
                 center_wavelength: 7.825
-                gsd: 20
               - name: B8
                 common_name: nir
                 center_wavelength: 8.351
-                gsd: 10
               - name: B8A
                 center_wavelength: 8.648
-                gsd: 20
               - name: B9
                 center_wavelength: 9.45
-                gsd: 60
               - name: B10
                 center_wavelength: 1.3735
-                gsd: 60
               - name: B11
                 common_name: swir16
                 center_wavelength: 1.6137
-                gsd: 20
               - name: B12
                 common_name: swir22
                 center_wavelength: 2.2024
-                gsd: 20
         links:
           - rel: self
             href: 'http://cool-sat.com/collections/Sentinel-2'

--- a/collection-spec/examples/landsat-collection.json
+++ b/collection-spec/examples/landsat-collection.json
@@ -68,77 +68,66 @@
         {
           "name": "B1",
           "common_name": "coastal",
-          "gsd": 30,
           "center_wavelength": 0.44,
           "full_width_half_max": 0.02
         },
         {
           "name": "B2",
           "common_name": "blue",
-          "gsd": 30,
           "center_wavelength": 0.48,
           "full_width_half_max": 0.06
         },
         {
           "name": "B3",
           "common_name": "green",
-          "gsd": 30,
           "center_wavelength": 0.56,
           "full_width_half_max": 0.06
         },
         {
           "name": "B4",
           "common_name": "red",
-          "gsd": 30,
           "center_wavelength": 0.65,
           "full_width_half_max": 0.04
         },
         {
           "name": "B5",
           "common_name": "nir",
-          "gsd": 30,
           "center_wavelength": 0.86,
           "full_width_half_max": 0.03
         },
         {
           "name": "B6",
           "common_name": "swir16",
-          "gsd": 30,
           "center_wavelength": 1.6,
           "full_width_half_max": 0.08
         },
         {
           "name": "B7",
           "common_name": "swir22",
-          "gsd": 30,
           "center_wavelength": 2.2,
           "full_width_half_max": 0.2
         },
         {
           "name": "B8",
           "common_name": "pan",
-          "gsd": 15,
           "center_wavelength": 0.59,
           "full_width_half_max": 0.18
         },
         {
           "name": "B9",
           "common_name": "cirrus",
-          "gsd": 30,
           "center_wavelength": 1.37,
           "full_width_half_max": 0.02
         },
         {
           "name": "B10",
           "common_name": "lwir11",
-          "gsd": 100,
           "center_wavelength": 10.9,
           "full_width_half_max": 0.8
         },
         {
           "name": "B11",
           "common_name": "lwir12",
-          "gsd": 100,
           "center_wavelength": 12,
           "full_width_half_max": 1
         }

--- a/collection-spec/examples/sentinel2.json
+++ b/collection-spec/examples/sentinel2.json
@@ -67,74 +67,61 @@
       {
         "name": "B1",
         "common_name": "coastal",
-        "center_wavelength": 4.439,
-        "gsd": 60
+        "center_wavelength": 4.439
       },
       {
         "name": "B2",
         "common_name": "blue",
-        "center_wavelength": 4.966,
-        "gsd": 10
+        "center_wavelength": 4.966
       },
       {
         "name": "B3",
         "common_name": "green",
-        "center_wavelength": 5.6,
-        "gsd": 10
+        "center_wavelength": 5.6
       },
       {
         "name": "B4",
         "common_name": "red",
-        "center_wavelength": 6.645,
-        "gsd": 10
+        "center_wavelength": 6.645
       },
       {
         "name": "B5",
-        "center_wavelength": 7.039,
-        "gsd": 20
+        "center_wavelength": 7.039
       },
       {
         "name": "B6",
-        "center_wavelength": 7.402,
-        "gsd": 20
+        "center_wavelength": 7.402
       },
       {
         "name": "B7",
-        "center_wavelength": 7.825,
-        "gsd": 20
+        "center_wavelength": 7.825
       },
       {
         "name": "B8",
         "common_name": "nir",
-        "center_wavelength": 8.351,
-        "gsd": 10
+        "center_wavelength": 8.351
       },
       {
         "name": "B8A",
-        "center_wavelength": 8.648,
-        "gsd": 20
+        "center_wavelength": 8.648
       },
       {
         "name": "B9",
-        "center_wavelength": 9.45,
-        "gsd": 60
+        "center_wavelength": 9.45
       },
       {
         "name": "B10",
-        "center_wavelength": 1.3735,
-        "gsd": 60
+        "center_wavelength": 1.3735
       },
       {
         "name": "B11",
         "common_name": "swir16",
-        "center_wavelength": 1.6137,
-        "gsd": 20
+        "center_wavelength": 1.6137
       },
       {
         "name": "B12",
         "common_name": "swir22",
-        "center_wavelength": 2.2024,
-        "gsd": 20
+        "center_wavelength": 2.2024
       }
     ]
   },

--- a/extensions/asset/examples/example-landsat8.json
+++ b/extensions/asset/examples/example-landsat8.json
@@ -75,77 +75,66 @@
       {
         "name": "B1",
         "common_name": "coastal",
-        "gsd": 30,
         "center_wavelength": 0.44,
         "full_width_half_max": 0.02
       },
       {
         "name": "B2",
         "common_name": "blue",
-        "gsd": 30,
         "center_wavelength": 0.48,
         "full_width_half_max": 0.06
       },
       {
         "name": "B3",
         "common_name": "green",
-        "gsd": 30,
         "center_wavelength": 0.56,
         "full_width_half_max": 0.06
       },
       {
         "name": "B4",
         "common_name": "red",
-        "gsd": 30,
         "center_wavelength": 0.65,
         "full_width_half_max": 0.04
       },
       {
         "name": "B5",
         "common_name": "nir",
-        "gsd": 30,
         "center_wavelength": 0.86,
         "full_width_half_max": 0.03
       },
       {
         "name": "B6",
         "common_name": "swir16",
-        "gsd": 30,
         "center_wavelength": 1.6,
         "full_width_half_max": 0.08
       },
       {
         "name": "B7",
         "common_name": "swir22",
-        "gsd": 30,
         "center_wavelength": 2.2,
         "full_width_half_max": 0.2
       },
       {
         "name": "B8",
         "common_name": "pan",
-        "gsd": 15,
         "center_wavelength": 0.59,
         "full_width_half_max": 0.18
       },
       {
         "name": "B9",
         "common_name": "cirrus",
-        "gsd": 30,
         "center_wavelength": 1.37,
         "full_width_half_max": 0.02
       },
       {
         "name": "B10",
         "common_name": "lwir11",
-        "gsd": 100,
         "center_wavelength": 10.9,
         "full_width_half_max": 0.8
       },
       {
         "name": "B11",
         "common_name": "lwir12",
-        "gsd": 100,
         "center_wavelength": 12,
         "full_width_half_max": 1
       }

--- a/extensions/commons/README.md
+++ b/extensions/commons/README.md
@@ -61,7 +61,6 @@ An incomplete Collection:
       {
         "name": "B1",
         "common_name": "coastal",
-        "gsd": 30,
         "center_wavelength": 0.44,
         "full_width_half_max": 0.02
       },
@@ -118,7 +117,6 @@ The merged Item then looks like this:
       {
         "name": "B1",
         "common_name": "coastal",
-        "gsd": 30,
         "center_wavelength": 0.44,
         "full_width_half_max": 0.02
       },

--- a/extensions/commons/examples/landsat-collection.json
+++ b/extensions/commons/examples/landsat-collection.json
@@ -68,77 +68,66 @@
         {
           "name": "B1",
           "common_name": "coastal",
-          "gsd": 30,
           "center_wavelength": 0.44,
           "full_width_half_max": 0.02
         },
         {
           "name": "B2",
           "common_name": "blue",
-          "gsd": 30,
           "center_wavelength": 0.48,
           "full_width_half_max": 0.06
         },
         {
           "name": "B3",
           "common_name": "green",
-          "gsd": 30,
           "center_wavelength": 0.56,
           "full_width_half_max": 0.06
         },
         {
           "name": "B4",
           "common_name": "red",
-          "gsd": 30,
           "center_wavelength": 0.65,
           "full_width_half_max": 0.04
         },
         {
           "name": "B5",
           "common_name": "nir",
-          "gsd": 30,
           "center_wavelength": 0.86,
           "full_width_half_max": 0.03
         },
         {
           "name": "B6",
           "common_name": "swir16",
-          "gsd": 30,
           "center_wavelength": 1.6,
           "full_width_half_max": 0.08
         },
         {
           "name": "B7",
           "common_name": "swir22",
-          "gsd": 30,
           "center_wavelength": 2.2,
           "full_width_half_max": 0.2
         },
         {
           "name": "B8",
           "common_name": "pan",
-          "gsd": 15,
           "center_wavelength": 0.59,
           "full_width_half_max": 0.18
         },
         {
           "name": "B9",
           "common_name": "cirrus",
-          "gsd": 30,
           "center_wavelength": 1.37,
           "full_width_half_max": 0.02
         },
         {
           "name": "B10",
           "common_name": "lwir11",
-          "gsd": 100,
           "center_wavelength": 10.9,
           "full_width_half_max": 0.8
         },
         {
           "name": "B11",
           "common_name": "lwir12",
-          "gsd": 100,
           "center_wavelength": 12,
           "full_width_half_max": 1
         }

--- a/extensions/datacube/examples/example-collection.json
+++ b/extensions/datacube/examples/example-collection.json
@@ -57,74 +57,61 @@
         {
           "name": "B1",
           "common_name": "coastal",
-          "center_wavelength": 4.439,
-          "gsd": 60
+          "center_wavelength": 4.439
         },
         {
           "name": "B2",
           "common_name": "blue",
-          "center_wavelength": 4.966,
-          "gsd": 10
+          "center_wavelength": 4.966
         },
         {
           "name": "B3",
           "common_name": "green",
-          "center_wavelength": 5.6,
-          "gsd": 10
+          "center_wavelength": 5.6
         },
         {
           "name": "B4",
           "common_name": "red",
-          "center_wavelength": 6.645,
-          "gsd": 10
+          "center_wavelength": 6.645
         },
         {
           "name": "B5",
-          "center_wavelength": 7.039,
-          "gsd": 20
+          "center_wavelength": 7.039
         },
         {
           "name": "B6",
-          "center_wavelength": 7.402,
-          "gsd": 20
+          "center_wavelength": 7.402
         },
         {
           "name": "B7",
-          "center_wavelength": 7.825,
-          "gsd": 20
+          "center_wavelength": 7.825
         },
         {
           "name": "B8",
           "common_name": "nir",
-          "center_wavelength": 8.351,
-          "gsd": 10
+          "center_wavelength": 8.351
         },
         {
           "name": "B8A",
-          "center_wavelength": 8.648,
-          "gsd": 20
+          "center_wavelength": 8.648
         },
         {
           "name": "B9",
-          "center_wavelength": 9.45,
-          "gsd": 60
+          "center_wavelength": 9.45
         },
         {
           "name": "B10",
-          "center_wavelength": 1.3735,
-          "gsd": 60
+          "center_wavelength": 1.3735
         },
         {
           "name": "B11",
           "common_name": "swir16",
-          "center_wavelength": 1.6137,
-          "gsd": 20
+          "center_wavelength": 1.6137
         },
         {
           "name": "B12",
           "common_name": "swir22",
-          "center_wavelength": 2.2024,
-          "gsd": 20
+          "center_wavelength": 2.2024
         }
       ]
     ]

--- a/extensions/eo/README.md
+++ b/extensions/eo/README.md
@@ -49,17 +49,8 @@ Multispectral 20° off-nadir value of 2.07 and for WorldView-3 the Multispectral
 | name                | string | The name of the band (e.g., "B01", "B02", "B1", "B5", "QA"). |
 | common_name         | string | The name commonly used to refer to the band to make it easier to search for bands across instruments. See the [list of accepted common names](#common-band-names). |
 | description         | string | Description to fully explain the band. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| gsd                 | number | Ground Sample Distance, the nominal distance between pixel centers available, in meters. Defaults to `eo:gsd` if not provided. |
-| accuracy            | number | The expected error between the measured location and the true location of a pixel, in meters on the ground. |
 | center_wavelength   | number | The center wavelength of the band, in micrometers (μm).      |
 | full_width_half_max | number | Full width at half maximum (FWHM). The width of the band, as measured at half the maximum transmission, in micrometers (μm). |
-
-**eo:gsd** is the Ground Sample Distance, measured in meters on the ground. This value is the nominal distance between 
-pixel centers for the data.
-Since GSD can vary across a scene depending on projection, this should be the average or most
-commonly used GSD in the center of the image. For instance, Landsat8 optical and short-wave IR bands are 30 meters
-and the panchromatic band is 15 meters. The Planet PlanetScope Ortho Tile Product has a band `gsd` of 3.125 (3 if 
-rounding), which is different from the `eo:gsd` of 3.7 (4 if rounding).
 
 **full_width_half_max** (FWHM) is a common way to describe the size of a spectral band. It is the
 width, in micrometers (μm), of the bandpass measured at a half of the maximum transmission. Thus, if the
@@ -116,21 +107,18 @@ See [example-landsat8.json](examples/example-landsat8.json) for a full example.
       {
         "name": "B1",
         "common_name": "coastal",
-        "gsd": 30,
         "center_wavelength": 0.44,
         "full_width_half_max": 0.02
       },
       {
         "name": "B2",
         "common_name": "blue",
-        "gsd": 30,
         "center_wavelength": 0.48,
         "full_width_half_max": 0.06
       },
       {
         "name": "B3",
         "common_name": "green",
-        "gsd": 30,
         "center_wavelength": 0.56,
         "full_width_half_max": 0.06
       },

--- a/extensions/eo/examples/example-landsat8.json
+++ b/extensions/eo/examples/example-landsat8.json
@@ -56,77 +56,66 @@
             {
                 "name": "B1",
                 "common_name": "coastal",
-                "gsd": 30,
                 "center_wavelength": 0.44,
                 "full_width_half_max": 0.02
             },
             {
                 "name": "B2",
                 "common_name": "blue",
-                "gsd": 30,
                 "center_wavelength": 0.48,
                 "full_width_half_max": 0.06
             },
             {
                 "name": "B3",
                 "common_name": "green",
-                "gsd": 30,
                 "center_wavelength": 0.56,
                 "full_width_half_max": 0.06
             },
             {
                 "name": "B4",
                 "common_name": "red",
-                "gsd": 30,
                 "center_wavelength": 0.65,
                 "full_width_half_max": 0.04
             },
             {
                 "name": "B5",
                 "common_name": "nir",
-                "gsd": 30,
                 "center_wavelength": 0.86,
                 "full_width_half_max": 0.03
             },
             {
                 "name": "B6",
                 "common_name": "swir16",
-                "gsd": 30,
                 "center_wavelength": 1.6,
                 "full_width_half_max": 0.08
             },
             {
                 "name": "B7",
                 "common_name": "swir22",
-                "gsd": 30,
                 "center_wavelength": 2.2,
                 "full_width_half_max": 0.2
             },
             {
                 "name": "B8",
                 "common_name": "pan",
-                "gsd": 15,
                 "center_wavelength": 0.59,
                 "full_width_half_max": 0.18
             },
             {
                 "name": "B9",
                 "common_name": "cirrus",
-                "gsd": 30,
                 "center_wavelength": 1.37,
                 "full_width_half_max": 0.02
             },
             {
                 "name": "B10",
                 "common_name": "lwir11",
-                "gsd": 100,
                 "center_wavelength": 10.9,
                 "full_width_half_max": 0.8
             },
             {
                 "name": "B11",
                 "common_name": "lwir12",
-                "gsd": 100,
                 "center_wavelength": 12,
                 "full_width_half_max": 1
             }

--- a/extensions/eo/json-schema/schema.json
+++ b/extensions/eo/json-schema/schema.json
@@ -43,10 +43,6 @@
                     "title": "Common Name of the band",
                     "type": "string"
                   },
-                  "gsd": {
-                    "title": "Ground Sample Distance",
-                    "type": "number"
-                  },
                   "accuracy": {
                     "title": "Accuracy",
                     "type": "number"

--- a/extensions/eo/json-schema/schema.json
+++ b/extensions/eo/json-schema/schema.json
@@ -43,10 +43,6 @@
                     "title": "Common Name of the band",
                     "type": "string"
                   },
-                  "accuracy": {
-                    "title": "Accuracy",
-                    "type": "number"
-                  },
                   "center_wavelength": {
                     "title": "Center Wavelength",
                     "type": "number"

--- a/extensions/projection/examples/example-landsat8.json
+++ b/extensions/projection/examples/example-landsat8.json
@@ -214,7 +214,6 @@
       {
         "name": "B1",
         "common_name": "coastal",
-        "gsd": 30,
         "center_wavelength": 0.44,
         "full_width_half_max": 0.02
       }

--- a/extensions/single-file-stac/examples/example-search.json
+++ b/extensions/single-file-stac/examples/example-search.json
@@ -399,77 +399,66 @@
                     {
                         "name": "B1",
                         "common_name": "coastal",
-                        "gsd": 30,
                         "center_wavelength": 0.44,
                         "full_width_half_max": 0.02
                     },
                     {
                         "name": "B2",
                         "common_name": "blue",
-                        "gsd": 30,
                         "center_wavelength": 0.48,
                         "full_width_half_max": 0.06
                     },
                     {
                         "name": "B3",
                         "common_name": "green",
-                        "gsd": 30,
                         "center_wavelength": 0.56,
                         "full_width_half_max": 0.06
                     },
                     {
                         "name": "B4",
                         "common_name": "red",
-                        "gsd": 30,
                         "center_wavelength": 0.65,
                         "full_width_half_max": 0.04
                     },
                     {
                         "name": "B5",
                         "common_name": "nir",
-                        "gsd": 30,
                         "center_wavelength": 0.86,
                         "full_width_half_max": 0.03
                     },
                     {
                         "name": "B6",
                         "common_name": "swir16",
-                        "gsd": 30,
                         "center_wavelength": 1.6,
                         "full_width_half_max": 0.08
                     },
                     {
                         "name": "B7",
                         "common_name": "swir22",
-                        "gsd": 30,
                         "center_wavelength": 2.2,
                         "full_width_half_max": 0.2
                     },
                     {
                         "name": "B8",
                         "common_name": "pan",
-                        "gsd": 15,
                         "center_wavelength": 0.59,
                         "full_width_half_max": 0.18
                     },
                     {
                         "name": "B9",
                         "common_name": "cirrus",
-                        "gsd": 30,
                         "center_wavelength": 1.37,
                         "full_width_half_max": 0.02
                     },
                     {
                         "name": "B10",
                         "common_name": "lwir11",
-                        "gsd": 100,
                         "center_wavelength": 10.9,
                         "full_width_half_max": 0.8
                     },
                     {
                         "name": "B11",
                         "common_name": "lwir12",
-                        "gsd": 100,
                         "center_wavelength": 12,
                         "full_width_half_max": 1
                     }


### PR DESCRIPTION
**Related Issue(s):** #

Remove gsd and accuracy from eo:bands which are spatial attributes, not spectral attributes and thus do not fit in here. Perhaps they belong in the asset, but there is currently no known use case for including these values so they should be removed. 

**Proposed Changes:**

1. remove gsd from eo:bands field in EO extension
2. remove `accuracy` field from `eo:bands` which appeared only in the readme and schema,is related to gsd

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).