### PR TITLE
Removed label:classes from required properties in label item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Label extension: `label:classes` was flagged as required when not always required.
 
 ## [v1.0.0-beta.2] - 2020-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Label extension: `label:classes` was flagged as required when not always required.
+- Label extension: `label:classes` was flagged as required in JSON Schema, but is only required for categorical data.
 
 ## [v1.0.0-beta.2] - 2020-07-08
 

--- a/extensions/label/json-schema/schema.json
+++ b/extensions/label/json-schema/schema.json
@@ -32,7 +32,6 @@
           "type": "object",
           "required": [
             "label:properties",
-            "label:classes",
             "label:description",
             "label:type"
           ],


### PR DESCRIPTION
**Related Issue(s):** #904 


**Proposed Changes:**

1. Changes the label:classes property to not be required in the JSON schema

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
