### PR TITLE
Asset metadata cleanup

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -4,6 +4,7 @@
 
 * [Field and ID formatting](#field-and-id-formatting)
 * [Field selection and Metadata Linking](#field-selection-and-metadata-linking)
+* [Common Use Cases of Additional Fields for Assets](#common-use-cases-of-additional-fields-for-assets)
 * [Static and Dynamic Catalogs](#static-and-dynamic-catalogs)
 * [Catalog Layout](#catalog-layout)
 * [Use of Links](#use-of-links)
@@ -45,6 +46,25 @@ it is not recommended. For very large
 catalogs (hundreds of millions of records), every additional field that is indexed will cost substantial money, so data
 providers are advised to just put the fields to be searched in STAC, so STAC API providers don't have bloated indices
 that no one actually uses.
+
+## Common Use Cases of Additional Fields for Assets
+
+As [described in the Item spec](item-spec/item-spec.md#additional-fields-for-assets), it is possible to use fields typically
+found in Item properties at the asset level. This mechanism of overriding or providing Item Properties only in the Assets 
+makes discovery more difficult and should generally be avoided. However, there are some core and extension fields for which 
+providing them at at the Asset level can prove to be very useful for using the data.
+
+- `datetime`: Provide individual timestamp on an Item, in case the Item has a `start_datetime` and `end_datetime`, but an Asset is for one specific time.
+- `gsd` ([Common Metadata](item-spec/common-metadata.md#instrument)): Specify some assets with different spatial resolution 
+than the overall best resolution.
+- `eo:bands` ([EO extension](extensions/eo/)): Provide spectral band information, and order of bands, within an individual asset.
+- `proj:epsg`/`proj:wkt2`/`proj:projjson` ([projection extension](extensions/projection/)): Specify different projection for some assets. If the projection is different
+ for all assets it should probably not be provided as an Item property. If most assets are one projection, and there is 
+ a single reprojected version (such as a Web Mercator preview image), it is sensible to specify the main projection in the 
+ Item and the alternate projection for the affected asset(s).
+- `proj:shape`/`proj:transform` ([projection extension](extensions/projection/)): If assets have different spatial resolutions and slightly different exact bounding boxes, specify these per asset to indicate the size of the asset in pixels and it's exact GeoTranform in the native projection.
+- `sar:polarizations` ([sar extension](extensions/sar/)): Provide the polarization content and ordering of a specific asset, similar to `eo:bands`.
+- `sar:product_type` ([sar extension](extensions/sar/)): If mixing multiple product types within a single Item, this can be used to specify the product_type for each asset.
 
 ## Static and Dynamic Catalogs
 

--- a/item-spec/examples/sentinel2-sample.json
+++ b/item-spec/examples/sentinel2-sample.json
@@ -55,6 +55,15 @@
       ]
     ]
   },
+  "properties": {
+    "collection": "s2-l2a",
+    "datetime": "2018-06-05T10:00:27.464Z",
+    "platform": "sentinel-2",
+    "gsd": 10,
+    "proj:epsg": 32635,
+    "eo:cloud_cover": 88.459539,
+    "view:sun_azimuth" : 176.091667178268
+  },
   "assets": {
     "metadata": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/metadata.xml",
@@ -121,54 +130,63 @@
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B02.jp2",
       "title": "Band 2 - Blue 0.490 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [1]
     },
     "B03_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B03.jp2",
       "title": "Band 3 - Green 0.560 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [2]
     },
     "B04_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B04.jp2",
       "title": "Band 4 - Red 0.665 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [3]
     },
     "B05_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B05.jp2",
       "title" : "Band 5 - Vegetation Red Edge 0.705 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [4]
     },
     "B06_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B06.jp2",
       "title": "Band 6 - Vegetation Red Edge 0.740 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [5]
     },
     "B07_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B07.jp2",
       "title": "Band 7 - Vegetation Red Edge 0.783 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [6]
     },
     "B8A_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B8A.jp2",
       "title": "Band 8A - Narrow NIR 0.865 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [8]
     },
     "B11_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B11.jp2",
       "title": "Band 11 - SWIR 1.610 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [11]
     },
     "B12_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B12.jp2",
       "title": "Band 12 - SWIR 2.190 (20m)",
       "type": "image/jp2",
+      "gsd": 20,
       "eo:bands": [12]
     },
     "AOT_20m": {
@@ -200,111 +218,6 @@
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/qi/SNW_20m.jp2",
       "title": "Snow (20m)",
       "type": "image/jp2"
-    },
-    "B01_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B01.jp2",
-      "title": "Band 1 - Coastal aerosol (60m)",
-      "type": "image/jp2",
-      "eo:bands": [0]
-    },
-    "B02_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B02.jp2",
-      "title": "Band 2 - Blue 0.490 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [1]
-    },
-    "B03_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B03.jp2",
-      "title": "Band 3 - Green 0.560 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [2]
-    },
-    "B04_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B04.jp2",
-      "title": "Band 4 - Red 0.665 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [3]
-    },
-    "B05_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B05.jp2",
-      "title" : "Band 5 - Vegetation Red Edge 0.705 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [4]
-    },
-    "B06_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B06.jp2",
-      "title": "Band 6 - Vegetation Red Edge 0.740 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [5]
-    },
-    "B07_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B07.jp2",
-      "title": "Band 7 - Vegetation Red Edge 0.783 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [6]
-    },
-    "B8A_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B8A.jp2",
-      "title": "Band 8A - Narrow NIR 0.865 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [8]
-    },
-    "B09_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B09.jp2",
-      "title": "Band 9 - Water vapour 0.945 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [9]
-    },
-    "B11_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B11.jp2",
-      "title": "Band 11 - SWIR 1.610 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [11]
-    },
-    "B12_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/B12.jp2",
-      "title": "Band 12 - SWIR 2.190 (60m)",
-      "type": "image/jp2",
-      "eo:bands": [12]
-    },
-    "AOT_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/AOT.jp2",
-      "title": "Aerosol Optical Thickness (60m)",
-      "type": "image/jp2"
-    },
-    "SCL_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/SCL.jp2",
-      "title": "Scene Classification (60m)",
-      "type": "image/jp2"
-    },
-    "TCI_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/TCI.jp2",
-      "title": "True Color Image (60m)",
-      "type": "image/jp2",
-      "roles": [ "overview" ]
-    },
-    "WVP_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R60m/WVP.jp2",
-      "title": "Water Vapor (60m)",
-      "type": "image/jp2"
-    },
-    "CLD_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/qi/CLD_60m.jp2",
-      "title": "Cloud (60m)",
-      "type": "image/jp2"
-    },
-    "SNW_60m": {
-      "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/qi/SNW_60m.jp2",
-      "title": "Snow (60m)",
-      "type": "image/jp2"
     }
-  },
-  "properties": {
-    "collection": "s2-l2a",
-    "datetime": "2018-06-05T10:00:27.464Z",
-    "platform": "sentinel-2",
-    "proj:epsg": 32635,
-    "eo:cloud_cover": 88.459539,
-    "view:sun_azimuth" : 176.091667178268
   }
 }

--- a/item-spec/examples/sentinel2-sample.json
+++ b/item-spec/examples/sentinel2-sample.json
@@ -56,14 +56,14 @@
     ]
   },
   "properties": {
-    "collection": "s2-l2a",
-    "datetime": "2018-06-05T10:00:27.464Z",
+    "datetime": "2018-06-05T10:00:27.46Z",
     "platform": "sentinel-2",
     "gsd": 10,
     "proj:epsg": 32635,
     "eo:cloud_cover": 88.459539,
     "view:sun_azimuth" : 176.091667178268
   },
+  "collection": "s2-l2a",
   "assets": {
     "metadata": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/metadata.xml",

--- a/item-spec/examples/sentinel2-sample.json
+++ b/item-spec/examples/sentinel2-sample.json
@@ -56,7 +56,7 @@
     ]
   },
   "properties": {
-    "datetime": "2018-06-05T10:00:27.46Z",
+    "datetime": "2018-06-05T10:00:27Z",
     "platform": "sentinel-2",
     "gsd": 10,
     "proj:epsg": 32635,

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -166,11 +166,8 @@ or streamed. It is allowed to add additional fields.
 | type        | string    | [Media type](#media-types) of the asset. |
 | roles       | \[string] | The [semantic roles](#asset-role-types) of the asset, similar to the use of `rel` in links. |
 
-In addition to the fields above, [additional fields](#additional-fields) may be added to the assets. (See [Additional Fields for Assets](#additional-fields-for-assets))
-
-* [STAC Common Metadata](common-metadata.md#stac-common-metadata) - A list of fields commonly used throughout all domains.
-* [Content Extensions](../extensions/README.md#list-of-content-extensions) - Domain-specific fields such as EO, SAR and point clouds.
-* [Custom Extensions](../extensions/README.md#extending-stac) - It is generally allowed to add custom fields.
+Beyond to the fields above, any of the [additional fields](#additional-fields) *may* be added to the assets. But this
+is recommended only in special cases, see [Additional Fields for Assets](#additional-fields-for-assets)) for more information.
 
 #### Asset Role Types
 
@@ -223,11 +220,18 @@ Both can still appear in old catalogues, but are deprecated and should be replac
 
 #### Additional Fields for Assets
 
-As detailed above, Items contain properties, which are the main source of metadata for searching across Items. Many content extensions can add further property fields as well. Any property that can be specified for an Item can also be specified for a specific asset. This can be used to override a property defined in the Item, or to specify fields for which there is no single value for all assets.
+As detailed above, Items contain properties, which are the main source of metadata for searching across Items. Many content
+extensions can add further property fields as well. Any property that can be specified for an Item can also be specified for 
+a specific asset. This can be used to override a property defined in the Item, or to specify fields for which there is no 
+single value for all assets.
 
-**It is important to note that the STAC API does not faciliate searching across Asset properties in this way, and this should be used sparingly.** It is primarily used to define properties at the Asset level that may be used during use of the data instead of for searching. 
+**It is important to note that the STAC API does not faciliate searching across Asset properties in this way, and this 
+should be used sparingly.** It is primarily used to define properties at the Asset level that may be used during use of 
+the data instead of for searching. 
 
-For example, `gsd` defined for an Item represents the best Ground Sample Distance (resolution) for the data within the Item. However, some assets may be lower resolution and thus have a higher `gsd`. The `eo:bands` field from the EO extension defines an array of spectral bands. However, it may be useful instead to specify the bands that are used in a particular asset.
+For example, `gsd` defined for an Item represents the best Ground Sample Distance (resolution) for the data within the Item. 
+However, some assets may be lower resolution and thus have a higher `gsd`. The `eo:bands` field from the EO extension defines 
+an array of spectral bands. However, it may be useful instead to specify the bands that are used in a particular asset.
 
 Here is a partial Sentinel-2 Item:
 
@@ -304,21 +308,17 @@ Here is a partial Sentinel-2 Item:
 }
 ```
 
-The Sentinel-2 overall `gsd` is 10m, because this is the best spatial resolution among all the bands and is defined in Item properties so it can be searched on. However, Band 5 has a `gsd` of 20m, so that asset specifies the `gsd` as well, which overrides the Item `gsd` for this one asset. Reduced resolution versions of files could also be included as assets and the `gsd` correectly represented.
+The Sentinel-2 overall `gsd` is 10m, because this is the best spatial resolution among all the bands and is defined in 
+Item properties so it can be searched on. However, Band 5 has a `gsd` of 20m, so that asset specifies the `gsd` as 
+well, which overrides the Item `gsd` for this one asset. Reduced resolution versions of files could also be included 
+as assets and the `gsd` correectly represented.
 
-For `eo:bands`, it could be put in Item properties as an array of all the bands, but in this case it's not. Instead, the assets each define an array containing the spectral band information for that asset (in the order the bands appear in the file).
+For `eo:bands`, it could be put in Item properties as an array of all the bands, but in this case it's not. Instead, 
+the assets each define an array containing the spectral band information for that asset (in the order the bands appear 
+in the file).
 
-##### Common Use Cases of Additional Fields for Assets
-
-Overriding or providing Item Properties only in the Assets makes discovery more difficult and should generally be avoided. However, there are some core and extension fields for which providing them at at the Asset level can prove to be very useful for using the data.
-
-- `datetime`: Provide individual timestamp on an Item, in case the Item has a `start_datetime` and `end_datetime`, but an Asset is for one specific time.
-- `gsd`: Specify some assets with different spatial resolution than the overall best resolution.
-- `eo:bands`: Provide spectral band information, and order of bands, within an individual asset.
-- `proj:epsg`/`proj:wkt2`/`proj:projjson`: Specify different projection for some assets. If the projection is different for all assets it should probably not be provided as an Item property. If most assets are one projection, and there is a single reprojected version (such as a Web Mercator preview image), it is sensible to specify the main projection in the Item and the alternate projection for the affected asset(s).
-- `proj:shape`/`proj:transform`: If assets have different spatial resolutions and slightly different exact bounding boxes, specify these per asset to indicate the size of the asset in pixels and it's exact GeoTranform in the native projection.
-- `sar:polarizations`: Provide the polarization content and ordering of a specific asset, similar to `eo:bands`.
-- `sar:product_type`: If mixing multiple product types within a single Item, this can be used to specify the product_type for each asset.
+For examples of fields that this construct is recommended for, see the [section of STAC Best Practices](../best-practices.md#common-use-cases-of-additional-fields-for-assets)
+that talks about common use cases of additional fields for assets.
 
 ## Extensions
 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -233,7 +233,7 @@ For example, `gsd` defined for an Item represents the best Ground Sample Distanc
 However, some assets may be lower resolution and thus have a higher `gsd`. The `eo:bands` field from the EO extension defines 
 an array of spectral bands. However, it may be useful instead to specify the bands that are used in a particular asset.
 
-For an example see the [sentinel2-sample](sentinel2-sample.json). The Sentinel-2 overall `gsd` is 10m, because this is 
+For an example see the [sentinel2-sample](examples/sentinel2-sample.json). The Sentinel-2 overall `gsd` is 10m, because this is 
 the best spatial resolution among all the bands and is defined in Item properties so it can be searched on. In the example 
 Band 5 and others have a `gsd` of 20m, so that asset specifies the `gsd` as well, which overrides the Item `gsd` for this 
 one asset. The example also includes reduced resolution versions of files included as assets, using `gsd` to represent

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -233,85 +233,11 @@ For example, `gsd` defined for an Item represents the best Ground Sample Distanc
 However, some assets may be lower resolution and thus have a higher `gsd`. The `eo:bands` field from the EO extension defines 
 an array of spectral bands. However, it may be useful instead to specify the bands that are used in a particular asset.
 
-Here is a partial Sentinel-2 Item:
-
-```json
-{
-    "id": "S2A_30PZQ_20190713_0_L2A",
-    "collection": "sentinel-s2-l2a",
-    "properties": {
-        "datetime": "2019-07-13T10:28:48.870000+00:00",
-        "gsd": 10
-    },
-    "assets": {
-        "visual": {
-            "title": "True color image",
-            "type": "image/jp2",
-            "roles": [
-                "visual"
-            ],
-            "eo:bands": [
-                {
-                    "full_width_half_max": 0.038,
-                    "center_wavelength": 0.6645,
-                    "name": "B04",
-                    "common_name": "red"
-                },
-                {
-                    "full_width_half_max": 0.045,
-                    "center_wavelength": 0.56,
-                    "name": "B03",
-                    "common_name": "green"
-                },
-                {
-                    "full_width_half_max": 0.098,
-                    "center_wavelength": 0.4966,
-                    "name": "B02",
-                    "common_name": "blue"
-                }
-            ],
-            "href": "s3://sentinel-s2-l2a/tiles/30/P/ZQ/2019/7/13/0/R10m/TCI.jp2"
-        },
-        "B05": {
-            "title": "Band 5",
-            "type": "image/jp2",
-            "roles": [
-                "data"
-            ],
-            "gsd": 20,
-            "eo:bands": [
-                {
-                    "full_width_half_max": 0.019,
-                    "center_wavelength": 0.7039,
-                    "name": "B05"
-                }
-            ],
-            "href": "s3://sentinel-s2-l2a/tiles/30/P/ZQ/2019/7/13/0/R20m/B05.jp2"
-        },
-        "B08": {
-            "title": "Band 8 (nir)",
-            "type": "image/jp2",
-            "roles": [
-                "data"
-            ],
-            "eo:bands": [
-                {
-                    "full_width_half_max": 0.145,
-                    "center_wavelength": 0.8351,
-                    "name": "B08",
-                    "common_name": "nir"
-                },
-            ],
-            "href": "s3://sentinel-s2-l2a/tiles/30/P/ZQ/2019/7/13/0/R10m/B08.jp2"
-        }
-    }
-}
-```
-
-The Sentinel-2 overall `gsd` is 10m, because this is the best spatial resolution among all the bands and is defined in 
-Item properties so it can be searched on. However, Band 5 has a `gsd` of 20m, so that asset specifies the `gsd` as 
-well, which overrides the Item `gsd` for this one asset. Reduced resolution versions of files could also be included 
-as assets and the `gsd` correectly represented.
+For an example see the [sentinel2-sample](sentinel2-sample.json). The Sentinel-2 overall `gsd` is 10m, because this is 
+the best spatial resolution among all the bands and is defined in Item properties so it can be searched on. In the example 
+Band 5 and others have a `gsd` of 20m, so that asset specifies the `gsd` as well, which overrides the Item `gsd` for this 
+one asset. The example also includes reduced resolution versions of files included as assets, using `gsd` to represent
+the proper resolution.
 
 For `eo:bands`, it could be put in Item properties as an array of all the bands, but in this case it's not. Instead, 
 the assets each define an array containing the spectral band information for that asset (in the order the bands appear 


### PR DESCRIPTION
**Related Issue(s):** #789 

**Proposed Changes:**

1. Moved section on common asset fields to best-practices
2. Moved example in item-spec.md to be in the s2 example
3. Cut the 60m assets from the s2 example, since they don't add much value imho and made the gsd stuff less clear. (Possibly controversial - the example is no longer aligns as closely with actual sentinel stac catalogs, but I think that's ok, as the examples in stac should be instructive imho. People can go
to the actual public catalogs to see the full example.

I don't believe this warrants a changelog entry, but happy to do one if others feel it should.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
