### PR TITLE
Fix SAR extension example

### DIFF
--- a/extensions/sar/examples/sentinel1.json
+++ b/extensions/sar/examples/sentinel1.json
@@ -65,7 +65,7 @@
       "href": "./measurement/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.tiff",
       "title": "Measurements",
       "type": "image/tiff",
-      "sar:bands": ["HH"],
+      "sar:polarizations": ["HH"],
       "checksum:multihash": "90e40210163700a8a6501eccd00b6d3b44ddaed0"
     },
     "thumbnail": {


### PR DESCRIPTION
**Proposed Changes:**

Just a fix for this SAR extension example, as `sar:bands` is no longer part of the spec.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
