### PR TITLE
Sortby update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Item properties.
 - Item `title` definition moved from core Item fields to [Common Metadata Basics](item-spec/common-metadata.md#basics) 
 fields. No change is required for STAC Items.
 - `putFeature` can return a `PreconditionFailed` to provide more explicit information when the resource has changed in the server
+- [Sort extension](api-spec/extensions/sort) now uses "+" and "-" prefixes for GET requests to denote sort order. 
 
 ### Fixed
 - Fixed Item JSON Schema now `allOf` optional Common Metadata properties are evaluated.

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -644,7 +644,7 @@ components:
         An array of property names, prefixed by either "+" for ascending or "-"
         for descending. If no prefix is provided, "+" is assumed.
       required: false
-      schema:ß
+      schema:
         type: string
         example: '+id,-properties.eo:cloud_cover'
       style: form

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -637,10 +637,13 @@ components:
       required: false
       schema:
         type: string
+        example: '+id,-properties.eo:cloud_cover'
     sortby:
       name: sortby
       in: query
-      description: Allows sorting results by the specified properties
+      description: |
+        An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is
+        provided, "+" is assumed.
       required: false
       schema:
         type: string

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -637,16 +637,18 @@ components:
       required: false
       schema:
         type: string
-        example: '+id,-properties.eo:cloud_cover'
     sortby:
       name: sortby
       in: query
-      description: |
-        An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is
+      description: >
+        An array of property names, prefixed by either "+" for ascending or "-"
+        for descending. If no prefix is
+
         provided, "+" is assumed.
       required: false
       schema:
         type: string
+        example: '+id,-properties.eo:cloud_cover'
       style: form
       explode: false
     fields:

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -642,11 +642,9 @@ components:
       in: query
       description: >
         An array of property names, prefixed by either "+" for ascending or "-"
-        for descending. If no prefix is
-
-        provided, "+" is assumed.
+        for descending. If no prefix is provided, "+" is assumed.
       required: false
-      schema:
+      schema:ß
         type: string
         example: '+id,-properties.eo:cloud_cover'
       style: form

--- a/api-spec/extensions/sort/README.md
+++ b/api-spec/extensions/sort/README.md
@@ -2,27 +2,44 @@
 
 **Extension [Maturity Classification](../../../extensions/README.md#extension-maturity): Pilot**
 
-By default, the STAC search endpoint `/search` returns results in no specified order.  Whatever order the results are in is up to the implementor, and will typically default to an arbitrary that is fastest for the underlying data store to retrieve results.
+By default, the STAC search endpoint `/search` returns results in no specified order.  Whatever order the results are in 
+is up to the implementor, and will typically default to an arbitrary order that is fastest for the underlying data store 
+to retrieve results.
  
- The Sort API Extension adds a new parameter, `sortby`, that allows the user to define fields by which to sort results. Only string, numeric, and datetime attributes of Item (`id` and `collection` only) or Item Properties (any attributes) may be used to sort results.  It is not required that implementations support sorting over all attributes, but implementations should return an error when attempting to sort over a field that does not support sorting. 
+The Sort API Extension adds a new parameter, `sortby`, that allows the user to define fields by which to sort results. 
+Only string, numeric, and datetime attributes of Item (`id` and `collection` only) or Item Properties (any attributes) 
+may be used to sort results.  It is not required that implementations support sorting over all attributes, but 
+implementations should return an error when attempting to sort over a field that does not support sorting. 
 
-Two values for direction are supported: "asc" (ascending) or "desc" (descending). If the direction is not specified, the value is ascending. The `sortby` value is an array, so multiple sort fields can be defined which will be used to sort the data in the order provided (e.g., first by `datetime`, then by `eo:cloud_cover`).
+Fields may be sorted in ascending or descending order.  The syntax between GET requests and POST requests with a JSON 
+body vary.  The `sortby` value is an array, so multiple sort fields can be defined which will be used to sort 
+the data in the order provided (e.g., first by `datetime`, then by `eo:cloud_cover`).
 
-## GET or POST Form
+## HTTP GET (or POST Form)
 
-When calling `/search` using GET or POST with `Content-Type: application/x-www-form-urlencoded` or `Content-Type: multipart/form-data`, the semantics are the same, except the syntax is a single parameter `sortby` with a comma-separated list of "<name>|<direction>" definitions.  It is recommended that in implementations, direction be mandatory, and that an error should result from not specifying a direction.
+When calling `/search` using GET (or POST with `Content-Type: application/x-www-form-urlencoded` or 
+`Content-Type: multipart/form-data)`, a single parameter `sortby` with a comma-separated list of item field names should 
+be provided. The field names may be prefixed with either "+" for ascending, or "-" for descending.  If no sign is 
+provided before the field name, it will be assumed to be "+". 
 
 Examples of `sortby` parameter:
 
-    GET /search?sortby=created|asc
+    1) GET /search?sortby=properties.created
     
-    GET /search?sortby=created|asc,id|desc
+    2) GET /search?sortby=+properties.created
     
-    GET /search?sortby=properties.eo:cloud_cover|desc
+    3) GET /search?sortby=properties.created,-id
+    
+    4) GET /search?sortby=+properties.created,-id
+    
+    5) GET /search?sortby=-properties.eo:cloud_cover
+    
+Note that examples 1 and 2 are symantically equivalent, as well as examples 3 and 4.
 
-# POST JSON Entity
+# HTTP POST JSON Entity
 
-When calling `/search` using POST with`Content-Type: application/json`, this extension adds an attribute `sortby` with an object value to the core JSON search request body.
+When calling `/search` using POST with`Content-Type: application/json`, this extension adds an attribute `sortby` with 
+an object value to the core JSON search request body.
 
 The syntax for the `sortby` attribute is:
 

--- a/api-spec/extensions/sort/README.md
+++ b/api-spec/extensions/sort/README.md
@@ -58,7 +58,7 @@ The syntax for the `sortby` attribute is:
 {
     "sortby": [
         {
-            "field": "created",
+            "field": "properties.created",
             "direction": "asc"
         },
         {

--- a/api-spec/extensions/sort/README.md
+++ b/api-spec/extensions/sort/README.md
@@ -24,18 +24,18 @@ provided before the field name, it will be assumed to be "+".
 
 Examples of `sortby` parameter:
 
-    1) GET /search?sortby=properties.created
+    1. GET /search?sortby=properties.created
     
-    2) GET /search?sortby=+properties.created
+    2. GET /search?sortby=+properties.created
     
-    3) GET /search?sortby=properties.created,-id
+    3. GET /search?sortby=properties.created,-id
     
-    4) GET /search?sortby=+properties.created,-id
+    4. GET /search?sortby=+properties.created,-id
     
-    5) GET /search?sortby=-properties.eo:cloud_cover
+    5. GET /search?sortby=-properties.eo:cloud_cover
     
 Note that examples 1 and 2 are symantically equivalent, as well as examples 3 and 4.
-
+ß
 # HTTP POST JSON Entity
 
 When calling `/search` using POST with`Content-Type: application/json`, this extension adds an attribute `sortby` with 

--- a/api-spec/extensions/sort/sort.fragment.yaml
+++ b/api-spec/extensions/sort/sort.fragment.yaml
@@ -9,10 +9,13 @@ components:
     sortby:
       name: sortby
       in: query
-      description: Allows sorting results by the specified properties
+      description: |
+        An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is
+        provided, "+" is assumed.
       required: false
       schema:
         type: string
+        example: '+id,-properties.eo:cloud_cover'
       style: form
       explode: false
   schemas:


### PR DESCRIPTION
**Related Issue(s):** #
https://github.com/radiantearth/stac-spec/issues/727

**Proposed Changes:**

1. Changed sort api extension to use "+" and "-" field prefixes to define sort order for GET requests

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).