### PR TITLE
Respond with PreconditionFailed when If-Match header invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- `putFeature` can return a `PreconditionFailed` to provide more explicit information when the resource has changed in the server
+
 ## [v0.9.0-rc1] - 2020-01-06
 
 ### Added
 - ItemCollection requires `stac_version` field, `stac_extensions` has also been added
-- A `description` field has been added to Item assets (also Asset definitions extension). 
+- A `description` field has been added to Item assets (also Asset definitions extension).
 - Field `mission` to [Common Metadata fields](item-spec/common-metadata.md).
 - Extensions:
     - [Version Indicators extension](extensions/version/README.md), adds `version` and `deprecated` fields to STAC Items and Collections
@@ -44,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Fields extension has a simplified format for GET parameters
     - `search` extension renamed to `context` extension. JSON object renamed from `search:metadata` to `context`
     - Removed "next" from the search metadata and query parameter, added POST body and headers to the links for paging support
-    - Query Extension - type restrictions on query predicates are more accurate, which may require additional implementation support. 
+    - Query Extension - type restrictions on query predicates are more accurate, which may require additional implementation support.
 
 ### Removed
 - `version` field in STAC Collections. Use [Version Extension](extensions/version/README.md) instead

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -226,6 +226,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
         5XX:
           $ref: '#/components/responses/InternalServerError'
         default:
@@ -240,7 +242,7 @@ paths:
     patch:
       summary: update an existing feature by Id with a partial item definition
       description: >-
-        Use this method to update an existing feature. Requires a GeoJSON 
+        Use this method to update an existing feature. Requires a GeoJSON
         fragement (containing the fields to be updated) be submitted.
       operationId: patchFeature
       tags:
@@ -2305,6 +2307,12 @@ components:
             type: string
     BadRequest:
       description: The request was malformed or semantically invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+    PreconditionFailed:
+      description: Some condition specified by the request could not be met in the server
       content:
         application/json:
           schema:

--- a/api-spec/extensions/transaction/transaction.fragment.yaml
+++ b/api-spec/extensions/transaction/transaction.fragment.yaml
@@ -94,6 +94,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+        '412':
+          $ref: '#/components/responses/PreconditionFailed'
         '5XX':
           $ref: '#/components/responses/InternalServerError'
         default:
@@ -108,7 +110,7 @@ paths:
     patch:
       summary: update an existing feature by Id with a partial item definition
       description: >-
-        Use this method to update an existing feature. Requires a GeoJSON 
+        Use this method to update an existing feature. Requires a GeoJSON
         fragement (containing the fields to be updated) be submitted.
       operationId: patchFeature
       tags:
@@ -243,6 +245,12 @@ components:
             $ref: '#/components/schemas/exception'
     BadRequest:
       description: The request was malformed or semantically invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/exception'
+    PreconditionFailed:
+      description: Some condition specified by the request could not be met in the server
       content:
         application/json:
           schema:


### PR DESCRIPTION
**Related Issue(s):** #

none

**Proposed Changes:**

1. Respond with as specific a response as possible when we know what went wrong with an item update in api transactions extension PUT. `BadRequest` and `NotFound` don't tell the user that they should refresh the object and try again, while a `PreconditionFailed` for a request with an `If-Match` header is extremely clear

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).