### PR TITLE
Don't allow 5 elements in bbox

### DIFF
--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -106,8 +106,16 @@
                   "items": {
                     "title": "Spatial extent",
                     "type": "array",
-                    "minItems": 4,
-                    "maxItems": 6,
+                    "oneOf": [
+                      {
+                        "minItems":4,
+                        "maxItems":4
+                      },
+                      {
+                        "minItems":6,
+                        "maxItems":6
+                      }
+                    ],
                     "items": {
                       "type": "number"
                     }

--- a/extensions/projection/json-schema/schema.json
+++ b/extensions/projection/json-schema/schema.json
@@ -67,8 +67,16 @@
             "proj:bbox":{
               "title":"Extent",
               "type":"array",
-              "minItems":4,
-              "maxItems":6,
+              "oneOf": [
+                {
+                  "minItems":4,
+                  "maxItems":4
+                },
+                {
+                  "minItems":6,
+                  "maxItems":6
+                }
+              ],
               "items":{
                 "type":"number"
               }
@@ -105,8 +113,16 @@
             "proj:transform":{
               "title":"Transform",
               "type":"array",
-              "minItems":6,
-              "maxItems":9,
+              "oneOf": [
+                {
+                  "minItems":6,
+                  "maxItems":6
+                },
+                {
+                  "minItems":9,
+                  "maxItems":9
+                }
+              ],
               "items":{
                 "type":"number"
               }

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -75,7 +75,16 @@
             },
             "bbox": {
               "type": "array",
-              "minItems": 4,
+              "oneOf": [
+                {
+                  "minItems": 4,
+                  "maxItems": 4
+                },
+                {
+                  "minItems": 6,
+                  "maxItems": 6
+                }
+              ],
               "items": {
                 "type": "number"
               }


### PR DESCRIPTION
**Related Issue(s):** https://github.com/opengeospatial/ogcapi-features/issues/401


**Proposed Changes:**

1. Allow 4 or 6 elements in bboxes, not 5.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR https://github.com/radiantearth/stac-api-spec/issues/28 to track the change.
