### PR TITLE
Fixed links in the Landsat example in the collection-spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Fixed links in the Landsat example in the collection-spec.
+
 ## [v0.9.0-rc2] - 2020-02-12
 
 ### Added

--- a/collection-spec/examples/landsat-collection.json
+++ b/collection-spec/examples/landsat-collection.json
@@ -138,19 +138,19 @@
     "links": [
       {
         "rel": "self",
-        "href": "https://example.com/stac/collections/landsat-8-l1"
+        "href": "https://example.com/stac-api/collections/landsat-8-l1"
       },
       {
         "rel": "parent",
-        "href": "https://example.com/stac"
+        "href": "https://example.com/stac-api"
       },
       {
         "rel": "root",
-        "href": "https://example.com/stac"
+        "href": "https://example.com/stac-api"
       },
       {
         "rel": "child",
-        "href": "https://example.com/stac/collections/landsat-8-l1/items"
+        "href": "https://example.com/stac-api/browse/landsat-8-l1/landsat-item.json"
       }
     ]
   }

--- a/collection-spec/examples/landsat-item.json
+++ b/collection-spec/examples/landsat-item.json
@@ -167,15 +167,19 @@
     "links": [
         {
             "rel": "self",
-            "href": "https://<endpoint>/search?id=LC08_L1TP_107018_20181001_20181001_01_RT"
+            "href": "https://example.com/stac-api/browse/landsat-8-l1/landsat-item.json"
         },
         {
             "rel": "parent",
-            "href": "https://<endpoint>/stac/collections/landsat-8-l1"
+            "href": "https://example.com/stac-api/collections/landsat-8-l1"
         },
         {
             "rel": "root",
-            "href": "https://<endpoint>/stac"
+            "href": "https://example.com/stac-api"
+        },
+        {
+            "rel": "collection",
+            "href": "https://example.com/stac-api/collections/landsat-8-l1"
         }
     ]
 }


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. The links in the landsat example were too API centric and linked with wrong rel types to an endpoint that contains data not part of the core spec. (.../items). See related Gitter conversations starting from Feb. 19 15:41 by @ycespb, @joshfix, @cholmes and me.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).