### PR TITLE
Remove warnings about spec instability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ available in a slightly different way. This will enable standard library compone
 implemented in a completely 'static' manner, enabling data publishers to expose their data by simply publishing linked JSON
 files online.
 
-## WARNING
+## Stability Note
 
-The specification is reaching maturity, and the next release will be 1.0-beta1. At this point we don't anticipate any 
-major changes, but reserve the right to make them if we get feedback that something just doesn't work.
+This specification has evolved over the past couple years, and is used in production in a variety of deployments. It is currently
+in a 'beta' state, with no major changes anticipated, so implementors can expect that most things will stay fairly stable. So 
+at this point we don't anticipate any major changes, but reserve the right to make them if we get feedback that something just doesn't 
+work. Which is to say the next couple months are a great time to implement STAC, as your changes will be head. After 1.0 our goal
+is to not change the core in any backwards incompatible way for a very long time, if ever, so that people can build on this until 
+JSON is no longer relevant. 
 
 ## Current version and branches
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -15,12 +15,6 @@ STAC Collections are meant to be compatible with *OGC API - Features* Collection
   * Landsat 8: A [Collection](examples/landsat-collection.json) that holds shared data from an [Item](examples/landsat-item.json).
 * [JSON Schema](json-schema/collection.json) - please see the [validation instructions](../validation/README.md)
 
-## WARNING
-
-**This is still an early version of the STAC spec, expect that there may be some changes before everything is finalized.**
-
-Implementations are encouraged, however, as good effort will be made to not change anything too drastically. Using the specification now will ensure that needed changes can be made before everything is locked in. So now is an ideal time to implement, as your feedback will be directly incorporated. 
-
 ## Collection fields
 
 | Element         | Type                                             | Description                                      |

--- a/item-spec/itemcollection-spec.md
+++ b/item-spec/itemcollection-spec.md
@@ -19,12 +19,6 @@ required fields is a valid STAC ItemCollection.
   - Real world [implementations](../implementations.md) are also available.
 - [JSON Schema](json-schema/itemcollection.json)
 
-## WARNING
-
-**This is still an early version of the STAC spec, expect that there may be some changes before everything is finalized.**
-
-Implementations are encouraged, however, as good effort will be made to not change anything too drastically. Using the specification now will ensure that needed changes can be made before everything is locked in. So now is an ideal time to implement, as your feedback will be directly incorporated. 
-
 ## ItemCollection fields
 
 This object describes a STAC ItemCollection. The fields `type` and `features` are inherited from GeoJSON FeatureCollection.


### PR DESCRIPTION
**Related Issue(s):** #766 


**Proposed Changes:**

1. Removed the 'warnings' from each of the specs.
2. Updated the readme to comment on 'beta' stability instead of a big 'warning'.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
