### PR TITLE
Small schema corrections

### DIFF
--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -39,7 +39,8 @@
                   "asset",
                   "commons",
                   "checksum",
-                  "scientific"
+                  "scientific",
+                  "version"
                 ]
               }
             ]

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -39,6 +39,7 @@
                   "asset",
                   "commons",
                   "checksum",
+                  "datacube",
                   "scientific",
                   "version"
                 ]

--- a/extensions/sat/json-schema/schema.json
+++ b/extensions/sat/json-schema/schema.json
@@ -11,7 +11,7 @@
       "$ref": "#/definitions/sat"
     },
     {
-      "$ref": "../instrument/json-schema/schema.json"
+      "$ref": "../../../item-spec/json-schema/instrument.json"
     }
   ],
   "definitions": {

--- a/item-spec/examples/landsat8-sample.json
+++ b/item-spec/examples/landsat8-sample.json
@@ -75,7 +75,6 @@
     "metadata": {
       "href": "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_MTL.txt",
       "type": "mtl",
-      "role": "metadata",
       "title": "Original Metadata",
       "description": "The original MTL metadata file provided for each Landsat scene",
       "roles": ["metadata"]

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -71,12 +71,15 @@
                     "enum": [
                       "checksum",
                       "commons",
-                      "cube",
+                      "datacube",
                       "eo",
                       "label",
                       "pointcloud",
+                      "projection",
                       "sar",
-                      "scientific"
+                      "sat",
+                      "scientific",
+                      "version"
                     ]
                   }
                 ]


### PR DESCRIPTION
**Related Issue(s):** #
N/A

**Proposed Changes:**
1. Fix an old ref link to instrument extension in sat schema
2. Updates the list of stac_extensions in item and collection schemas to match current extensions directories

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).