### PR TITLE
Fixes for the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ Item properties.
 fields. No change is required for STAC Items.
 - `putFeature` can return a `PreconditionFailed` to provide more explicit information when the resource has changed in the server
 - [Sort extension](api-spec/extensions/sort) now uses "+" and "-" prefixes for GET requests to denote sort order. 
+- Clarified how `/search` links must be added to `/` and changed that links to both GET and POST must be provided now that the method can be specified in links.
 
 ### Fixed
 - Fixed Item JSON Schema now `allOf` optional Common Metadata properties are evaluated.
 - Clarified usage of optional Common Metadata fields for STAC Items.
+- Fixed API spec regarding license expressions
+- Added missing schema in the API Version extension
 
 
 ## [v0.9.0-rc1] - 2020-01-06

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -1400,28 +1400,17 @@ components:
         text representation.
     license:
       type: string
-      description: >-
+      description: |-
         License(s) of the data as a SPDX
-
-        [License identifier](https://spdx.org/licenses/) or
-
-        [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60).
-         Alternatively, use
+        [License identifier](https://spdx.org/licenses/). Alternatively, use
         `proprietary` if the license is not on the SPDX license list or
-
         `various` if multiple licenses apply. In these two cases links to the
-
         license texts SHOULD be added, see the `license` link relation type.
 
-
         Non-SPDX licenses SHOULD add a link to the license text with the
-
         `license` relation in the links section. The license text MUST NOT be
-
         provided as a value of this field. If there is no public license URL
-
         available, it is RECOMMENDED to host the license text and
-
         link to it.
       example: Apache-2.0
     providers:

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -323,6 +323,11 @@ paths:
 
         This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
+
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` to the
+        `links` array in `GET /`. As `GET` is the default method, the `method`
+        may not be set explicitly in the link.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -362,8 +367,8 @@ paths:
 
         This method is mandatory to implement if `GET /search` is implemented.
         If this endpoint is implemented on a server, it is required to add a
-        link with `rel` set to `search` to the `links` array in `GET /` that
-        refers to this endpoint.
+        link referring to this endpoint with `rel` set to `search` and `method`
+        set to `POST` to the `links` array in `GET /`.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -2065,8 +2070,9 @@ components:
         Collections (path `/collections`, link relation
         `data`).
 
-        A link to the search endpoint (path `/search`, link relation `search`)
-        is **required** to be specified if the API implements `/search`.
+        Links to the search endpoints (path `/search`, link relation `search`,
+        method `GET` or `POST`) are **required** to be specified if the API
+        implements `/search` for any of the specified HTTP methods.
       content:
         application/json:
           schema:

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -317,10 +317,9 @@ paths:
   /search:
     get:
       summary: Search STAC items with simple filtering.
-      description: >-
+      description: |-
         Retrieve Items matching filters. Intended as a shorthand API for simple
         queries.
-
 
         This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
@@ -357,10 +356,9 @@ paths:
                 type: string
     post:
       summary: Search STAC items with full-featured filtering.
-      description: >-
+      description: |-
         retrieve items matching filters. Intended as the standard, full-featured
         query API.
-
 
         This method is mandatory to implement if `GET /search` is implemented.
         If this endpoint is implemented on a server, it is required to add a
@@ -463,9 +461,10 @@ components:
         selected.
 
         The bounding box is provided as four or six numbers, depending on
-        whether the
 
-        coordinate reference system includes a vertical axis (height or depth):
+        whether the coordinate reference system includes a vertical axis (height
+
+        or depth):
 
 
         * Lower left corner, coordinate axis 1
@@ -482,24 +481,23 @@ components:
 
 
         The coordinate reference system of the values is WGS 84
-        longitude/latitude
 
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different
-        coordinate
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
 
-        reference system is specified in the parameter `bbox-crs`.
+        a different coordinate reference system is specified in the parameter
+
+        `bbox-crs`.
 
 
         For WGS 84 longitude/latitude the values are in most cases the sequence
-        of
 
-        minimum longitude, minimum latitude, maximum longitude and maximum
-        latitude.
+        of minimum longitude, minimum latitude, maximum longitude and maximum
 
-        However, in cases where the box spans the antimeridian the first value
+        latitude. However, in cases where the box spans the antimeridian the
 
-        (west-most box edge) is larger than the third value (east-most box
-        edge).
+        first value (west-most box edge) is larger than the third value
+
+        (east-most box edge).
 
 
         If the vertical axis is included, the third and the sixth number are
@@ -508,21 +506,18 @@ components:
 
 
         If a feature has multiple spatial geometry properties, it is the
-        decision of the
 
-        server whether only a single spatial geometry property is used to
-        determine
+        decision of the server whether only a single spatial geometry property
 
-        the extent or all relevant geometries.
+        is used to determine the extent or all relevant geometries.
 
 
         Example: The bounding box of the New Zealand Exclusive Economic Zone in
-        WGS 84
 
-        (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be represented
-        in JSON
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
 
-        as `[160.6, -55.95, -170, -25.89]` and in a query as
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+
         `bbox=160.6,-55.95,-170,-25.89`.
       required: false
       schema:
@@ -609,11 +604,9 @@ components:
     ids:
       name: ids
       in: query
-      description: >
+      description: |-
         Array of Item ids to return. All other filter parameters that further
-        restrict the number of 
-
-        search results are ignored
+        restrict the number of search results are ignored
       required: false
       schema:
         $ref: '#/components/schemas/ids'
@@ -640,9 +633,9 @@ components:
     sortby:
       name: sortby
       in: query
-      description: >
-        An array of property names, prefixed by either "+" for ascending or "-"
-        for descending. If no prefix is provided, "+" is assumed.
+      description: |-
+        An array of property names, prefixed by either "+" for ascending or
+        "-" for descending. If no prefix is provided, "+" is assumed.
       required: false
       schema:
         type: string
@@ -746,7 +739,7 @@ components:
         providers:
           $ref: '#/components/schemas/providers'
         summaries:
-          description: >-
+          description: |-
             Summaries are either a unique set of all available values *or*
             statistics. Statistics by default only specify the range (minimum
             and maximum values), but can optionally be accompanied by additional
@@ -767,7 +760,7 @@ components:
                   description: A value of any type.
               - type: object
                 title: Statistics
-                description: >-
+                description: |-
                   By default, only ranges with a minimum and a maximum value can
                   be specified. Ranges can be specified for ordinal values only,
                   which means they need to have a rank order. Therefore, ranges
@@ -1264,17 +1257,18 @@ components:
         merge:
           type: boolean
           default: false
-          description: >-
+          description: |-
             This is only valid when the server is responding to POST request.
 
             If merge is true, the client is expected to merge the body value
-            into the current request body before following the link. This avoids
-            passing large post bodies back and forth when following links,
-            particularly for navigating pages through the POST /search endpoint.
+            into the current request body before following the link.
+            This avoids passing large post bodies back and forth when following
+            links, particularly for navigating pages through the `POST /search`
+            endpoint.
 
             NOTE: To support form encoding it is expected that a client be able
-            to merge in the key value pairs specified as JSON `{"next":
-            "token"}` will become `&next=token`
+            to merge in the key value pairs specified as JSON
+            `{"next": "token"}` will become `&next=token`.
       title: Link
     multilinestringGeoJSON:
       type: object
@@ -1398,29 +1392,37 @@ components:
       example: '2017-08-17T08:05:32Z'
     description:
       type: string
-      description: >-
+      description: |-
         Detailed multi-line description to fully explain the catalog or
         collection.
-
 
         [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
         text representation.
     license:
       type: string
       description: >-
-        License(s) of the data as a SPDX [License
-        identifier](https://spdx.org/licenses/) or
+        License(s) of the data as a SPDX
+
+        [License identifier](https://spdx.org/licenses/) or
+
         [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60).
-        Alternatively, use `proprietary` if the license is not on the SPDX
-        license list or `various` if multiple licenses apply. In these two cases
-        links to the license texts SHOULD be added, see the `license` link
-        relation type.
+         Alternatively, use
+        `proprietary` if the license is not on the SPDX license list or
+
+        `various` if multiple licenses apply. In these two cases links to the
+
+        license texts SHOULD be added, see the `license` link relation type.
 
 
         Non-SPDX licenses SHOULD add a link to the license text with the
+
         `license` relation in the links section. The license text MUST NOT be
+
         provided as a value of this field. If there is no public license URL
-        available, it is RECOMMENDED to host the license text and link to it.
+
+        available, it is RECOMMENDED to host the license text and
+
+        link to it.
       example: Apache-2.0
     providers:
       type: array
@@ -1448,26 +1450,22 @@ components:
               CommonMark 0.29 syntax MAY be used for rich text representation.
             type: string
           roles:
-            description: >-
+            description: |-
               Roles of the provider.
-
 
               The provider's role(s) can be one or more of the following
               elements:
 
               * licensor: The organization that is licensing the dataset under
-              the license specified in the collection's license field.
-
+                the license specified in the collection's license field.
               * producer: The producer of the data is the provider that
-              initially captured and processed the source data, e.g. ESA for
-              Sentinel-2 data.
-
+                initially captured and processed the source data, e.g. ESA for
+                Sentinel-2 data.
               * processor: A processor is any provider who processed data to a
-              derived product.
-
+                derived product.
               * host: The host is the actual provider offering the data on their
-              storage. There should be no more than one host, specified as last
-              element of the list.
+                storage. There should be no more than one host, specified as last
+                element of the list.
             type: array
             items:
               type: string
@@ -1503,63 +1501,37 @@ components:
       maximum: 10000
       description: The maximum number of results to return (page size). Defaults to 10
     bbox:
-      description: >-
+      description: |-
         Only features that have a geometry that intersects the bounding box are
-
         selected. The bounding box is provided as four or six numbers,
-
         depending on whether the coordinate reference system includes a
-
         vertical axis (elevation or depth):
 
-
         * Lower left corner, coordinate axis 1
-
         * Lower left corner, coordinate axis 2  
-
         * Lower left corner, coordinate axis 3 (optional) 
-
         * Upper right corner, coordinate axis 1 
-
         * Upper right corner, coordinate axis 2 
-
         * Upper right corner, coordinate axis 3 (optional)
 
-
         The coordinate reference system of the values is WGS84
-
         longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
-
         a different coordinate reference system is specified in the parameter
-
         `bbox-crs`.
 
-
         For WGS84 longitude/latitude the values are in most cases the sequence
-
         of minimum longitude, minimum latitude, maximum longitude and maximum
-
         latitude. However, in cases where the box spans the antimeridian the
-
         first value (west-most box edge) is larger than the third value
-
         (east-most box edge).
 
-
         If a feature has multiple spatial geometry properties, it is the
-
         decision of the server whether only a single spatial geometry property
-
         is used to determine the extent or all relevant geometries.
 
-
         Example: The bounding box of the New Zealand Exclusive Economic Zone in
-        WGS 84
-
-        (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be represented
-        in JSON
-
-        as `[160.6, -55.95, -170, -25.89]` and in a query as
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
         `bbox=160.6,-55.95,-170,-25.89`.
       type: array
       minItems: 4
@@ -1579,18 +1551,16 @@ components:
           $ref: '#/components/schemas/bbox'
     collectionsArray:
       type: array
-      description: |
+      description: |-
         Array of Collection IDs to include in the search for items.
-        Only Items in one of the provided Collections will be searched
+        Only Items in one of the provided Collections will be searched.
       items:
         type: string
     ids:
       type: array
-      description: >
+      description: |-
         Array of Item ids to return. All other filter parameters that further
-        restrict the number of 
-
-        search results are ignored
+        restrict the number of search results are ignored
       items:
         type: string
     datetimeFilter:
@@ -1625,32 +1595,22 @@ components:
           $ref: '#/components/schemas/collectionsArray'
     datetime:
       type: string
-      description: >-
+      description: |-
         Either a date-time or an interval, open or closed. Date and time
-        expressions
-
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
-
+        expressions adhere to RFC 3339. Open intervals are expressed using
+        double-dots.
 
         Examples:
 
-
         * A date-time: "2018-02-12T23:20:50Z"
-
         * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-
         * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
 
-
         Only features that have a temporal property that intersects the value of
-
         `datetime` are selected.
 
-
         If a feature has multiple temporal properties, it is the decision of the
-
         server whether only a single temporal property is used to determine
-
         the extent or all relevant temporal properties.
       example: '2018-02-12T00:00:00Z/2018-03-18T12:31:12Z'
     stac_version:
@@ -1832,9 +1792,8 @@ components:
             example: Thumbnail
           description:
             type: string
-            description: >-
+            description: |-
               Multi-line description to explain the asset.
-
 
               [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
               rich text representation.
@@ -2109,24 +2068,16 @@ components:
             $ref: '#/components/schemas/link'
   responses:
     LandingPage:
-      description: >-
+      description: |-
         The landing page provides links to the API definition
-
         (link relations `service-desc` and `service-doc`),
-
         the Conformance declaration (path `/conformance`,
-
         link relation `conformance`), and the Feature
-
         Collections (path `/collections`, link relation
-
         `data`).
 
-
-        A link to the search endpoint (path `/search`, link relation
-
-        `search`) is **required** to be specified if the API implements
-        `/search`
+        A link to the search endpoint (path `/search`, link relation `search`)
+        is **required** to be specified if the API implements `/search`.
       content:
         application/json:
           schema:

--- a/api-spec/STAC-extensions.yaml
+++ b/api-spec/STAC-extensions.yaml
@@ -700,14 +700,10 @@ components:
           type: string
           example: address
         description:
-          description: >-
-            Detailed multi-line description to fully explain the collection.
-
-
-            [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
-            rich text representation.
+          description: a description of the features in the collection
           type: string
           example: An address.
+          $ref: '#/components/schemas/description'
         links:
           type: array
           items:
@@ -1400,6 +1396,15 @@ components:
       type: string
       format: date-time
       example: '2017-08-17T08:05:32Z'
+    description:
+      type: string
+      description: >-
+        Detailed multi-line description to fully explain the catalog or
+        collection.
+
+
+        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
+        text representation.
     license:
       type: string
       description: >-
@@ -2078,6 +2083,30 @@ components:
       properties:
         datetime:
           $ref: '#/components/schemas/datetime'
+    catalogDefinition:
+      type: object
+      required:
+        - stac_version
+        - id
+        - description
+        - links
+      properties:
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        id:
+          description: 'identifier of the catalog used, for example, in URIs'
+          type: string
+        title:
+          description: human readable title of the catalog
+          type: string
+        description:
+          $ref: '#/components/schemas/description'
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
   responses:
     LandingPage:
       description: >-

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -142,6 +142,11 @@ paths:
 
         This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
+
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` to the
+        `links` array in `GET /`. As `GET` is the default method, the `method`
+        may not be set explicitly in the link.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -178,8 +183,8 @@ paths:
 
         This method is mandatory to implement if `GET /search` is implemented.
         If this endpoint is implemented on a server, it is required to add a
-        link with `rel` set to `search` to the `links` array in `GET /` that
-        refers to this endpoint.
+        link referring to this endpoint with `rel` set to `search` and `method`
+        set to `POST` to the `links` array in `GET /`.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -1513,8 +1518,9 @@ components:
         Collections (path `/collections`, link relation
         `data`).
 
-        A link to the search endpoint (path `/search`, link relation `search`)
-        is **required** to be specified if the API implements `/search`.
+        Links to the search endpoints (path `/search`, link relation `search`,
+        method `GET` or `POST`) are **required** to be specified if the API
+        implements `/search` for any of the specified HTTP methods.
       content:
         application/json:
           schema:

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -1104,28 +1104,17 @@ components:
         text representation.
     license:
       type: string
-      description: >-
+      description: |-
         License(s) of the data as a SPDX
-
-        [License identifier](https://spdx.org/licenses/) or
-
-        [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60).
-         Alternatively, use
+        [License identifier](https://spdx.org/licenses/). Alternatively, use
         `proprietary` if the license is not on the SPDX license list or
-
         `various` if multiple licenses apply. In these two cases links to the
-
         license texts SHOULD be added, see the `license` link relation type.
 
-
         Non-SPDX licenses SHOULD add a link to the license text with the
-
         `license` relation in the links section. The license text MUST NOT be
-
         provided as a value of this field. If there is no public license URL
-
         available, it is RECOMMENDED to host the license text and
-
         link to it.
       example: Apache-2.0
     providers:

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -136,10 +136,9 @@ paths:
   /search:
     get:
       summary: Search STAC items with simple filtering.
-      description: >-
+      description: |-
         Retrieve Items matching filters. Intended as a shorthand API for simple
         queries.
-
 
         This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
@@ -173,10 +172,9 @@ paths:
                 type: string
     post:
       summary: Search STAC items with full-featured filtering.
-      description: >-
+      description: |-
         retrieve items matching filters. Intended as the standard, full-featured
         query API.
-
 
         This method is mandatory to implement if `GET /search` is implemented.
         If this endpoint is implemented on a server, it is required to add a
@@ -219,9 +217,10 @@ components:
         selected.
 
         The bounding box is provided as four or six numbers, depending on
-        whether the
 
-        coordinate reference system includes a vertical axis (height or depth):
+        whether the coordinate reference system includes a vertical axis (height
+
+        or depth):
 
 
         * Lower left corner, coordinate axis 1
@@ -238,24 +237,23 @@ components:
 
 
         The coordinate reference system of the values is WGS 84
-        longitude/latitude
 
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different
-        coordinate
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
 
-        reference system is specified in the parameter `bbox-crs`.
+        a different coordinate reference system is specified in the parameter
+
+        `bbox-crs`.
 
 
         For WGS 84 longitude/latitude the values are in most cases the sequence
-        of
 
-        minimum longitude, minimum latitude, maximum longitude and maximum
-        latitude.
+        of minimum longitude, minimum latitude, maximum longitude and maximum
 
-        However, in cases where the box spans the antimeridian the first value
+        latitude. However, in cases where the box spans the antimeridian the
 
-        (west-most box edge) is larger than the third value (east-most box
-        edge).
+        first value (west-most box edge) is larger than the third value
+
+        (east-most box edge).
 
 
         If the vertical axis is included, the third and the sixth number are
@@ -264,21 +262,18 @@ components:
 
 
         If a feature has multiple spatial geometry properties, it is the
-        decision of the
 
-        server whether only a single spatial geometry property is used to
-        determine
+        decision of the server whether only a single spatial geometry property
 
-        the extent or all relevant geometries.
+        is used to determine the extent or all relevant geometries.
 
 
         Example: The bounding box of the New Zealand Exclusive Economic Zone in
-        WGS 84
 
-        (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be represented
-        in JSON
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
 
-        as `[160.6, -55.95, -170, -25.89]` and in a query as
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+
         `bbox=160.6,-55.95,-170,-25.89`.
       required: false
       schema:
@@ -365,11 +360,9 @@ components:
     ids:
       name: ids
       in: query
-      description: >
+      description: |-
         Array of Item ids to return. All other filter parameters that further
-        restrict the number of 
-
-        search results are ignored
+        restrict the number of search results are ignored
       required: false
       schema:
         $ref: '#/components/schemas/ids'
@@ -450,7 +443,7 @@ components:
         providers:
           $ref: '#/components/schemas/providers'
         summaries:
-          description: >-
+          description: |-
             Summaries are either a unique set of all available values *or*
             statistics. Statistics by default only specify the range (minimum
             and maximum values), but can optionally be accompanied by additional
@@ -471,7 +464,7 @@ components:
                   description: A value of any type.
               - type: object
                 title: Statistics
-                description: >-
+                description: |-
                   By default, only ranges with a minimum and a maximum value can
                   be specified. Ranges can be specified for ordinal values only,
                   which means they need to have a rank order. Therefore, ranges
@@ -968,17 +961,18 @@ components:
         merge:
           type: boolean
           default: false
-          description: >-
+          description: |-
             This is only valid when the server is responding to POST request.
 
             If merge is true, the client is expected to merge the body value
-            into the current request body before following the link. This avoids
-            passing large post bodies back and forth when following links,
-            particularly for navigating pages through the POST /search endpoint.
+            into the current request body before following the link.
+            This avoids passing large post bodies back and forth when following
+            links, particularly for navigating pages through the `POST /search`
+            endpoint.
 
             NOTE: To support form encoding it is expected that a client be able
-            to merge in the key value pairs specified as JSON `{"next":
-            "token"}` will become `&next=token`
+            to merge in the key value pairs specified as JSON
+            `{"next": "token"}` will become `&next=token`.
       title: Link
     multilinestringGeoJSON:
       type: object
@@ -1102,29 +1096,37 @@ components:
       example: '2017-08-17T08:05:32Z'
     description:
       type: string
-      description: >-
+      description: |-
         Detailed multi-line description to fully explain the catalog or
         collection.
-
 
         [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
         text representation.
     license:
       type: string
       description: >-
-        License(s) of the data as a SPDX [License
-        identifier](https://spdx.org/licenses/) or
+        License(s) of the data as a SPDX
+
+        [License identifier](https://spdx.org/licenses/) or
+
         [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60).
-        Alternatively, use `proprietary` if the license is not on the SPDX
-        license list or `various` if multiple licenses apply. In these two cases
-        links to the license texts SHOULD be added, see the `license` link
-        relation type.
+         Alternatively, use
+        `proprietary` if the license is not on the SPDX license list or
+
+        `various` if multiple licenses apply. In these two cases links to the
+
+        license texts SHOULD be added, see the `license` link relation type.
 
 
         Non-SPDX licenses SHOULD add a link to the license text with the
+
         `license` relation in the links section. The license text MUST NOT be
+
         provided as a value of this field. If there is no public license URL
-        available, it is RECOMMENDED to host the license text and link to it.
+
+        available, it is RECOMMENDED to host the license text and
+
+        link to it.
       example: Apache-2.0
     providers:
       type: array
@@ -1152,26 +1154,22 @@ components:
               CommonMark 0.29 syntax MAY be used for rich text representation.
             type: string
           roles:
-            description: >-
+            description: |-
               Roles of the provider.
-
 
               The provider's role(s) can be one or more of the following
               elements:
 
               * licensor: The organization that is licensing the dataset under
-              the license specified in the collection's license field.
-
+                the license specified in the collection's license field.
               * producer: The producer of the data is the provider that
-              initially captured and processed the source data, e.g. ESA for
-              Sentinel-2 data.
-
+                initially captured and processed the source data, e.g. ESA for
+                Sentinel-2 data.
               * processor: A processor is any provider who processed data to a
-              derived product.
-
+                derived product.
               * host: The host is the actual provider offering the data on their
-              storage. There should be no more than one host, specified as last
-              element of the list.
+                storage. There should be no more than one host, specified as last
+                element of the list.
             type: array
             items:
               type: string
@@ -1204,63 +1202,37 @@ components:
       maximum: 10000
       description: The maximum number of results to return (page size). Defaults to 10
     bbox:
-      description: >-
+      description: |-
         Only features that have a geometry that intersects the bounding box are
-
         selected. The bounding box is provided as four or six numbers,
-
         depending on whether the coordinate reference system includes a
-
         vertical axis (elevation or depth):
 
-
         * Lower left corner, coordinate axis 1
-
         * Lower left corner, coordinate axis 2  
-
         * Lower left corner, coordinate axis 3 (optional) 
-
         * Upper right corner, coordinate axis 1 
-
         * Upper right corner, coordinate axis 2 
-
         * Upper right corner, coordinate axis 3 (optional)
 
-
         The coordinate reference system of the values is WGS84
-
         longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
-
         a different coordinate reference system is specified in the parameter
-
         `bbox-crs`.
 
-
         For WGS84 longitude/latitude the values are in most cases the sequence
-
         of minimum longitude, minimum latitude, maximum longitude and maximum
-
         latitude. However, in cases where the box spans the antimeridian the
-
         first value (west-most box edge) is larger than the third value
-
         (east-most box edge).
 
-
         If a feature has multiple spatial geometry properties, it is the
-
         decision of the server whether only a single spatial geometry property
-
         is used to determine the extent or all relevant geometries.
 
-
         Example: The bounding box of the New Zealand Exclusive Economic Zone in
-        WGS 84
-
-        (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be represented
-        in JSON
-
-        as `[160.6, -55.95, -170, -25.89]` and in a query as
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
         `bbox=160.6,-55.95,-170,-25.89`.
       type: array
       minItems: 4
@@ -1280,18 +1252,16 @@ components:
           $ref: '#/components/schemas/bbox'
     collectionsArray:
       type: array
-      description: |
+      description: |-
         Array of Collection IDs to include in the search for items.
-        Only Items in one of the provided Collections will be searched
+        Only Items in one of the provided Collections will be searched.
       items:
         type: string
     ids:
       type: array
-      description: >
+      description: |-
         Array of Item ids to return. All other filter parameters that further
-        restrict the number of 
-
-        search results are ignored
+        restrict the number of search results are ignored
       items:
         type: string
     datetimeFilter:
@@ -1326,32 +1296,22 @@ components:
           $ref: '#/components/schemas/collectionsArray'
     datetime:
       type: string
-      description: >-
+      description: |-
         Either a date-time or an interval, open or closed. Date and time
-        expressions
-
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
-
+        expressions adhere to RFC 3339. Open intervals are expressed using
+        double-dots.
 
         Examples:
 
-
         * A date-time: "2018-02-12T23:20:50Z"
-
         * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-
         * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
 
-
         Only features that have a temporal property that intersects the value of
-
         `datetime` are selected.
 
-
         If a feature has multiple temporal properties, it is the decision of the
-
         server whether only a single temporal property is used to determine
-
         the extent or all relevant temporal properties.
       example: '2018-02-12T00:00:00Z/2018-03-18T12:31:12Z'
     stac_version:
@@ -1514,9 +1474,8 @@ components:
             example: Thumbnail
           description:
             type: string
-            description: >-
+            description: |-
               Multi-line description to explain the asset.
-
 
               [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
               rich text representation.
@@ -1557,24 +1516,16 @@ components:
             http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
   responses:
     LandingPage:
-      description: >-
+      description: |-
         The landing page provides links to the API definition
-
         (link relations `service-desc` and `service-doc`),
-
         the Conformance declaration (path `/conformance`,
-
         link relation `conformance`), and the Feature
-
         Collections (path `/collections`, link relation
-
         `data`).
 
-
-        A link to the search endpoint (path `/search`, link relation
-
-        `search`) is **required** to be specified if the API implements
-        `/search`
+        A link to the search endpoint (path `/search`, link relation `search`)
+        is **required** to be specified if the API implements `/search`.
       content:
         application/json:
           schema:

--- a/api-spec/STAC.yaml
+++ b/api-spec/STAC.yaml
@@ -404,14 +404,10 @@ components:
           type: string
           example: address
         description:
-          description: >-
-            Detailed multi-line description to fully explain the collection.
-
-
-            [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
-            rich text representation.
+          description: a description of the features in the collection
           type: string
           example: An address.
+          $ref: '#/components/schemas/description'
         links:
           type: array
           items:
@@ -1104,6 +1100,15 @@ components:
       type: string
       format: date-time
       example: '2017-08-17T08:05:32Z'
+    description:
+      type: string
+      description: >-
+        Detailed multi-line description to fully explain the catalog or
+        collection.
+
+
+        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
+        text representation.
     license:
       type: string
       description: >-

--- a/api-spec/extensions/sort/sort.fragment.yaml
+++ b/api-spec/extensions/sort/sort.fragment.yaml
@@ -9,9 +9,9 @@ components:
     sortby:
       name: sortby
       in: query
-      description: |
-        An array of property names, prefixed by either "+" for ascending or "-" for descending. If no prefix is
-        provided, "+" is assumed.
+      description: |-
+        An array of property names, prefixed by either "+" for ascending or
+        "-" for descending. If no prefix is provided, "+" is assumed.
       required: false
       schema:
         type: string

--- a/api-spec/extensions/version/version.fragment.yaml
+++ b/api-spec/extensions/version/version.fragment.yaml
@@ -57,6 +57,31 @@ paths:
         '200':
           $ref: '#/components/responses/Collections'
 components:
+  schemas:
+    catalogDefinition:
+      type: object
+      required:
+        - stac_version
+        - id
+        - description
+        - links
+      properties:
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        id:
+          description: identifier of the catalog used, for example, in URIs
+          type: string
+        title:
+          description: human readable title of the catalog
+          type: string
+        description:
+          $ref: '#/components/schemas/description'
+        links:
+          type: array
+          items:
+            $ref: "#/components/schemas/link"
   parameters:
     versionId:
       name: versionId

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -449,9 +449,7 @@ components:
       type: string
       description: |-
         License(s) of the data as a SPDX
-        [License identifier](https://spdx.org/licenses/) or
-        [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60).
-         Alternatively, use
+        [License identifier](https://spdx.org/licenses/). Alternatively, use
         `proprietary` if the license is not on the SPDX license list or
         `various` if multiple licenses apply. In these two cases links to the
         license texts SHOULD be added, see the `license` link relation type.

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -34,12 +34,12 @@ paths:
   /search:
     get:
       summary: Search STAC items with simple filtering.
-      description: >-
+      description: |-
         Retrieve Items matching filters. Intended as a shorthand API for simple
         queries.
         
-
-        This method is optional, but you MUST implement `POST /search` if you want to implement this method.
+        This method is optional, but you MUST implement `POST /search` if you
+        want to implement this method.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -72,12 +72,14 @@ paths:
                 type: string
     post:
       summary: Search STAC items with full-featured filtering.
-      description: >-
+      description: |-
         retrieve items matching filters. Intended as the standard, full-featured
         query API.
         
-        
-        This method is mandatory to implement if `GET /search` is implemented. If this endpoint is implemented on a server, it is required to add a link with `rel` set to `search` to the `links` array in `GET /` that refers to this endpoint.
+        This method is mandatory to implement if `GET /search` is implemented.
+        If this endpoint is implemented on a server, it is required to add a
+        link with `rel` set to `search` to the `links` array in `GET /` that
+        refers to this endpoint.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -111,9 +113,9 @@ components:
     ids:
       name: ids
       in: query
-      description: |
-        Array of Item ids to return. All other filter parameters that further restrict the number of 
-        search results are ignored
+      description: |-
+        Array of Item ids to return. All other filter parameters that further
+        restrict the number of search results are ignored
       required: false
       schema:
         $ref: '#/components/schemas/ids'
@@ -134,8 +136,9 @@ components:
       in: query
       description: |-
         Only features that have a geometry that intersects the bounding box are selected.
-        The bounding box is provided as four or six numbers, depending on whether the
-        coordinate reference system includes a vertical axis (height or depth):
+        The bounding box is provided as four or six numbers, depending on
+        whether the coordinate reference system includes a vertical axis (height
+        or depth):
 
         * Lower left corner, coordinate axis 1
         * Lower left corner, coordinate axis 2
@@ -144,25 +147,28 @@ components:
         * Upper right corner, coordinate axis 2
         * Maximum value, coordinate axis 3 (optional)
 
-        The coordinate reference system of the values is WGS 84 longitude/latitude
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate
-        reference system is specified in the parameter `bbox-crs`.
+        The coordinate reference system of the values is WGS 84
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
+        a different coordinate reference system is specified in the parameter
+        `bbox-crs`.
 
-        For WGS 84 longitude/latitude the values are in most cases the sequence of
-        minimum longitude, minimum latitude, maximum longitude and maximum latitude.
-        However, in cases where the box spans the antimeridian the first value
-        (west-most box edge) is larger than the third value (east-most box edge).
+        For WGS 84 longitude/latitude the values are in most cases the sequence
+        of minimum longitude, minimum latitude, maximum longitude and maximum
+        latitude. However, in cases where the box spans the antimeridian the
+        first value (west-most box edge) is larger than the third value
+        (east-most box edge).
 
         If the vertical axis is included, the third and the sixth number are
         the bottom and the top of the 3-dimensional bounding box.
 
-        If a feature has multiple spatial geometry properties, it is the decision of the
-        server whether only a single spatial geometry property is used to determine
-        the extent or all relevant geometries.
+        If a feature has multiple spatial geometry properties, it is the
+        decision of the server whether only a single spatial geometry property
+        is used to determine the extent or all relevant geometries.
 
-        Example: The bounding box of the New Zealand Exclusive Economic Zone in WGS 84
-        (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be represented in JSON
-        as `[160.6, -55.95, -170, -25.89]` and in a query as `bbox=160.6,-55.95,-170,-25.89`.
+        Example: The bounding box of the New Zealand Exclusive Economic Zone in
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+        `bbox=160.6,-55.95,-170,-25.89`.
       required: false
       schema:
         type: array
@@ -183,8 +189,8 @@ components:
         Collections (path `/collections`, link relation
         `data`).
 
-        A link to the search endpoint (path `/search`, link relation
-        `search`) is **required** to be specified if the API implements `/search`
+        A link to the search endpoint (path `/search`, link relation `search`)
+        is **required** to be specified if the API implements `/search`.
       content:
         application/json:
           example:
@@ -206,9 +212,9 @@ components:
   schemas:
     description:
       type: string
-      description: >-
-        Detailed multi-line description to fully explain the catalog or collection.
-
+      description: |-
+        Detailed multi-line description to fully explain the catalog or
+        collection.
 
         [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
         text representation.
@@ -237,8 +243,18 @@ components:
         providers:
           $ref: '#/components/schemas/providers'
         summaries:
-          description: >-
-            Summaries are either a unique set of all available values *or* statistics. Statistics by default only specify the range (minimum and maximum values), but can optionally be accompanied by additional statistical values. The range can specify the potential range of values, but it is recommended to be as precise as possible. The set of values must contain at least one element and it is strongly recommended to list all values. It is recommended to list as many properties as reasonable so that consumers get a full overview of the Collection. Properties that are covered by the Collection specification (e.g. `providers` and `license`) may not be repeated in the summaries.
+          description: |-
+            Summaries are either a unique set of all available values *or*
+            statistics. Statistics by default only specify the range (minimum
+            and maximum values), but can optionally be accompanied by additional
+            statistical values. The range can specify the potential range of
+            values, but it is recommended to be as precise as possible. The set
+            of values must contain at least one element and it is strongly
+            recommended to list all values. It is recommended to list as many
+            properties as reasonable so that consumers get a full overview of
+            the Collection. Properties that are covered by the Collection
+            specification (e.g. `providers` and `license`) may not be repeated
+            in the summaries.
           type: object
           additionalProperties:
             oneOf:
@@ -248,8 +264,14 @@ components:
                   description: A value of any type.
               - type: object
                 title: Statistics
-                description: >-
-                  By default, only ranges with a minimum and a maximum value can be specified. Ranges can be specified for ordinal values only, which means they need to have a rank order. Therefore, ranges can only be specified for numbers and some special types of strings. Examples: grades (A to F), dates or times. Implementors are free to add other derived statistical values to the object, for example `mean` or `stddev`.
+                description: |-
+                  By default, only ranges with a minimum and a maximum value can
+                  be specified. Ranges can be specified for ordinal values only,
+                  which means they need to have a rank order. Therefore, ranges
+                  can only be specified for numbers and some special types of
+                  strings. Examples: grades (A to F), dates or times.
+                  Implementors are free to add other derived statistical values
+                  to the object, for example `mean` or `stddev`.
                 required:
                   - min
                   - max
@@ -411,19 +433,28 @@ components:
         merge:
           type: boolean
           default: false
-          description: >-
+          description: |-
             This is only valid when the server is responding to POST request.
 
-            If merge is true, the client is expected to merge the body value into the current request body before following the link.
-            This avoids passing large post bodies back and forth when following links, particularly for navigating pages through the POST /search endpoint.
+            If merge is true, the client is expected to merge the body value
+            into the current request body before following the link.
+            This avoids passing large post bodies back and forth when following
+            links, particularly for navigating pages through the `POST /search`
+            endpoint.
 
-            NOTE: To support form encoding it is expected that a client be able to merge in the key value pairs specified as JSON
-            `{"next": "token"}` will become `&next=token`
+            NOTE: To support form encoding it is expected that a client be able
+            to merge in the key value pairs specified as JSON
+            `{"next": "token"}` will become `&next=token`.
     license:
       type: string
-      description: >-
-        License(s) of the data as a SPDX [License identifier](https://spdx.org/licenses/) or [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60). Alternatively, use `proprietary` if the license is not on the SPDX license list or `various` if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the `license` link relation type.
-        
+      description: |-
+        License(s) of the data as a SPDX
+        [License identifier](https://spdx.org/licenses/) or
+        [expression](https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60).
+         Alternatively, use
+        `proprietary` if the license is not on the SPDX license list or
+        `various` if multiple licenses apply. In these two cases links to the
+        license texts SHOULD be added, see the `license` link relation type.
         
         Non-SPDX licenses SHOULD add a link to the license text with the
         `license` relation in the links section. The license text MUST NOT be
@@ -457,26 +488,22 @@ components:
               CommonMark 0.29 syntax MAY be used for rich text representation.
             type: string
           roles:
-            description: >-
+            description: |-
               Roles of the provider.
-
 
               The provider's role(s) can be one or more of the following
               elements:
 
               * licensor: The organization that is licensing the dataset under
-              the license specified in the collection's license field.
-
+                the license specified in the collection's license field.
               * producer: The producer of the data is the provider that
-              initially captured and processed the source data, e.g. ESA for
-              Sentinel-2 data.
-
+                initially captured and processed the source data, e.g. ESA for
+                Sentinel-2 data.
               * processor: A processor is any provider who processed data to a
-              derived product.
-
+                derived product.
               * host: The host is the actual provider offering the data on their
-              storage. There should be no more than one host, specified as last
-              element of the list.
+                storage. There should be no more than one host, specified as last
+                element of the list.
             type: array
             items:
               type: string
@@ -541,9 +568,10 @@ components:
         decision of the server whether only a single spatial geometry property
         is used to determine the extent or all relevant geometries.
 
-        Example: The bounding box of the New Zealand Exclusive Economic Zone in WGS 84
-        (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be represented in JSON
-        as `[160.6, -55.95, -170, -25.89]` and in a query as `bbox=160.6,-55.95,-170,-25.89`.
+        Example: The bounding box of the New Zealand Exclusive Economic Zone in
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+        `bbox=160.6,-55.95,-170,-25.89`.
       type: array
       minItems: 4
       maxItems: 6
@@ -562,16 +590,16 @@ components:
           $ref: '#/components/schemas/bbox'
     collectionsArray:
       type: array
-      description: |
+      description: |-
         Array of Collection IDs to include in the search for items.
-        Only Items in one of the provided Collections will be searched
+        Only Items in one of the provided Collections will be searched.
       items:
         type: string
     ids:
       type: array
-      description: |
-        Array of Item ids to return. All other filter parameters that further restrict the number of 
-        search results are ignored
+      description: |-
+        Array of Item ids to return. All other filter parameters that further
+        restrict the number of search results are ignored
       items:
         type: string
     datetimeFilter:
@@ -608,8 +636,9 @@ components:
     datetime:
       type: string
       description: |-
-        Either a date-time or an interval, open or closed. Date and time expressions
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
+        Either a date-time or an interval, open or closed. Date and time
+        expressions adhere to RFC 3339. Open intervals are expressed using
+        double-dots.
 
         Examples:
 
@@ -792,12 +821,11 @@ components:
             example: Thumbnail
           description:
             type: string
-            description: >-
+            description: |-
               Multi-line description to explain the asset.
-      
-      
-              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
-              text representation.
+
+              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
+              rich text representation.
             example: Small 256x256px PNG thumbnail for a preview.
           type:
             type: string

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -40,6 +40,11 @@ paths:
         
         This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
+
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` to the
+        `links` array in `GET /`. As `GET` is the default method, the `method`
+        may not be set explicitly in the link.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -78,8 +83,8 @@ paths:
         
         This method is mandatory to implement if `GET /search` is implemented.
         If this endpoint is implemented on a server, it is required to add a
-        link with `rel` set to `search` to the `links` array in `GET /` that
-        refers to this endpoint.
+        link referring to this endpoint with `rel` set to `search` and `method`
+        set to `POST` to the `links` array in `GET /`.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -189,8 +194,9 @@ components:
         Collections (path `/collections`, link relation
         `data`).
 
-        A link to the search endpoint (path `/search`, link relation `search`)
-        is **required** to be specified if the API implements `/search`.
+        Links to the search endpoints (path `/search`, link relation `search`,
+        method `GET` or `POST`) are **required** to be specified if the API
+        implements `/search` for any of the specified HTTP methods.
       content:
         application/json:
           example:

--- a/api-spec/openapi/STAC.yaml
+++ b/api-spec/openapi/STAC.yaml
@@ -204,6 +204,14 @@ components:
           schema:
             $ref: '#/components/schemas/item'
   schemas:
+    description:
+      type: string
+      description: >-
+        Detailed multi-line description to fully explain the catalog or collection.
+
+
+        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
+        text representation.
     # This schema extends OAFeat.yaml#/components/schemas/collection to add and require additional fields and add an example.
     collection:
       type: object
@@ -218,12 +226,7 @@ components:
         stac_extensions:
           $ref: '#/components/schemas/stac_extensions'
         description:
-          description: >-
-            Detailed multi-line description to fully explain the collection.
-    
-    
-            [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
-            text representation.
+          $ref: '#/components/schemas/description'
         keywords:
           type: array
           description: List of keywords describing the collection.


### PR DESCRIPTION
**Related Issue(s):** Fixed #730 and #726, also related to #724


**Proposed Changes:**

1. The STAC-extensions.yaml was broken as the Version extension referred to a non-existing schema. Fixed in commit https://github.com/radiantearth/stac-spec/commit/f9bf4b82107949005801e706b970dc2cccb3f72a.
2. License Expressions were removed in the last release, but were still mentioned in the API. Removed with commit https://github.com/radiantearth/stac-spec/commit/de3f49f2c122ac1b6b0f5394d8b262fd3a12ac2e
3. There was a white-space issue as discussed in PR #728. I figured out it is because some lines in the YAML files are longer than 80 chars and the YAML merge tool doesn't like that as it tries to wrap things at 80 lines. So I fixed it by fixing the line lengths. That looks a bit weird in diff, but there's no functional change in commit https://github.com/radiantearth/stac-spec/commit/b1e7e135133a2055951c3a9ec12618a336098476 except that texts are now easier to read in YAML and the rendered versions.
4. Somewhat related to #724 and improves the situation mentioned in #726: I clarified how `/search` links must be added to `/` and added that links to both GET and POST must be provided now that the method can be specified in links. Commit: https://github.com/radiantearth/stac-spec/commit/d8b03af5b2c395bd4aa0ea843a3752c8dbffcd67

As this PR tackles multiple things, including a lot of changes regarding white-spaces, I provided the links to the individual commits so that it is easier to review individually compared to reviewing as a whole.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).