### PR TITLE
Modify valid range for sun_elevation to be -90-90.

### DIFF
--- a/extensions/view/README.md
+++ b/extensions/view/README.md
@@ -20,7 +20,7 @@ This document explains the fields of the View Geometry Extension to a STAC Item.
 | view:incidence_angle | number               | The incidence angle is the angle between the vertical (normal) to the intercepting surface and the line of sight back to the satellite at the scene center. Measured in degrees (0-90). |
 | view:azimuth         | number               | Viewing azimuth angle. The angle measured from the sub-satellite point (point on the ground below the platform) between the scene center and true north. Measured clockwise from north in degrees (0-360). |
 | view:sun_azimuth     | number               | Sun azimuth angle. From the scene center point on the ground, this is the angle between truth north and the sun. Measured clockwise in degrees (0-360). |
-| view:sun_elevation   | number               | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (-90-90). |
+| view:sun_elevation   | number               | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (`-90`-`90`). Negative values indicate the sun is below the horizon, e.g. this data was captured at night. |
 
 *At least one of the fields must be specified.*
 

--- a/extensions/view/README.md
+++ b/extensions/view/README.md
@@ -20,7 +20,7 @@ This document explains the fields of the View Geometry Extension to a STAC Item.
 | view:incidence_angle | number               | The incidence angle is the angle between the vertical (normal) to the intercepting surface and the line of sight back to the satellite at the scene center. Measured in degrees (0-90). |
 | view:azimuth         | number               | Viewing azimuth angle. The angle measured from the sub-satellite point (point on the ground below the platform) between the scene center and true north. Measured clockwise from north in degrees (0-360). |
 | view:sun_azimuth     | number               | Sun azimuth angle. From the scene center point on the ground, this is the angle between truth north and the sun. Measured clockwise in degrees (0-360). |
-| view:sun_elevation   | number               | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (0-90). |
+| view:sun_elevation   | number               | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (-90-90). |
 
 *At least one of the fields must be specified.*
 

--- a/extensions/view/README.md
+++ b/extensions/view/README.md
@@ -20,7 +20,7 @@ This document explains the fields of the View Geometry Extension to a STAC Item.
 | view:incidence_angle | number               | The incidence angle is the angle between the vertical (normal) to the intercepting surface and the line of sight back to the satellite at the scene center. Measured in degrees (0-90). |
 | view:azimuth         | number               | Viewing azimuth angle. The angle measured from the sub-satellite point (point on the ground below the platform) between the scene center and true north. Measured clockwise from north in degrees (0-360). |
 | view:sun_azimuth     | number               | Sun azimuth angle. From the scene center point on the ground, this is the angle between truth north and the sun. Measured clockwise in degrees (0-360). |
-| view:sun_elevation   | number               | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (`-90`-`90`). Negative values indicate the sun is below the horizon, e.g. this data was captured at night. |
+| view:sun_elevation   | number               | Sun elevation angle. The angle from the tangent of the scene center point to the sun. Measured from the horizon in degrees (`-90`-`90`). Negative values indicate the sun is below the horizon, Negative values indicate the sun is below the horizon, e.g. sun elevation of -10° means the data was captured during [nautical twilight](https://www.timeanddate.com/astronomy/different-types-twilight.html). |
 
 *At least one of the fields must be specified.*
 

--- a/extensions/view/json-schema/schema.json
+++ b/extensions/view/json-schema/schema.json
@@ -65,7 +65,7 @@
             "view:sun_elevation": {
               "title": "Sun Elevation",
               "type": "number",
-              "minimum": 0,
+              "minimum": -90,
               "maximum": 90
             }
           }


### PR DESCRIPTION
Fixes #853

**Related Issue(s):** #853


**Proposed Changes:**

As mentioned in #853, a negative view angle can be validly recorded in remove sensing data. Besides the example listed by the issue author, I've hit up against this in ASTER L1T data, in which the [product specification](https://lpdaac.usgs.gov/documents/300/ASTER_L1T_Product_Specification.pdf) states values will range from -90 to 90, and a many of the images record such a value in the HDF metadata.

This change modifies the spec text and JSON schema to allow for sun_elevation values ranging from -90 to 90.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] ~~This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.~~
