### PR TITLE
Remove api building requirement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,3 @@
 
 - [ ] This PR has **no** breaking changes.
 - [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
-- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,4 @@
 
 - [ ] This PR has **no** breaking changes.
 - [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
-- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to 
-track the change.
+- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,5 @@
 
 - [ ] This PR has **no** breaking changes.
 - [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
+- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to 
+track the change.


### PR DESCRIPTION
**Related Issue(s):** #749


**Proposed Changes:**

1. Removes the requirement to run the api script, since we moved the api stuff out.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
