### PR TITLE
Fixed JSON Schema for `providers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Label extension: `label:classes` was flagged as required in JSON Schema, but is only required for categorical data.
+- Fixed JSON Schema for `providers` (Collections and Items) to be an object and require a `name`.
 
 ## [v1.0.0-beta.2] - 2020-07-08
 

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -54,6 +54,10 @@
         "providers": {
           "type": "array",
           "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "title": "Organization name",

--- a/item-spec/json-schema/provider.json
+++ b/item-spec/json-schema/provider.json
@@ -8,6 +8,10 @@
       "title": "Providers",
       "type": "array",
       "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "title": "Organization name",


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. Fixed JSON Schema for `providers` (Collections and Items) to be an object and require a `name`

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
