### PR TITLE
adding JSON schema for pointcloud extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- JSON-schema file in the Point Cloud extension.
 
 ### Changes
 

--- a/extensions/pointcloud/README.md
+++ b/extensions/pointcloud/README.md
@@ -38,17 +38,16 @@ the point cloud, their types, and their sizes (in full bytes).
 
 ### Stats Object
 
-A sequential array of items mapping to `pc:schemas` defines per-channel statistics. All fields
-are optional.
+A sequential array of items mapping to `pc:schemas` defines per-channel statistics. The channel name is required and at least one statistic.
 
 | Field Name | Type    | Description |
 | ---------- | ------- | ----------- |
+| name       | string  | **REQUIRED.** The name of the channel. |
+| position   | integer | Position of the channel in the schema. |
 | average    | number  | The average of the channel. |
 | count      | integer | The number of elements in the channel. |
 | maximum    | number  | The maximum value of the channel. |
 | minimum    | number  | The minimum value of the channel. |
-| name       | string  | The name of the channel. |
-| position   | integer | Position of the channel in the schema. |
 | stddev     | number  | The standard deviation of the channel. |
 | variance   | number  | The variance of the channel. |
 

--- a/extensions/pointcloud/README.md
+++ b/extensions/pointcloud/README.md
@@ -12,7 +12,7 @@ come from either active or passive sensors, and data is frequently acquired usin
 tools such as LiDAR or coincidence-matched imagery.
 
 - [Example](examples/example-autzen.json)
-- JSON Schema is missing. PRs are welcome.
+- [JSON Schema](json-schema/schema.json)
 
 ## Item Fields
 

--- a/extensions/pointcloud/README.md
+++ b/extensions/pointcloud/README.md
@@ -34,7 +34,7 @@ the point cloud, their types, and their sizes (in full bytes).
 | ---------- | ------- | -------------------------- |
 | name       | string  | **REQUIRED.** The name of the dimension. |
 | size       | integer | **REQUIRED.** The size of the dimension in bytes. Whole bytes only are supported. |
-| type       | string  | **REQUIRED.** Dimension type. Valid values include `floating`, `unsigned`, and `signed` |
+| type       | string  | **REQUIRED.** Dimension type. Valid values are `floating`, `unsigned`, and `signed` |
 
 ### Stats Object
 

--- a/extensions/pointcloud/json-schema/schema.json
+++ b/extensions/pointcloud/json-schema/schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/dev/extensions/pointcloud/json-schema/schema.json#",
+  "title": "Point Cloud Extension",
+  "description": "STAC Point Cloud Extension to a STAC Item",
+  "allOf": [
+    {
+      "$ref": "../../../item-spec/json-schema/item.json"
+    },
+    {
+      "$ref": "#/definitions/stac_extensions"
+    },
+    {
+      "$ref": "#/definitions/pointcloud"
+    }
+  ],
+  "definitions": {
+    "pointcloud": {
+      "type": "object",
+      "required": [
+        "stac_extensions",
+        "properties"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "pointcloud"
+          }
+        },
+        "properties": {
+          "type": "object",
+          "required": [
+            "pc:count",
+            "pc:type",
+            "pc:encoding",
+            "pc:schemas"
+          ],
+          "properties": {
+            "pc:count": {
+              "type": "number",
+              "multipleOf": 1.0
+            },
+            "pc:type": { "type": "string" },
+            "pc:encoding": { "type": "string" },
+            "pc:schemas": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/schema" }
+            },
+            "pc:density": { "type": "number"},
+            "pc:statistics": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/stats" }
+            }
+          }
+        }
+      }
+    },
+    "schema":{
+      "type": "object",
+      "properties": {
+        "name": {"type": "string" },
+        "size": {"type": "number", "multipleOf": 1.0 },
+        "type": {"type": "string" },
+        "required": ["name", "size", "type"]
+      }
+    },
+    "stats":{
+      "type": "object",
+      "properties": {
+        "average":  {"type": "number"},
+        "count":    {"type": "number", "multipleOf": 1.0 },
+        "maximum":  {"type": "number"},
+        "minimum":  {"type": "number"},
+        "name":     {"type": "string"},
+        "position": {"type": "number", "multipleOf": 1.0 },
+        "stddev":   {"type": "number"},
+        "variance": {"type": "number"}
+      }
+    }
+  }
+}

--- a/extensions/pointcloud/json-schema/schema.json
+++ b/extensions/pointcloud/json-schema/schema.json
@@ -5,7 +5,7 @@
   "description": "STAC Point Cloud Extension to a STAC Item",
   "allOf": [
     {
-      "$ref": "#/definitions/stac_extensions"
+      "$ref": "../../../item-spec/json-schema/item.json"
     },
     {
       "$ref": "#/definitions/pointcloud"

--- a/extensions/pointcloud/json-schema/schema.json
+++ b/extensions/pointcloud/json-schema/schema.json
@@ -5,9 +5,6 @@
   "description": "STAC Point Cloud Extension to a STAC Item",
   "allOf": [
     {
-      "$ref": "../../../item-spec/json-schema/item.json"
-    },
-    {
       "$ref": "#/definitions/stac_extensions"
     },
     {
@@ -25,7 +22,10 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "pointcloud"
+            "enum": [
+              "pointcloud",
+              "https://schemas.stacspec.org/dev/extensions/pointcloud/json-schema/schema.json"
+            ]
           }
         },
         "properties": {
@@ -38,44 +38,92 @@
           ],
           "properties": {
             "pc:count": {
-              "type": "number",
-              "multipleOf": 1.0
+              "type": "integer",
+              "minimum": 0
             },
-            "pc:type": { "type": "string" },
-            "pc:encoding": { "type": "string" },
+            "pc:type": {
+              "type": "string"
+            },
+            "pc:encoding": {
+              "type": "string"
+            },
             "pc:schemas": {
               "type": "array",
-              "items": { "$ref": "#/definitions/schema" }
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/schema"
+              }
             },
-            "pc:density": { "type": "number"},
+            "pc:density": {
+              "type": "number",
+              "minimum": 0
+            },
             "pc:statistics": {
               "type": "array",
-              "items": { "$ref": "#/definitions/stats" }
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/stats"
+              }
             }
           }
         }
       }
     },
-    "schema":{
+    "schema": {
       "type": "object",
+      "required": [
+        "name",
+        "size",
+        "type"
+      ],
       "properties": {
-        "name": {"type": "string" },
-        "size": {"type": "number", "multipleOf": 1.0 },
-        "type": {"type": "string" },
-        "required": ["name", "size", "type"]
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "floating",
+            "unsigned",
+            "signed"
+          ]
+        }
       }
     },
-    "stats":{
+    "stats": {
       "type": "object",
+      "minProperties": 2,
+      "required": [
+        "name",
+      ],
       "properties": {
-        "average":  {"type": "number"},
-        "count":    {"type": "number", "multipleOf": 1.0 },
-        "maximum":  {"type": "number"},
-        "minimum":  {"type": "number"},
-        "name":     {"type": "string"},
-        "position": {"type": "number", "multipleOf": 1.0 },
-        "stddev":   {"type": "number"},
-        "variance": {"type": "number"}
+        "name": {
+          "type": "string"
+        },
+        "position": {
+          "type": "integer"
+        },
+        "average": {
+          "type": "number"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "stddev": {
+          "type": "number"
+        },
+        "variance": {
+          "type": "number"
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "remark-preset-lint-consistent": "^3.0.0",
     "remark-preset-lint-markdown-style-guide": "^3.0.0",
     "remark-preset-lint-recommended": "^4.0.0",
-    "remark-validate-links": "^10.0.0",
-    "stac-node-validator": "^0.2.1"
+    "remark-validate-links": "^10.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "remark-preset-lint-consistent": "^3.0.0",
     "remark-preset-lint-markdown-style-guide": "^3.0.0",
     "remark-preset-lint-recommended": "^4.0.0",
-    "remark-validate-links": "^10.0.0"
+    "remark-validate-links": "^10.0.0",
+    "stac-node-validator": "^0.2.1"
   }
 }


### PR DESCRIPTION
Noticed there hadn't been any updates on this for a few months and thought I would give it a try (Sorry @adamsteer. If you already have something put together, I'm happy removing this PR.) I'm new to JSON schema so happy to get feedback.

One thing that I wasn't quite sure about was adding Property Dependencies on Statistics. So if a `stats` object is given, there should also be a `schema` object with the same name.

**Related Issue(s):** #391 

**Proposed Changes:**

1. Adding schema file for pointcloud extension.

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
