### PR TITLE
Item Asset Definition: Don't specify the required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved item recommendations to best practices, and added a bit more in item spec about 'search'
 - Moved `eo:gsd` from `eo` extension to core `gsd` field in Item common metadata
 - `asset` extension renamed to `item-assets` and renamed `assets` field in Collections to `item_assets`
+- `item-assets` extension only requires any two fields to be available, not the two specific fields `title` and `type`
 - `datetime` allows `null` as value, but requires `start_datetime` and `end_datetime` then
 
 ### Fixed

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -36,10 +36,10 @@
                 "title": "Reference to a core extension",
                 "type": "string",
                 "enum": [
-                  "asset",
                   "commons",
                   "checksum",
                   "datacube",
+                  "item-assets",
                   "scientific",
                   "tiled-assets",
                   "version"

--- a/extensions/item-assets/README.md
+++ b/extensions/item-assets/README.md
@@ -21,8 +21,7 @@ This extension serves two purposes:
 
 This extension introduces a single new field, `item_assets` at the top level of a collection.
 An Asset Object defined at the Collection level is nearly the same as the [Asset Object in Items](../../item-spec/item-spec.md#asset-object), except for two differences.
-The `href` field is not required, because collections don't point to any data by themselves.
-Additioanlly the remaining fields, `title` and `type` are required in the Asset Definition, in order for it to adequately describe Item assets.
+The `href` field is not required, because collections don't point to any data by themselves, but at least two other fields must be present.
 
 | Field Name  | Type                                       | Description |
 | ----------- | ------------------------------------------ | ----------- |
@@ -30,16 +29,21 @@ Additioanlly the remaining fields, `title` and `type` are required in the Asset 
 
 ### Asset Object
 
-An asset is an object that contains details about the datafiles that will be included in member Items. Assets included at the Collection level do not imply that all assets are available from all Items. However, it is recommended that the Asset Definition is a complete set of all assets that may be available from any member Items.
+An asset is an object that contains details about the datafiles that will be included in member Items.
+Assets included at the Collection level do not imply that all assets are available from all Items.
+However, it is recommended that the Asset Definition is a complete set of all assets that may be available from any member Items.
 
 | Field Name  | Type      | Description |
 | ----------- | --------- | ----------- |
-| title       | string    | **REQUIRED.** The displayed title for clients and users. |
+| title       | string    | The displayed title for clients and users. |
 | description | string    | A description of the Asset providing additional details, such as how it was processed or created. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| type        | string    | **REQUIRED.** [Media type](../../item-spec/item-spec.md#media-types) of the asset. |
+| type        | string    | [Media type](../../item-spec/item-spec.md#media-types) of the asset. |
 | roles       | \[string] | The [semantic roles](../../item-spec/item-spec.md#asset-role-types) of the asset, similar to the use of `rel` in links. |
 
 Other custom fields, or fields from other extensions may also be included in the Asset object.
+
+At least two fields (e.g. `title` and `type`) are required to be provided, in order for it to adequately describe Item assets.
+The two fields must not necessarily be taken from the list above and may include any custom field.
 
 ## Implementations
 

--- a/extensions/item-assets/json-schema/schema.json
+++ b/extensions/item-assets/json-schema/schema.json
@@ -29,10 +29,7 @@
     },
     "asset": {
       "type": "object",
-      "required": [
-        "title",
-        "type"
-      ],
+      "minProperties": 2,
       "properties": {
         "title": {
           "title": "Asset title",


### PR DESCRIPTION
**Related Issue(s):** #799


**Proposed Changes:**

1. Change the specific set of required fields to just require two fields. Idea originates in PR #754
2. Fix stac_extension entry for "item-assets", was forgotten to be renamed in #787

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
