### PR TITLE
Changed created to published

### DIFF
--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -142,5 +142,5 @@ Fields to describe the metadata file itself. These fields do NOT describe the as
 
 | Field Name | Type   | Description |
 | ---------- | ------ | ----------- |
-published    | string | Date and time the metadata file was first published. This is NOT the timestamp the asset was created. MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
+| published  | string | Date and time the metadata file was first published. This is NOT the timestamp the asset was created. MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | updated    | string | Date and time the metadata file was updated last. This is NOT the timestamp the asset was updated last. MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -142,5 +142,5 @@ Fields to describe the metadata file itself. These fields do NOT describe the as
 
 | Field Name | Type   | Description |
 | ---------- | ------ | ----------- |
-| created    | string | Creation date and time of the metadata file. This is NOT the timestamp the asset was created. MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
+published    | string | Date and time the metadata file was first published. This is NOT the timestamp the asset was created. MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | updated    | string | Date and time the metadata file was updated last. This is NOT the timestamp the asset was updated last. MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |

--- a/item-spec/examples/sample-full.json
+++ b/item-spec/examples/sample-full.json
@@ -34,7 +34,7 @@
         "url": "https://cool-sat.com/"
       }
     ],
-    "created": "2016-05-04T00:00:01Z",
+    "published": "2016-05-04T00:00:01Z",
     "updated": "2017-01-01T00:30:55Z",
     "view:sun_azimuth": 168.7,
     "eo:cloud_cover": 0.12,

--- a/item-spec/json-schema/metadata.json
+++ b/item-spec/json-schema/metadata.json
@@ -4,8 +4,8 @@
   "title": "Metadata Fields",
   "type": "object",
   "properties": {
-    "created": {
-      "title": "Metadata Creation",
+    "published": {
+      "title": "Metadata Published",
       "type": "string",
       "format": "date-time"
     },


### PR DESCRIPTION
**Related Issue(s):** #693 


**Proposed Changes:**

1. Change 'created' to 'published', as it feels clearer. The 'creation' of the metadata file makes me think about when the file was created, and what creation of metadata even means - is it when the image arrives in the system? Published to me makes it clear that it's when the record first appears in the catalog.


**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).