### PR TITLE
Added reminder for basing PR's against dev

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 
 **PR Checklist:**
 
+- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
 - [ ] This PR has **no** breaking changes.
 - [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
 - [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.


### PR DESCRIPTION
**Related Issue(s):** #768


**Proposed Changes:**

1. Added a reminder to the PR checklist to help remind people they should base their PR's against dev.


**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).