### PR TITLE
remove reference to commons extension in single-file-stac

### DIFF
--- a/extensions/single-file-stac/README.md
+++ b/extensions/single-file-stac/README.md
@@ -8,8 +8,6 @@
 
 An extension to provide a set of Collections and Items within a single file catalog. The single file is a STAC catalog that contains everything that would normally be in a linked set of STAC files. This format is useful to save a portion of a catalog, or when creating a small catalog from derived data that should remain portable. It is most useful for saving the results of a search from a STAC API, as the Items, Collections, and optionally the search parameters are all saved within the single file. Hierarchical links have no meaning in a single file STAC, and so, if present, should be removed when creating a single file catalog.
 
-The Items in the single file catalog should not be merged with the Collection properties (i.e., common properties). The Collections are all included in the file as well, so there is no need to duplicate the common properties for every Item in the catalog.
-
 - [Example](examples/example-search.json)
 - [JSON Schema](json-schema/schema.json)
 


### PR DESCRIPTION
**Related Issue(s):** #
#840 

**Proposed Changes:**

1. Remove some old wording referencing commons extenson

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [n/a] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [n/a] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
