### PR TITLE
Improve/Fix JSON Schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v1.0.0-beta.1] - 2020-05-29
 
-### Changed
-
-- Extensions:
-  - [Label extension](extensions/label/README.md) types were clarified and types in README and JSON schema were brought into alignment
-
 ### Removed
 - The API portion of STAC has been split off into a [new repository: stac-api-spec](https://github.com/radiantearth/stac-api-spec) and will start being versioned and released separately than the core STAC spec.
 - proj4 string from proj extension
@@ -35,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [Tiled Assets extension](extensions/tiled-assets/README.md), for representing data that has been split into tiles
 
 ### Changed
+- [Label extension](extensions/label/README.md) types were clarified and types in README and JSON schema were brought into alignment
 - Moved item recommendations to best practices, and added a bit more in item spec about 'search'
 - Moved `eo:gsd` from `eo` extension to core `gsd` field in Item common metadata
 - `asset` extension renamed to `item-assets` and renamed `assets` field in Collections to `item_assets`
@@ -42,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `datetime` allows `null` as value, but requires `start_datetime` and `end_datetime` then
 - Extensions `sat`, `scientific` and `view`: At least one field is required to be specified.
 - [Single File STAC extension](extensions/single-file-stac/README.md) changed to be a complete STAC catalog + GeoJSON FeatureCollection that contains collections and items.
+- Improved several JSON Schemas
 
 ### Fixed
 - Datacube extension: `cube:dimensions` was not flagged as required.

--- a/catalog-spec/json-schema/catalog.json
+++ b/catalog-spec/json-schema/catalog.json
@@ -37,12 +37,7 @@
               },
               {
                 "title": "Reference to a core extension",
-                "type": "string",
-                "enum": [
-                  "checksum",
-                  "single-file-stac",
-                  "tiled-assets"
-                ]
+                "type": "string"
               }
             ]
           }

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -34,16 +34,7 @@
               },
               {
                 "title": "Reference to a core extension",
-                "type": "string",
-                "enum": [
-                  "collection-assets",
-                  "checksum",
-                  "datacube",
-                  "item-assets",
-                  "scientific",
-                  "tiled-assets",
-                  "version"
-                ]
+                "type": "string"
               }
             ]
           }

--- a/extensions/checksum/README.md
+++ b/extensions/checksum/README.md
@@ -17,6 +17,8 @@ Provides a way to specify file checksums (e.g. BLAKE2, MD5, SHA1, SHA2, SHA3) fo
 | ------------------ | ------ | ------------------------------------------------------------ |
 | checksum:multihash | string | Multihash for the corresponding file, encoded as hexadecimal (base 16) string with lowercase letters. |
 
+This extension can OPTIONALLY be used with the [Collection Assets Extension](../collection-assets/README.md). Checksums MUST NOT be part of the [Item Assets Definition](../item-assets/README.md) in Collections.
+
 ### Examples
 
 Checksum for a text file with file content `test`.

--- a/extensions/checksum/json-schema/schema.json
+++ b/extensions/checksum/json-schema/schema.json
@@ -3,27 +3,83 @@
   "$id": "schema.json#",
   "title": "Checksum Extension Specification",
   "description": "STAC Checksum Extension to a STAC Item",
-  "allOf": [
+  "oneOf": [
     {
-      "$ref": "../../../item-spec/json-schema/item.json#/definitions/core"
+      "allOf": [
+        {
+          "$ref": "../../../item-spec/json-schema/item.json"
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/checksum_links"
+        },
+        {
+          "$ref": "#/definitions/checksum_assets"
+        }
+      ]
     },
     {
-      "$ref": "#/definitions/checksum"
+      "allOf": [
+        {
+          "$ref": "../../../catalog-spec/json-schema/catalog.json"
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/checksum_links"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "../../../collection-spec/json-schema/collection.json"
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
+          "$ref": "#/definitions/checksum_links"
+        },
+        {
+          "$ref": "#/definitions/checksum_assets"
+        }
+      ]
     }
   ],
   "definitions": {
-    "checksum": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "checksum"
+          }
+        }
+      }
+    },
+    "checksum_links": {
       "type": "object",
       "properties": {
         "links": {
-          "title": "Links",
           "type": "array",
           "items": {
             "$ref": "#/definitions/checksums"
           }
-        },
+        }
+      }
+    },
+    "checksum_assets": {
+      "type": "object",
+      "properties": {
         "assets": {
-          "title": "Assets",
           "type": "object",
           "patternProperties": {
             ".+": {

--- a/extensions/collection-assets/json-schema/schema.json
+++ b/extensions/collection-assets/json-schema/schema.json
@@ -10,9 +10,16 @@
     {
       "type": "object",
       "required": [
+        "stac_extensions",
         "assets"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "collection-assets"
+          }
+        },
         "assets": {
           "$ref": "../../../item-spec/json-schema/item.json#/definitions/assets"
         }

--- a/extensions/datacube/json-schema/schema.json
+++ b/extensions/datacube/json-schema/schema.json
@@ -10,6 +10,9 @@
           "$ref": "../../../item-spec/json-schema/item.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "type": "object",
           "required": [
             "properties"
@@ -28,12 +31,29 @@
           "$ref": "../../../collection-spec/json-schema/collection.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "$ref": "#/definitions/datacube"
         }
       ]
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "datacube"
+          }
+        }
+      }
+    },
     "datacube": {
       "type": "object",
       "required": [

--- a/extensions/eo/json-schema/schema.json
+++ b/extensions/eo/json-schema/schema.json
@@ -15,10 +15,17 @@
     "eo": {
       "type": "object",
       "required": [
+        "stac_extensions",
         "properties",
         "assets"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "eo"
+          }
+        },
         "properties": {
           "type": "object",
           "required": [

--- a/extensions/item-assets/json-schema/schema.json
+++ b/extensions/item-assets/json-schema/schema.json
@@ -16,9 +16,16 @@
       "title": "Item Assets Definition",
       "type": "object",
       "required": [
+        "stac_extensions",
         "item_assets"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "item-assets"
+          }
+        },
         "item_assets": {
           "type": "object",
           "additionalProperties": {

--- a/extensions/label/json-schema/schema.json
+++ b/extensions/label/json-schema/schema.json
@@ -1,132 +1,155 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "stac-label-item-schema.json#",
-  "title": "STAC Label Data Item Extension Spec",
-  "type": "object",
-  "properties": {
-    "properties": {
+  "$id": "schema.json#",
+  "title": "Label Extension",
+  "description": "STAC Label Data Item Extension Spec",
+  "allOf": [
+    {
+      "$ref": "../../../item-spec/json-schema/item.json"
+    },
+    {
+      "$ref": "#/definitions/label"
+    }
+  ],
+  "definitions": {
+    "label": {
       "type": "object",
       "required": [
-        "label:properties",
-        "label:classes",
-        "label:description",
-        "label:type"
+        "stac_extensions",
+        "properties"
       ],
       "properties": {
-        "label:properties": {
-          "title": "Property",
-          "oneOf": [
-            {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "label"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "required": [
+            "label:properties",
+            "label:classes",
+            "label:description",
+            "label:type"
+          ],
+          "properties": {
+            "label:properties": {
+              "title": "Property",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "label:classes": {
+              "title": "Classes",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "classes"
+                ],
+                "properties": {
+                  "name": {
+                    "title": "Name",
+                    "type": "string"
+                  },
+                  "classes": {
+                    "title": "Classes",
+                    "oneOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "number"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "label:description": {
+              "title": "Description",
+              "type": "string"
+            },
+            "label:type": {
+              "title": "Type",
+              "type": "string",
+              "enum": [
+                "raster",
+                "vector"
+              ]
+            },
+            "label:tasks": {
+              "title": "Task",
               "type": "array",
               "items": {
                 "type": "string"
               }
             },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "label:classes": {
-          "title": "Classes",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "classes"
-            ],
-            "properties": {
-              "name": {
-                "title": "Name",
+            "label:methods": {
+              "title": "Method",
+              "type": "array",
+              "items": {
                 "type": "string"
-              },
-              "classes": {
-                "title": "Classes",
-                "oneOf": [
-                  {
+              }
+            },
+            "label:overviews": {
+              "title": "Overview",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "property_key": {
+                    "title": "Property Key",
+                    "type": "string"
+                  },
+                  "counts": {
+                    "title": "Counts",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "title": "Class Name",
+                          "type": "string"
+                        },
+                        "count": {
+                          "title": "Count",
+                          "type": "integer"
+                        }
+                      }
                     }
                   },
-                  {
+                  "statistics": {
+                    "title": "Statistics",
                     "type": "array",
                     "items": {
-                      "type": "number"
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "label:description": {
-          "title": "Description",
-          "type": "string"
-        },
-        "label:type": {
-          "title": "Type",
-          "type": "string",
-          "enum": [
-            "raster",
-            "vector"
-          ]
-        },
-        "label:tasks": {
-          "title": "Task",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "label:methods": {
-          "title": "Method",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "label:overviews": {
-          "title": "Overview",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "property_key": {
-                "title": "Property Key",
-                "type": "string"
-              },
-              "counts": {
-                "title": "Counts",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "title": "Class Name",
-                      "type": "string"
-                    },
-                    "count": {
-                      "title": "Count",
-                      "type": "integer"
-                    }
-                  }
-                }
-              },
-              "statistics": {
-                "title": "Statistics",
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "title": "Stat Name",
-                      "type": "string"
-                    },
-                    "value": {
-                      "title": "Value",
-                      "type": "number"
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "title": "Stat Name",
+                          "type": "string"
+                        },
+                        "value": {
+                          "title": "Value",
+                          "type": "number"
+                        }
+                      }
                     }
                   }
                 }

--- a/extensions/projection/json-schema/schema.json
+++ b/extensions/projection/json-schema/schema.json
@@ -15,9 +15,16 @@
     "proj":{
       "type": "object",
       "required": [
+        "stac_extensions",
         "properties"
       ],
       "properties":{
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "projection"
+          }
+        },
         "properties":{
           "type":"object",
           "required":[

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -15,10 +15,17 @@
     "sar": {
       "type": "object",
       "required": [
+        "stac_extensions",
         "properties",
         "assets"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "sar"
+          }
+        },
         "properties": {
           "type": "object",
           "required": [

--- a/extensions/sat/json-schema/schema.json
+++ b/extensions/sat/json-schema/schema.json
@@ -18,9 +18,16 @@
     "sat": {
       "type": "object",
       "required": [
+        "stac_extensions",
         "properties"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "sat"
+          }
+        },
         "properties": {
           "type": "object",
           "anyOf": [

--- a/extensions/scientific/json-schema/schema.json
+++ b/extensions/scientific/json-schema/schema.json
@@ -10,6 +10,9 @@
           "$ref": "../../../item-spec/json-schema/item.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "type": "object",
           "required": [
             "properties"
@@ -28,12 +31,29 @@
           "$ref": "../../../collection-spec/json-schema/collection.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "$ref": "#/definitions/scientific"
         }
       ]
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "scientific"
+          }
+        }
+      }
+    },
     "scientific": {
       "type": "object",
       "anyOf": [

--- a/extensions/single-file-stac/json-schema/schema.json
+++ b/extensions/single-file-stac/json-schema/schema.json
@@ -18,9 +18,16 @@
     "single-file-stac": {
       "type": "object",
       "required": [
+        "stac_extensions",
         "features"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "single-file-stac"
+          }
+        },
         "collections": {
           "type": "array",
           "items": {

--- a/extensions/tiled-assets/json-schema/schema.json
+++ b/extensions/tiled-assets/json-schema/schema.json
@@ -10,6 +10,9 @@
           "$ref": "../../../item-spec/json-schema/item.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "$ref": "#/definitions/item-tiles"
         }
       ]
@@ -17,6 +20,9 @@
       "allOf": [
         {
           "$ref": "../../../catalog-spec/json-schema/catalog.json"
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
         },
         {
           "$ref": "#/definitions/catalog-collection-tiles"
@@ -28,12 +34,29 @@
           "$ref": "../../../collection-spec/json-schema/collection.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "$ref": "#/definitions/catalog-collection-tiles"
         }
       ]
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "tiled-assets"
+          }
+        }
+      }
+    },
     "catalog-collection-tiles": {
       "title": "Tile matrix additions to STAC Collections and Catalogs",
       "description": "Allows the definition of tile matrix sets on a Collection or Catalog.",

--- a/extensions/timestamps/json-schema/schema.json
+++ b/extensions/timestamps/json-schema/schema.json
@@ -10,10 +10,17 @@
     {
       "type": "object",
       "required": [
+        "stac_extensions",
         "properties",
         "assets"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "timestamps"
+          }
+        },
         "properties": {
           "$ref": "#/definitions/all"
         },

--- a/extensions/version/json-schema/schema.json
+++ b/extensions/version/json-schema/schema.json
@@ -10,6 +10,9 @@
           "$ref": "../../../item-spec/json-schema/item.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "type": "object",
           "required": [
             "properties"
@@ -28,12 +31,29 @@
           "$ref": "../../../collection-spec/json-schema/collection.json"
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "$ref": "#/definitions/version_extension"
         }
       ]
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "version"
+          }
+        }
+      }
+    },
     "version_extension": {
       "type": "object",
       "required": [

--- a/extensions/view/json-schema/schema.json
+++ b/extensions/view/json-schema/schema.json
@@ -15,9 +15,16 @@
     "view": {
       "type": "object",
       "required": [
+        "stac_extensions",
         "properties"
       ],
       "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "view"
+          }
+        },
         "properties": {
           "type": "object",
           "anyOf": [

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -64,22 +64,7 @@
                   },
                   {
                     "title": "Reference to a core extension",
-                    "type": "string",
-                    "enum": [
-                      "checksum",
-                      "datacube",
-                      "eo",
-                      "label",
-                      "pointcloud",
-                      "projection",
-                      "sar",
-                      "sat",
-                      "scientific",
-                      "tiled-assets",
-                      "timestamps",
-                      "version",
-                      "view"
-                    ]
+                    "type": "string"
                   }
                 ]
               }


### PR DESCRIPTION
**Related Issue(s):** #826, #816, #624 


**Proposed Changes:**

1. Align label extension JSON Schema with rest of the extension schemas #624
2. Put stac_extension entries into extension schemas instead of core spec schemas #826 #816 
3. Make checksum extension schema also validate collections and catalogs.
4. Clarify in checksum extension that in can be used in collection assets, but can't be used in Item assets
5. Merge "Changed" sections in CHANGELOG

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
