### PR TITLE
Contributing.md improvements - instructions to run check-markdown locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added a code of conduct based on github's template.
 - Added the ability to define Item properties under Assets (item-spec/item-spec.md)
 - Add `proj:shape` and `proj:transform` to the projections extension.
+- Instructions on how to run check-markdown locally
 
 ### Changed
 - Moved item recommendations to best practices, and added a bit more in item spec about 'search'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,56 @@
 ## Contributing
 
-Anyone building software that catalogs imagery or other geospatial assets is welcome to collaborate.
-Our goal is to be a collaboration of developers, not [architecture astronauts](http://www.joelonsoftware.com/articles/fog0000000018.html).
-A number of developers met in person and [sprinted on specs](https://github.com/radiantearth/boulder-sprint/)
-and made a number of key decisions. 
+Pull Requests are the primary method of contributing to the spec itself, and everyone is welcome to submit 
+changes. Suggestions for changes to the core will be taken with higher priority if a clear implementation 
+of STAC has been built that can highlight the problem. If the changes can be done as an [extension](extensions/) 
+instead of modifying the core files then that route is recommended first, and once there is uptake for the 
+extension it will be considered for core.
 
-The best way to contribute is to try to implement the specification and give feedback on what worked
-well and what could be improved. Currently there are a few major things to still work out, so if you
-are interested in implementing you should jump on our [gitter channel](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby)
-and check in on how ready the spec is and how you can support it. For the next bit of time you'll
-probably be encouraged to just do what feels best in some areas, so we can capture best practices
-and standardize.
+We consider everyone using the specification to catalog their data to be a 'contributor', as STAC is
+really about the end result of more interoperable data, not just creating a spec for the sake of it.
+So if you want to help then the best thing you can do is make new catalogs or build software that uses
+the spec. And please do give us feedback. The best place to do so is on our 
+[gitter channel](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby).
+
+### Submitting Pull Requests
 
 Any proposed changes to the specification should be done as pull requests. Please make these
 requests against the [dev](https://github.com/radiantearth/stac-spec/tree/dev) branch (this will
-require you to switch from the default of 'master', which we keep so it displays first). Ideally a
-proposed change would also update all of the examples, but for now that is not required - the team
-can validate and update all examples before a release. But it is recommended to update at least a
-couple examples to reflect the change.
+require you to switch from the default of 'master', which we keep so it displays first). 
 
-All pull requests require a review of two team members.
+Creating a Pull Request will show our PR template, which includes checkbox reminders for a number
+of things.
+
+* Adding an entry the [CHANGELOG](CHANGELOG.md). If the change is more editorial and minor then this 
+is not required, but any change to the actual specification should definitely have one.
+* Base the PR against dev, as mentioned above - even if the branch was made off of dev this reminds
+you to change the base in GitHub's PR creation page.
+* Make a ticket in the STAC API repo if anything here affects there.
+* Make sure the PR makes no breaking changes to the specification.
+
+All pull requests additionally require a review of two STAC core team members. Releases are cut
+from dev to master (and require 3 approvals), see the [process](process.md) document for more details.
+
+There are also two additional checks done by the continuous integration system. The one most likely
+to catch you the markdown checker, which ensures we have clean markdown throughout the specification.
+You can click through to see what it caught. If you do not want to wait till you push to see if things
+failed then you can use the same tool locally.
+
+### Using check-markdown locally
+
+The same check-markdown program that runs as a check on PR's is part of the repo and can be run locally. 
+To install you'll need npm, which is a standard part of any [node.js installation](https://nodejs.org/en/download/).
+
+First you'll need to install everything with npm. Just navigate to the root of the stac-spec repo and on 
+your command line run:
+
+```bash
+npm install
+```
+Then to do the check on your markdown you run:
+
+```bash
+npm run check-markdown
+```
+
+This will spit out the same text that you see online, and you can then go and fix your markdown.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,15 +26,16 @@ is not required, but any change to the actual specification should definitely ha
 * Base the PR against dev, as mentioned above - even if the branch was made off of dev this reminds
 you to change the base in GitHub's PR creation page.
 * Make a ticket in the STAC API repo if anything here affects there.
-* Make sure the PR makes no breaking changes to the specification.
+* Highlight if the PR makes breaking changes to the specification (in beta there can still be
+select breaking changes, but after 1.0 this will change)
+
+All pull requests should submit clean markdown, which is checked by the continuous integration
+system. Please use `check-markdown` locally, as described in the [next section](#using-check-markdown-locally), 
+to ensure that the checks on the pull request succeed. If it does not then you can look at the
+mistakes online, which are the same as running `check-markdown` locally would surface.
 
 All pull requests additionally require a review of two STAC core team members. Releases are cut
 from dev to master (and require 3 approvals), see the [process](process.md) document for more details.
-
-There are also two additional checks done by the continuous integration system. The one most likely
-to catch you the markdown checker, which ensures we have clean markdown throughout the specification.
-You can click through to see what it caught. If you do not want to wait till you push to see if things
-failed then you can use the same tool locally.
 
 ### Using check-markdown locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ failed then you can use the same tool locally.
 ### Using check-markdown locally
 
 The same check-markdown program that runs as a check on PR's is part of the repo and can be run locally. 
-To install you'll need npm, which is a standard part of any [node.js installation](https://nodejs.org/en/download/).
+To install you'll need npm, which is a standard part of any [node.js installation](https://nodejs.org/en/download/). Alternatively, you can also use [yarn](https://yarnpkg.com/) instead of npm. In this case replace all occurrences of `npm` with `yarn` below.
 
 First you'll need to install everything with npm. Just navigate to the root of the stac-spec repo and on 
 your command line run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ failed then you can use the same tool locally.
 The same check-markdown program that runs as a check on PR's is part of the repo and can be run locally. 
 To install you'll need npm, which is a standard part of any [node.js installation](https://nodejs.org/en/download/). Alternatively, you can also use [yarn](https://yarnpkg.com/) instead of npm. In this case replace all occurrences of `npm` with `yarn` below.
 
-First you'll need to install everything with npm. Just navigate to the root of the stac-spec repo and on 
+First you'll need to install everything with npm once. Just navigate to the root of the stac-spec repo and on 
 your command line run:
 
 ```bash


### PR DESCRIPTION
**Related Issue(s):** #773 and a bit of #793 


**Proposed Changes:**

1. Reworked the contributing.md document to reflect maturity of spec
2. Added instructions on installing and running check-markdown locally

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
