### PR TITLE
Fix asset extension example

### DIFF
--- a/extensions/asset/examples/example-landsat8.json
+++ b/extensions/asset/examples/example-landsat8.json
@@ -240,7 +240,7 @@
       ],
       "title": "LWIR Band (B11)",
       "description": "Long-wave IR Band at 12um (B11) Top Of the Atmosphere"
-    },
-    "links": []
-  }
+    }
+  },
+  "links": []
 }


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. Fixes the asset extension example. The link was part of the assets and not on the top level.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-spec/blob/dev/api-spec/README.md#openapi-definitions).