### PR TITLE
Spelling fixes for things found with codespell

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -30,7 +30,7 @@ on the extension.
 | Pilot                   | 1           | Idea is fleshed out, with examples and a JSON schema, and implemented in one or more catalogs. Additional implementations encouraged to help give feedback | Approaching stability - breaking changes are not anticipated but can easily come from additional feedback |
 | Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. |
 | Stable                  | 6           | Highest current level of maturity. The community of extension maintainers commits to a STAC review process for any changes, which are not made lightly. | Completely stable, all changes require a new version number and review process. |
-| Deprecated              | N/A         | A previous extension that has likely been superceded by a newer one or did not work out for some reason. | DO NOT USE, is not supported |
+| Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | DO NOT USE, is not supported |
 
 Maturity mostly comes through diverse implementations, so the minimum number of implementations
 column is the main gating function for an extension to mature. But extension authors can also

--- a/extensions/label/README.md
+++ b/extensions/label/README.md
@@ -145,7 +145,7 @@ The raster label file (e.g. a GeoTIFF) should be included as an asset under the 
 The source imagery used for creating the label is linked to under `links` (see below). However the source imagery is likely to have been rendered in some way when creating the training data. For instance, a byte-scaled true color image may have been created from the source imagery. It may be useful to save this image and include it as an asset in the `Item`.
 
 #### Links: source imagery
-A Label Item links to any source imagery that the AOI applys to by linking to the STAC Item representing the imagery. Source imagery is indicated by using a `rel` type of "source" and providing the link to the STAC Item.
+A Label Item links to any source imagery that the AOI applies to by linking to the STAC Item representing the imagery. Source imagery is indicated by using a `rel` type of "source" and providing the link to the STAC Item.
 
 In addition the source imagery link has a new label extension specific field:
 

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -38,7 +38,7 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 
 **sar:polarizations** specifies a single polarization or a polarization combination. For single polarized radars one of `HH`, `VV`, `HV` or `VH` must be set. Fully polarimetric radars add all four polarizations to the array. Dual polarized radars and alternating polarization add the corresponding polarizations to the array, for instance for `HH+HV` add both `HH` and `HV`.
 
-**sar:product_type**: The product type defines the type of procesed data contained in the assets. A list of suggestions include:
+**sar:product_type**: The product type defines the type of processed data contained in the assets. A list of suggestions include:
 
 | sar:product_type  | Type      | Description |
 | ----------------- | --------- | ----------- |

--- a/extensions/sat/README.md
+++ b/extensions/sat/README.md
@@ -24,7 +24,7 @@ The Satellite extension requires the [Instrument Fields](../../item-spec/common-
 
 **sat:orbit_state** indicates the type and current state of orbit. Satellites are either geosynchronous in which case they have one state: `geostationary`, or they are sun synchronous (i.e., polar orbiting satellites) in which case they are either `ascending` or `descending`. For sun synchronous satellites it is daytime during one of these states, and nighttime during the other.
 
-**sat:relative_orbit** is a count of orbits from 1 to the number of orbits contained in a repeat cycle, where relative orbit 1 starts from a specific reference location of the sub-satellite point (the point on the earth directly below the satellite). It resets to 1 when the sub-satellite point revisits the refernece location.
+**sat:relative_orbit** is a count of orbits from 1 to the number of orbits contained in a repeat cycle, where relative orbit 1 starts from a specific reference location of the sub-satellite point (the point on the earth directly below the satellite). It resets to 1 when the sub-satellite point revisits the reference location.
 
 ## Implementations
 

--- a/extensions/tiled-assets/README.md
+++ b/extensions/tiled-assets/README.md
@@ -49,7 +49,7 @@ This object allows to reference a tile matrix set. This concept is modelled afte
 **url**/**well_known_scale_set**: Either one of these parameters must be present.
 
 **url**: The URL must refer to a valid tile matrix set definition as defined in the Two-dimensional tile matrix set specification in any encoding (JSON, JSON-LD, or XML).
-It is also possible, to have the tile matrix set embedded in the items collection, catalog or even in the items file itself using the `tiles:tile_matrix_sets` property. When refering to an embedded tile matrix set definition, the name of the map key of that tile matrix set definition must be used as a URL fragment.
+It is also possible, to have the tile matrix set embedded in the items collection, catalog or even in the items file itself using the `tiles:tile_matrix_sets` property. When referring to an embedded tile matrix set definition, the name of the map key of that tile matrix set definition must be used as a URL fragment.
 
 Example reference to an external tile matrix definition:
 
@@ -87,7 +87,7 @@ This object allows to specify subset region of the source tileset. This concept 
 
 ### Pixel Buffer Object
 
-Pixel buffer objects allow the definition of image boundarys, so that the internal tiles may overlap. When using this information, the clients may be able to reduce the number of requests.
+Pixel buffer objects allow the definition of image boundaries, so that the internal tiles may overlap. When using this information, the clients may be able to reduce the number of requests.
 
 | Field Name    | Type    | Description                                                                                                        |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |

--- a/principles.md
+++ b/principles.md
@@ -31,7 +31,7 @@ for data in a different projection.
 * **Working code required.** Proposed changes should be accompanied by working code
 (ideally with a link to an online service running the code). A reference implementation should be available
 online to power the interactive documentation. Fully accepted specifications should have at least 3 implementations
-that cover the entire specification. Extensions have their own[Extension Maturity](./extensions/README.md#extension-maturity) model.
+that cover the entire specification. Extensions have their own [Extension Maturity](./extensions/README.md#extension-maturity) model.
 
 * **Design for scale.** The design should work great with more data than can be imagined right now.
 Ideally implementations are built with large test data sets to validate that they will work.

--- a/principles.md
+++ b/principles.md
@@ -31,7 +31,7 @@ for data in a different projection.
 * **Working code required.** Proposed changes should be accompanied by working code
 (ideally with a link to an online service running the code). A reference implementation should be available
 online to power the interactive documentation. Fully accepted specifications should have at least 3 implementations
-that cover the entire specification. Extensions have their own[Extention Maturity](./extensions/README.md#extension-maturity) model.
+that cover the entire specification. Extensions have their own[Extension Maturity](./extensions/README.md#extension-maturity) model.
 
 * **Design for scale.** The design should work great with more data than can be imagined right now.
 Ideally implementations are built with large test data sets to validate that they will work.


### PR DESCRIPTION
Fixes to spelling errors found with codespell version 1.16.0.

Pretty unexciting stuff.

**Related Issue(s):** None


**Proposed Changes:**

1. Spelling corrections - No functional changes

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change. - I don't think it's worth an issue
