### PR TITLE
JSON Schema for `sar:polarizations` in `assets` fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Label extension: `label:classes` was flagged as required in JSON Schema, but is only required for categorical data.
+- JSON Schema for `sar:polarizations` in `assets` fixed
 
 ## [v1.0.0-beta.2] - 2020-07-08
 
@@ -88,7 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - New [View Geometry Extension](extensions/view/README.md)
 - STAC API:
   - Added the [Item and Collection API Version extension](https://github.com/radiantearth/stac-api-spec/tree/master/extensions/version/README.md) to support versioning in the API specification
-  - Run `npm run serve` or `npm run serve-ext` to quickly render development versions of the OpenAPI spec in the browser
+  - Run `npm run serve` or `npm run serve-ext` to quickly render development versions of the OpenAPI spec in the browser
 - [Basics](item-spec/common-metadata.md#basics) added to Common Metadata definitions with new `description` field for
 Item properties
 - New fields to the `link` object to facilitate [pagination support for POST requests](https://github.com/radiantearth/stac-api-spec/tree/master/api-spec.md#paging-extension)

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -62,20 +62,7 @@
               "type": "number"
             },
             "sar:polarizations": {
-              "title": "Polarizations",
-              "type": "array",
-              "minItems": 1,
-              "maxItems": 4,
-              "uniqueItems": true,
-              "items": {
-                "type": "string",
-                "enum": [
-                  "HH",
-                  "VV",
-                  "HV",
-                  "VH"
-                ]
-              }
+              "$ref": "#/definitions/polarizations"
             },
             "sar:product_type": {
               "title": "Product type",
@@ -133,26 +120,28 @@
         },
         "assets": {
           "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "properties": {
-              "sar:polarizations": {
-                "title": "Polarizations",
-                "type": "array",
-                "minItems": 1,
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "HH",
-                    "VV",
-                    "HV",
-                    "VH"
-                  ]
-                }
-              }
+          "properties": {
+            "sar:polarizations": {
+              "$ref": "#/definitions/polarizations"
             }
           }
         }
+      }
+    },
+    "polarizations": {
+      "title": "Polarizations",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "HH",
+          "VV",
+          "HV",
+          "VH"
+        ]
       }
     }
   }


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. The field `sar:polarizations` in assets was not validated correctly.
2. Also centralized the `sar:polarizations` definition (for re-use).

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
