### PR TITLE
Update proj extension to include grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `proj:shape` and `proj:transform` to the projections extension.
+
 ### Changed
 
 ### Removed

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -74,7 +74,13 @@ defined in latitude and longitude, even if the data coordinate system does not u
 The number of pixels should be specified in Y, X order. If the shape is defined in an item's properties it is used as 
 the default shape for all assets that don't have an overriding shape.
 
-**proj:transform** - An array of affine transformation coefficients that are compatible with Rasterio as defined in the GDAL [`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd) or the Rasterio [`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform). If the transform is defined in an item's properties it is used as the default transform for all assets that don't have an overriding shape.
+**proj: transform** - Linear mapping from pixel coordinate space (Pixel, Line) to projection coordinate space (Xp, Yp). It is a `3x3` matrix stored as a flat array of 9 elements in row major order. Since the last row is always `0,0,1` it can be omitted, in which case only 6 elements are recorded. This mapping can be obtained from GDAL([`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd)) or the Rasterio ([`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform)).
+```
+  [Xp]   [a0, a1, a2]   [Pixel]
+  [Yp] = [a3, a4, a5] * [Line ]
+  [1 ]   [0 ,  0,  1]   [1    ]
+```
+If the transform is defined in an item's properties it is used as the default transform for all assets that don't have an overriding shape. 
 
 ### Item [`Asset Object`](../../item-spec/item-spec.md#asset-object) fields
 | Field Name | Type     | Description                                  |

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -11,11 +11,13 @@ for "projection", and not a reference to the use of the PROJ/PROJ4 formats.
 
 The field names defined herein should be added as fields in the Item Properties object. 
 
-When specified on an Item, the values are assumed to apply to all Assets in that Item.  For example, an Item may have 
+When specified on an Item, the values are assumed to apply to all Assets in that Item. For example, an Item may have 
 several related Assets each representing a band or layer for the Item, and which typically all use the same CRS, 
-e.g. a UTM Zone.  However, there may also be assets intended for display, like a preview image or thumbnail, that have 
-been reprojected to a different CRS, e.g., Web Mercator, to better accommodate that use case.  This case of differing 
-projections per Asset is not currently handled by this extension.
+e.g. a UTM Zone. However, there may also be assets intended for display, like a preview image or thumbnail, that have 
+been reprojected to a different CRS, e.g., Web Mercator, to better accommodate that use case. This case of differing 
+projections per Asset is not currently handled by this extension. The exception to this is that `proj:shape` and 
+`proj:transform` can be overridden at the asset level, where an asset has a different shape and transform from the
+default, which should be specified at the asset level, while those assets that use the defaults can remain unspecified.
 
 ## Examples
 - [Example Landsat8](examples/example-landsat8.json)
@@ -33,6 +35,8 @@ projections per Asset is not currently handled by this extension.
 | proj:geometry    | [Polygon Object](https://geojson.org/schema/Polygon.json)  | Defines the footprint of this Item. |
 | proj:bbox        | \[number]       | Bounding box of the Item in the asset CRS in 2 or 3 dimensions. |
 | proj:centroid    | Centroid Object | Coordinates representing the centroid of the Item in the asset CRS |
+| proj:shape       | [number]        | Number of pixels in x and y directions for the default grid |
+| proj:transform   | [number]        | The affine transformation coefficients for the default grid  |
 
 **proj:epsg** - A Coordinate Reference System (CRS) is the data reference system (sometimes called a
 'projection') used by the asset data, and can usually be referenced using an [EPSG code](http://epsg.io).
@@ -65,6 +69,19 @@ of the lower left corner, followed by coordinates of upper right corner, , e.g.,
 
 **proj:centroid** - Coordinates representing the centroid of the item in the asset data CRS.  Coordinates are 
 defined in latitude and longitude, even if the data coordinate system does not use lat/long.
+
+**proj:shape** - An array of integers that represents the number of pixels in the most common grid used by the item's assets.
+The number of pixels should be specified in X and Y order. If the shape is defined in an item's properties it is used as 
+the default shape for all assets that don't have an overriding shape.
+
+**proj:transform** - An array of affine transformation coefficientsas defined in the GDAL [`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd) or the Rasterio [`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform). If the transform is defined in an item's properties it is used as the default transform for all 
+assets that don't have an overriding shape.
+
+### Item [`Asset Object`](../../item-spec/item-spec.md#asset-object) fields
+| Field Name | Type     | Description                                  |
+| ---------- | -------- | -------------------------------------------- |
+| proj:shape    | [number] | See item description.  |
+| proj:transorm | [number] | See item description.  |
 
 ## Centroid Object
 

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -37,7 +37,7 @@ default, which should be specified at the asset level, while those assets that u
 | proj:geometry    | [Polygon Object](https://geojson.org/schema/Polygon.json)  | Defines the footprint of this Item. |
 | proj:bbox        | \[number]       | Bounding box of the Item in the asset CRS in 2 or 3 dimensions. |
 | proj:centroid    | Centroid Object | Coordinates representing the centroid of the Item in the asset CRS |
-| proj:shape       | \[number]       | Number of pixels in Y and X directions for the default grid |
+| proj:shape       | \[integer]       | Number of pixels in Y and X directions for the default grid |
 | proj:transform   | \[number]       | The affine transformation coefficients for the default grid  |
 
 **proj:epsg** - A Coordinate Reference System (CRS) is the data reference system (sometimes called a
@@ -90,7 +90,7 @@ If the transform is defined in an item's properties it is used as the default tr
 
 | Field Name | Type     | Description                                  |
 | ---------- | -------- | -------------------------------------------- |
-| proj:shape    | \[number] | See item description.  |
+| proj:shape    | \[integer] | See item description.  |
 | proj:transorm | \[number] | See item description.  |
 
 ## Centroid Object

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -71,7 +71,7 @@ of the lower left corner, followed by coordinates of upper right corner, , e.g.,
 defined in latitude and longitude, even if the data coordinate system does not use lat/long.
 
 **proj:shape** - An array of integers that represents the number of pixels in the most common grid used by the item's assets.
-The number of pixels should be specified in X and Y order. If the shape is defined in an item's properties it is used as 
+The number of pixels should be specified in Y, X order. If the shape is defined in an item's properties it is used as 
 the default shape for all assets that don't have an overriding shape.
 
 **proj:transform** - An array of affine transformation coefficientsas defined in the GDAL [`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd) or the Rasterio [`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform). If the transform is defined in an item's properties it is used as the default transform for all 

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -74,8 +74,7 @@ defined in latitude and longitude, even if the data coordinate system does not u
 The number of pixels should be specified in Y, X order. If the shape is defined in an item's properties it is used as 
 the default shape for all assets that don't have an overriding shape.
 
-**proj:transform** - An array of affine transformation coefficientsas defined in the GDAL [`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd) or the Rasterio [`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform). If the transform is defined in an item's properties it is used as the default transform for all 
-assets that don't have an overriding shape.
+**proj:transform** - An array of affine transformation coefficients that are compatible with Rasterio as defined in the GDAL [`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd) or the Rasterio [`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform). If the transform is defined in an item's properties it is used as the default transform for all assets that don't have an overriding shape.
 
 ### Item [`Asset Object`](../../item-spec/item-spec.md#asset-object) fields
 | Field Name | Type     | Description                                  |

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -31,14 +31,14 @@ default, which should be specified at the asset level, while those assets that u
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer \|null   | **Required** [EPSG code](http://www.epsg-registry.org/) of the datasource |
+| proj:epsg        | integer \|null  | **Required** [EPSG code](http://www.epsg-registry.org/) of the datasource |
 | proj:wkt2        | string \|null   | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/usage/projjson.html) \|null   | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [Polygon Object](https://geojson.org/schema/Polygon.json)  | Defines the footprint of this Item. |
 | proj:bbox        | \[number]       | Bounding box of the Item in the asset CRS in 2 or 3 dimensions. |
 | proj:centroid    | Centroid Object | Coordinates representing the centroid of the Item in the asset CRS |
-| proj:shape       | \[number]        | Number of pixels in Y and X directions for the default grid |
-| proj:transform   | \[number]        | The affine transformation coefficients for the default grid  |
+| proj:shape       | \[number]       | Number of pixels in Y and X directions for the default grid |
+| proj:transform   | \[number]       | The affine transformation coefficients for the default grid  |
 
 **proj:epsg** - A Coordinate Reference System (CRS) is the data reference system (sometimes called a
 'projection') used by the asset data, and can usually be referenced using an [EPSG code](http://epsg.io).
@@ -90,8 +90,8 @@ If the transform is defined in an item's properties it is used as the default tr
 
 | Field Name | Type     | Description                                  |
 | ---------- | -------- | -------------------------------------------- |
-| proj:shape    | [number] | See item description.  |
-| proj:transorm | [number] | See item description.  |
+| proj:shape    | \[number] | See item description.  |
+| proj:transorm | \[number] | See item description.  |
 
 ## Centroid Object
 

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -76,7 +76,7 @@ defined in latitude and longitude, even if the data coordinate system does not u
 The number of pixels should be specified in Y, X order. If the shape is defined in an item's properties it is used as
 the default shape for all assets that don't have an overriding shape.
 
-**proj: transform** - Linear mapping from pixel coordinate space (Pixel, Line) to projection coordinate space (Xp, Yp). It is a `3x3` matrix stored as a flat array of 9 elements in row major order. Since the last row is always `0,0,1` it can be omitted, in which case only 6 elements are recorded. This mapping can be obtained from GDAL([`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd)) or the Rasterio ([`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform)).
+**proj:transform** - Linear mapping from pixel coordinate space (Pixel, Line) to projection coordinate space (Xp, Yp). It is a `3x3` matrix stored as a flat array of 9 elements in row major order. Since the last row is always `0,0,1` it can be omitted, in which case only 6 elements are recorded. This mapping can be obtained from GDAL([`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd)) or the Rasterio ([`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform)).
 
 ``` bash
   [Xp]   [a0, a1, a2]   [Pixel]

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -9,20 +9,22 @@
 This document explains the fields of the STAC Projection (`proj`) Extension to a STAC Item. Here `proj` is short
 for "projection", and not a reference to the use of the PROJ/PROJ4 formats.
 
-The field names defined herein should be added as fields in the Item Properties object. 
+The field names defined herein should be added as fields in the Item Properties object.
 
-When specified on an Item, the values are assumed to apply to all Assets in that Item. For example, an Item may have 
-several related Assets each representing a band or layer for the Item, and which typically all use the same CRS, 
-e.g. a UTM Zone. However, there may also be assets intended for display, like a preview image or thumbnail, that have 
-been reprojected to a different CRS, e.g., Web Mercator, to better accommodate that use case. This case of differing 
-projections per Asset is not currently handled by this extension. The exception to this is that `proj:shape` and 
+When specified on an Item, the values are assumed to apply to all Assets in that Item. For example, an Item may have
+several related Assets each representing a band or layer for the Item, and which typically all use the same CRS,
+e.g. a UTM Zone. However, there may also be assets intended for display, like a preview image or thumbnail, that have
+been reprojected to a different CRS, e.g., Web Mercator, to better accommodate that use case. This case of differing
+projections per Asset is not currently handled by this extension. The exception to this is that `proj:shape` and
 `proj:transform` can be overridden at the asset level, where an asset has a different shape and transform from the
 default, which should be specified at the asset level, while those assets that use the defaults can remain unspecified.
 
 ## Examples
+
 - [Example Landsat8](examples/example-landsat8.json)
 
 ## Schema
+
 - [JSON Schema](json-schema/schema.json)
 
 ## Item Properties fields
@@ -56,33 +58,36 @@ If the data does not have a CRS, such as in the case of non-rectified imagery wi
 Points, proj:projjson should be set to null. It should also be set to null if a CRS exists, but for which
 a PROJJSON string does not exist. The schema for this object can be found [here](https://proj.org/schemas/v0.1/projjson.schema.json).
 
-**proj:geometry** - A Polygon object representing the footprint of this item, formatted according the Polygon 
-object format specified in [RFC 7946, sections 3.1.6](https://tools.ietf.org/html/rfc7946), except not necessarily 
-in EPSG:4326 as required by RFC7946.  Specified based on the `proj:epsg`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326). 
-Ideally, this will be represented by a Polygon with five coordinates, as the item in the asset data CRS should be 
-a square aligned to the original CRS grid. 
+**proj:geometry** - A Polygon object representing the footprint of this item, formatted according the Polygon
+object format specified in [RFC 7946, sections 3.1.6](https://tools.ietf.org/html/rfc7946), except not necessarily
+in EPSG:4326 as required by RFC7946.  Specified based on the `proj:epsg`, `proj:projjson` or `proj:wkt2` fields (not necessarily EPSG:4326).
+Ideally, this will be represented by a Polygon with five coordinates, as the item in the asset data CRS should be
+a square aligned to the original CRS grid.
 
-**proj:bbox** - Bounding box of the assets represented by this item in the asset data CRS. Specified as 4 or 6 
-coordinates based on the CRS defined in the `proj:epsg`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates 
-of the lower left corner, followed by coordinates of upper right corner, , e.g., \[west, south, east, north], 
+**proj:bbox** - Bounding box of the assets represented by this item in the asset data CRS. Specified as 4 or 6
+coordinates based on the CRS defined in the `proj:epsg`, `proj:projjson` or `proj:wkt2` fields.  First two numbers are coordinates
+of the lower left corner, followed by coordinates of upper right corner, , e.g., \[west, south, east, north],
 \[xmin, ymin, xmax, ymax], \[left, down, right, up], or \[west, south, lowest, east, north, highest]. The length of the array must be 2*n where n is the number of dimensions. The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most extent is the minimum elevation in meters and the elevation of the northeasterly most extent is the maximum in meters.
 
-**proj:centroid** - Coordinates representing the centroid of the item in the asset data CRS.  Coordinates are 
+**proj:centroid** - Coordinates representing the centroid of the item in the asset data CRS.  Coordinates are
 defined in latitude and longitude, even if the data coordinate system does not use lat/long.
 
 **proj:shape** - An array of integers that represents the number of pixels in the most common pixel grid used by the item's assets.
-The number of pixels should be specified in Y, X order. If the shape is defined in an item's properties it is used as 
+The number of pixels should be specified in Y, X order. If the shape is defined in an item's properties it is used as
 the default shape for all assets that don't have an overriding shape.
 
 **proj: transform** - Linear mapping from pixel coordinate space (Pixel, Line) to projection coordinate space (Xp, Yp). It is a `3x3` matrix stored as a flat array of 9 elements in row major order. Since the last row is always `0,0,1` it can be omitted, in which case only 6 elements are recorded. This mapping can be obtained from GDAL([`GetGeoTransform`](https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd)) or the Rasterio ([`Transform`](https://rasterio.readthedocs.io/en/stable/api/rasterio.io.html#rasterio.io.BufferedDatasetWriter.transform)).
-```
+
+``` bash
   [Xp]   [a0, a1, a2]   [Pixel]
   [Yp] = [a3, a4, a5] * [Line ]
   [1 ]   [0 ,  0,  1]   [1    ]
 ```
-If the transform is defined in an item's properties it is used as the default transform for all assets that don't have an overriding shape. 
+
+If the transform is defined in an item's properties it is used as the default transform for all assets that don't have an overriding transform.
 
 ### Item [`Asset Object`](../../item-spec/item-spec.md#asset-object) fields
+
 | Field Name | Type     | Description                                  |
 | ---------- | -------- | -------------------------------------------- |
 | proj:shape    | [number] | See item description.  |

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -86,13 +86,6 @@ the default shape for all assets that don't have an overriding shape.
 
 If the transform is defined in an item's properties it is used as the default transform for all assets that don't have an overriding transform.
 
-### Item [`Asset Object`](../../item-spec/item-spec.md#asset-object) fields
-
-| Field Name | Type     | Description                                  |
-| ---------- | -------- | -------------------------------------------- |
-| proj:shape    | \[integer] | See item description.  |
-| proj:transorm | \[number] | See item description.  |
-
 ## Centroid Object
 
 This object represents the centroid of an item's geometry.

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -31,14 +31,14 @@ default, which should be specified at the asset level, while those assets that u
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |
-| proj:epsg        | integer\|null   | **Required** [EPSG code](http://www.epsg-registry.org/) of the datasource |
+| proj:epsg        | integer \|null   | **Required** [EPSG code](http://www.epsg-registry.org/) of the datasource |
 | proj:wkt2        | string \|null   | [WKT2](http://docs.opengeospatial.org/is/12-063r5/12-063r5.html) string representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:projjson    | [PROJJSON Object](https://proj.org/usage/projjson.html) \|null   | PROJJSON object representing the Coordinate Reference System (CRS) that the `proj:geometry` and `proj:bbox` fields represent |
 | proj:geometry    | [Polygon Object](https://geojson.org/schema/Polygon.json)  | Defines the footprint of this Item. |
 | proj:bbox        | \[number]       | Bounding box of the Item in the asset CRS in 2 or 3 dimensions. |
 | proj:centroid    | Centroid Object | Coordinates representing the centroid of the Item in the asset CRS |
-| proj:shape       | [number]        | Number of pixels in Y and X directions for the default grid |
-| proj:transform   | [number]        | The affine transformation coefficients for the default grid  |
+| proj:shape       | \[number]        | Number of pixels in Y and X directions for the default grid |
+| proj:transform   | \[number]        | The affine transformation coefficients for the default grid  |
 
 **proj:epsg** - A Coordinate Reference System (CRS) is the data reference system (sometimes called a
 'projection') used by the asset data, and can usually be referenced using an [EPSG code](http://epsg.io).

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -35,7 +35,7 @@ default, which should be specified at the asset level, while those assets that u
 | proj:geometry    | [Polygon Object](https://geojson.org/schema/Polygon.json)  | Defines the footprint of this Item. |
 | proj:bbox        | \[number]       | Bounding box of the Item in the asset CRS in 2 or 3 dimensions. |
 | proj:centroid    | Centroid Object | Coordinates representing the centroid of the Item in the asset CRS |
-| proj:shape       | [number]        | Number of pixels in x and y directions for the default grid |
+| proj:shape       | [number]        | Number of pixels in Y and X directions for the default grid |
 | proj:transform   | [number]        | The affine transformation coefficients for the default grid  |
 
 **proj:epsg** - A Coordinate Reference System (CRS) is the data reference system (sometimes called a
@@ -70,7 +70,7 @@ of the lower left corner, followed by coordinates of upper right corner, , e.g.,
 **proj:centroid** - Coordinates representing the centroid of the item in the asset data CRS.  Coordinates are 
 defined in latitude and longitude, even if the data coordinate system does not use lat/long.
 
-**proj:shape** - An array of integers that represents the number of pixels in the most common grid used by the item's assets.
+**proj:shape** - An array of integers that represents the number of pixels in the most common pixel grid used by the item's assets.
 The number of pixels should be specified in Y, X order. If the shape is defined in an item's properties it is used as 
 the default shape for all assets that don't have an overriding shape.
 

--- a/extensions/projection/examples/example-landsat8.json
+++ b/extensions/projection/examples/example-landsat8.json
@@ -48,6 +48,16 @@
         0
       ],
       "title": "Band 1 (coastal)"
+    },
+    "B8": {
+      "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B8.TIF",
+      "type": "image/tiff; application=geotiff",
+      "eo:bands": [
+        1
+      ],
+      "title": "Band 8 (panchromatic)",
+      "proj:shape": [16781, 16621],
+      "proj:transform": [15.0, 0.0, 224992.5, 0.0, -15.0, 6790207.5, 0.0, 0.0, 1.0]
     }
   },
   "properties": {
@@ -209,12 +219,20 @@
       "lat": 34.595302781575604,
       "lon": -101.34448382627504
     },
+    "proj:shape": [8391, 8311],
+    "proj:transform": [30.0, 0.0, 224985.0, 0.0, -30.0, 6790215.0, 0.0, 0.0, 1.0],
     "eo:bands": [
       {
         "name": "B1",
         "common_name": "coastal",
         "center_wavelength": 0.44,
         "full_width_half_max": 0.02
+      },
+      {
+        "name": "B8",
+        "common_name": "panchromatic",
+        "center_wavelength": 0.59,
+        "full_width_half_max": 0.18
       }
     ]
   },

--- a/extensions/projection/json-schema/schema.json
+++ b/extensions/projection/json-schema/schema.json
@@ -105,32 +105,6 @@
               }
             }
           }
-        },
-        "assets": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "proj:shape":{
-                "title":"Shape",
-                "type":"array",
-                "minItems":2,
-                "maxItems":2,
-                "items":{
-                  "type":"integer"
-                }
-              },
-              "proj:transform":{
-                "title":"Transform",
-                "type":"array",
-                "minItems":6,
-                "maxItems":9,
-                "items":{
-                  "type":"number"
-                }
-              }
-            }
-          }
         }
       }
     }

--- a/extensions/projection/json-schema/schema.json
+++ b/extensions/projection/json-schema/schema.json
@@ -92,7 +92,7 @@
               "minItems":2,
               "maxItems":2,
               "items":{
-                "type":"number"
+                "type":"integer"
               }
             },
             "proj:transform":{

--- a/extensions/projection/json-schema/schema.json
+++ b/extensions/projection/json-schema/schema.json
@@ -85,6 +85,24 @@
                   "maximum": 180
                 }
               }
+            },
+            "proj:shape":{
+              "title":"Shape",
+              "type":"array",
+              "minItems":2,
+              "maxItems":2,
+              "items":{
+                "type":"number"
+              }
+            },
+            "proj:transform":{
+              "title":"Transform",
+              "type":"array",
+              "minItems":9,
+              "maxItems":9,
+              "items":{
+                "type":"number"
+              }
             }
           }
         }

--- a/extensions/projection/json-schema/schema.json
+++ b/extensions/projection/json-schema/schema.json
@@ -98,7 +98,7 @@
             "proj:transform":{
               "title":"Transform",
               "type":"array",
-              "minItems":9,
+              "minItems":6,
               "maxItems":9,
               "items":{
                 "type":"number"

--- a/extensions/projection/json-schema/schema.json
+++ b/extensions/projection/json-schema/schema.json
@@ -105,6 +105,32 @@
               }
             }
           }
+        },
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "proj:shape":{
+                "title":"Shape",
+                "type":"array",
+                "minItems":2,
+                "maxItems":2,
+                "items":{
+                  "type":"integer"
+                }
+              },
+              "proj:transform":{
+                "title":"Transform",
+                "type":"array",
+                "minItems":6,
+                "maxItems":9,
+                "items":{
+                  "type":"number"
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
**Related Issue(s):** #756


**Proposed Changes:**

1. Incorporate the proposed grid extension changes into the projections extension
2. Include two new properties, `proj:shape` and `proj:transform`

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
