### PR TITLE
Updating contributing docs to use jsonformatter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ system. Please use `check-markdown` locally, as described in the [next section](
 to ensure that the checks on the pull request succeed. If it does not then you can look at the
 mistakes online, which are the same as running `check-markdown` locally would surface.
 
-All pull requests that modify or create JSON schema files should use https://jsonformatter.org/ to keep files consistent across the repo. 
+All pull requests that modify or create JSON schema files should use [JSON formatter](https://jsonformatter.org/) to keep files consistent across the repo. 
 
 All pull requests additionally require a review of two STAC core team members. Releases are cut
 from dev to master (and require 3 approvals), see the [process](process.md) document for more details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ system. Please use `check-markdown` locally, as described in the [next section](
 to ensure that the checks on the pull request succeed. If it does not then you can look at the
 mistakes online, which are the same as running `check-markdown` locally would surface.
 
+All pull requests that modify or create JSON schema files should use https://jsonformatter.org/ to keep files consistent across the repo. 
+
 All pull requests additionally require a review of two STAC core team members. Releases are cut
 from dev to master (and require 3 approvals), see the [process](process.md) document for more details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ system. Please use `check-markdown` locally, as described in the [next section](
 to ensure that the checks on the pull request succeed. If it does not then you can look at the
 mistakes online, which are the same as running `check-markdown` locally would surface.
 
-All pull requests that modify or create JSON schema files should use [JSON formatter](https://jsonformatter.org/) to keep files consistent across the repo. 
+All pull requests that modify or create JSON schema files or examples should use [JSON formatter](https://jsonformatter.org/) to keep files consistent across the repo. 
 
 All pull requests additionally require a review of two STAC core team members. Releases are cut
 from dev to master (and require 3 approvals), see the [process](process.md) document for more details.


### PR DESCRIPTION
**Proposed Changes:**

1. Simple change to the CONTRIBUTING doc to add a note about passing schema files through jsonformatter for consistency.

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
