### PR TITLE
Add clarification around collection-level assets in item-assets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added clarification about how collection-level assset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))
+
 ### Changed
 
 ### Removed
@@ -119,10 +121,10 @@ Item properties
   - `search` extension renamed to `context` extension. JSON object renamed from `search:metadata` to `context`
   - Removed "next" from the search metadata and query parameter, added POST body and headers to the links for paging support
   - Query Extension - type restrictions on query predicates are more accurate, which may require additional implementation support
-- Item `title` definition moved from core Item fields to [Common Metadata Basics](item-spec/common-metadata.md#basics) 
+- Item `title` definition moved from core Item fields to [Common Metadata Basics](item-spec/common-metadata.md#basics)
 fields. No change is required for STAC Items.
 - `putFeature` can return a `PreconditionFailed` to provide more explicit information when the resource has changed in the server
-- [Sort extension](https://github.com/radiantearth/stac-api-spec/tree/master/extensions/sort) now uses "+" and "-" prefixes for GET requests to denote sort order. 
+- [Sort extension](https://github.com/radiantearth/stac-api-spec/tree/master/extensions/sort) now uses "+" and "-" prefixes for GET requests to denote sort order.
 - Clarified how `/search` links must be added to `/` and changed that links to both GET and POST must be provided now that the method can be specified in links
 
 ### Removed

--- a/extensions/item-assets/README.md
+++ b/extensions/item-assets/README.md
@@ -42,7 +42,8 @@ However, it is recommended that the Asset Definition is a complete set of all as
 
 Other custom fields, or fields from other extensions may also be included in the Asset object.
 
-Any property that exists for a collection-level asset object must also exist in the correspond assets object in each item. If a collection's asset object contains properties that are not explicitly stated in the item's asset object then that property does not apply to the item's asset. Collection-level asset objects can describe any of the properties of an asset, but those assets properties and values must also reside in the item's asset object.
+Any property that exists for a collection-level asset object must also exist in the corresponding assets object in each item. If a collection's asset object contains properties that are not explicitly stated in the item's asset object then that property does not apply to the item's asset. Item asset objects at the collection-level can describe any of the properties of an asset, but those assets properties and values must also reside in the item's asset object.
+To consolidate item-level asset object properties in an API setting, consider storing the STAC items without the larger properties internally as 'invalid' STAC items, and merge in the desired properties at serving time from the collection-level.
 
 At least two fields (e.g. `title` and `type`) are required to be provided, in order for it to adequately describe Item assets.
 The two fields must not necessarily be taken from the list above and may include any custom field.

--- a/extensions/item-assets/README.md
+++ b/extensions/item-assets/README.md
@@ -42,6 +42,8 @@ However, it is recommended that the Asset Definition is a complete set of all as
 
 Other custom fields, or fields from other extensions may also be included in the Asset object.
 
+Any property that exists for a collection-level asset object must also exist in the correspond assets object in each item. If a collection's asset object contains properties that are not explicitly stated in the item's asset object then that property does not apply to the item's asset. Collection-level asset objects can describe any of the properties of an asset, but those assets properties and values must also reside in the item's asset object.
+
 At least two fields (e.g. `title` and `type`) are required to be provided, in order for it to adequately describe Item assets.
 The two fields must not necessarily be taken from the list above and may include any custom field.
 


### PR DESCRIPTION
This PR adds language to the `item-assets` spec to clarify that collection-level asset objects should not contain properties that are not explicitly stated in the item's asset objects themselves.

This comes out of a discussion during STAC Sprint 6. It was determined that while allowing for asset properties to be defined in _only_ the collection-level asset objects was a way to save space, it would be more in line with the spec to have items explicitly contain all asset property information.

If you're currently using the item-assets extension to consolidate item-level asset object properties in an API setting, consider storing the STAC items without those consolidated properties internally as 'invalid' STAC items, and merge in the desired collection-level asset object properties at serving time.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
