### PR TITLE
Align asset description

### DIFF
--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -1820,6 +1820,15 @@ components:
             type: string
             description: Displayed title
             example: Thumbnail
+          description:
+            type: string
+            description: >-
+              Multi-line description to explain the asset.
+
+
+              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
+              rich text representation.
+            example: Small 256x256px PNG thumbnail for a preview.
           type:
             type: string
             description: Media type of the asset

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -1507,6 +1507,15 @@ components:
             type: string
             description: Displayed title
             example: Thumbnail
+          description:
+            type: string
+            description: >-
+              Multi-line description to explain the asset.
+
+
+              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
+              rich text representation.
+            example: Small 256x256px PNG thumbnail for a preview.
           type:
             type: string
             description: Media type of the asset

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -787,6 +787,15 @@ components:
             type: string
             description: Displayed title
             example: Thumbnail
+          description:
+            type: string
+            description: >-
+              Multi-line description to explain the asset.
+      
+      
+              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
+              text representation.
+            example: Small 256x256px PNG thumbnail for a preview.
           type:
             type: string
             description: Media type of the asset

--- a/extensions/asset/README.md
+++ b/extensions/asset/README.md
@@ -30,7 +30,7 @@ An asset is an object that contains details about the datafiles that will be inc
 | Field Name  | Type   | Description |
 | ----------- | ------ | ----------- |
 | title       | string | The displayed title for clients and users. |
-| description | string | A description of the Asset providing additional details, such as how it was processed or created. |
+| description | string | A description of the Asset providing additional details, such as how it was processed or created. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | type        | string | [Media type](../../item-spec/item-spec.md#media-types) of the asset. |
 | roles       | [string] | The semantic roles of the asset, similar to the use of `rel` in links. |
 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -105,7 +105,7 @@ Currently, the JSON schema for links does not require them to be formatted as UR
 implementors to provide relative links. In general, Catalog APIs should aim to provide absolute links
 whenever possible. Static Catalogs are potentially more portable if they incorporate only
 relative links, so that every link doesn't need to be rewritten when the data is copied. Additional
-recommendations for particular ```rel``` types are given in the ```rel``` type description.
+recommendations for particular `rel` types are given in the `rel` type description.
 
 #### Relation types
 
@@ -153,7 +153,7 @@ or streamed. It is allowed to add additional fields.
 | ----------- | ------ | ----------- |
 | href        | string | **REQUIRED.** Link to the asset object. Relative and absolute links are both allowed. |
 | title       | string | The displayed title for clients and users. |
-| description | string | A description of the Asset providing additional details, such as how it was processed or created. |
+| description | string | A description of the Asset providing additional details, such as how it was processed or created. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | type        | string | [Media type](#media-types) of the asset. |
 | roles       | [string] | The semantic role of the asset, similar to the use of `rel` in links. 
 


### PR DESCRIPTION
**Related Issue(s):** None

**Proposed Changes:**

1. We forgot to allow Commonmark in the asset description. There's no good reason to not allow it when all other descriptions allow it.
2. We forgot to add the asset description field in the API.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).