### PR TITLE
Remove duplicate "collection" from example

### DIFF
--- a/item-spec/examples/sentinel2-sample.json
+++ b/item-spec/examples/sentinel2-sample.json
@@ -6,7 +6,6 @@
   ],
   "type": "Feature",
   "id": "S2A_OPER_MSI_L2A_TL_SGS__20180524T190423_A015250_T26SKD_N02.08",
-  "collection": "sentinel-s2-l2a",
   "links": [
     {
       "rel": "self",


### PR DESCRIPTION
While technically valid JSON, having two "collection" keys generally means the first value is ignored, and is likely to cause confusion.

**Related Issue(s):** #
No related issue, figured a PR would be better than a issue

**Proposed Changes:**

1. Removes a duplicate "collection" key from a example

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.

SInce this was a minor change, I have not done the following:
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
