### PR TITLE
Including gsd field for assets with resolution distinct from the valu…

### DIFF
--- a/item-spec/examples/sentinel2-sample.json
+++ b/item-spec/examples/sentinel2-sample.json
@@ -123,78 +123,93 @@
     "B02_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B02.jp2",
       "title": "Band 2 - Blue 0.490 (20m)",
-
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "B03_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B03.jp2",
       "title": "Band 3 - Green 0.560 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
+
     },
     "B04_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B04.jp2",
       "title": "Band 4 - Red 0.665 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "B05_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B05.jp2",
       "title" : "Band 5 - Vegetation Red Edge 0.705 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "B06_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B06.jp2",
       "title": "Band 6 - Vegetation Red Edge 0.740 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "B07_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B07.jp2",
       "title": "Band 7 - Vegetation Red Edge 0.783 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "B8A_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B8A.jp2",
       "title": "Band 8A - Narrow NIR 0.865 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "B11_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B11.jp2",
       "title": "Band 11 - SWIR 1.610 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "B12_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/B12.jp2",
       "title": "Band 12 - SWIR 2.190 (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "AOT_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/AOT.jp2",
       "title": "Aerosol Optical Thickness (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "SCL_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/SCL.jp2",
       "title": "Scene Classification (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "TCI_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/TCI.jp2",
       "title": "True Color Image (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "WVP_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/R20m/WVP.jp2",
       "title": "Water Vapor (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "CLD_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/qi/CLD_20m.jp2",
       "title": "Cloud (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     },
     "SNW_20m": {
       "href": "s3://sentinel-s2-l2a/tiles/35/V/MK/2018/6/5/0/qi/SNW_20m.jp2",
       "title": "Snow (20m)",
-      "type": "image/jp2"
+      "type": "image/jp2",
+      "gsd": 20
     }
   }
 }


### PR DESCRIPTION
…e defined at properties level.

**Related Issue(s):** #NA


**Proposed Changes:**

1. Including gsd value back in S2 example for assets with resolution distinct from the 10m value defined at properties. 

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] This PR does not affect the [STAC API spec](https://github.com/radiantearth/stac-api-spec)
