### PR TITLE
Add implementation links to pystac for sat, scientific, and version.

### DIFF
--- a/extensions/sat/README.md
+++ b/extensions/sat/README.md
@@ -28,7 +28,7 @@ The Satellite extension requires the [Instrument Fields](../../item-spec/common-
 
 ## Implementations
 
-- No implementations yet
+- [pystac](https://github.com/stac-utils/pystac/blob/develop/pystac/extensions/sat.py)
 
 ## Extensions
 

--- a/extensions/scientific/README.md
+++ b/extensions/scientific/README.md
@@ -60,4 +60,4 @@ This extension adds the following types as applicable `rel` types for the [Link 
 
 ## Implementations
 
-None yet, still in proposal stage.
+- [pystac](https://github.com/stac-utils/pystac/blob/develop/pystac/extensions/scientific.py)

--- a/extensions/version/README.md
+++ b/extensions/version/README.md
@@ -34,4 +34,4 @@ The following types should be used as applicable `rel` types for the [Link Objec
 
 ## Implementations
 
-None yet, still in proposal stage.
+- [pystac](https://github.com/stac-utils/pystac/blob/develop/pystac/extensions/version.py)


### PR DESCRIPTION
**Related Issue(s):** #

None

**Proposed Changes:**

1. Added implementation links for the sat, scientific, and version extensions in pystac

**PR Checklist:**

- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
  - I don't think this warrants a CHANGELOG entry, but I can add one if folks thing there should be one 
- I only added the extensions that I implemented.  I can add links for the rest of the pystac extensions if folks want.