### PR TITLE
Fix invalid STAC extensions in Collection example

### DIFF
--- a/collection-spec/examples/landsat-collection.json
+++ b/collection-spec/examples/landsat-collection.json
@@ -1,9 +1,6 @@
 {
     "stac_version": "1.0.0-beta.1",
-    "stac_extensions": [
-      "view",
-      "eo"
-    ],
+    "stac_extensions": [],
     "id": "landsat-8-l1",
     "title": "Landsat 8 L1",
     "description": "Landat 8 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. Fix collection example. Those stac_extensions are only defined for items.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
