### PR TITLE
Only use "cite-as" link to refer to main publication for data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
- - 'via' and 'canonical' rel types as options in items.
-
-- Added clarification about how collection-level assset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))
+- 'via' and 'canonical' rel types as options in items.
+- Added clarification about how collection-level asset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))
 - Added [processing extension](extensions/processing/README.md)
 - Added additional acquisition parameters in the `sat` extension: sat:platform_international_designator, sat:absolute_orbit, sat:anx_datetime* ([#894](https://github.com/radiantearth/stac-spec/pull/894))
 
@@ -34,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Clarification on null geometries, making bbox not required if a null geometry is used.
 - Multiple extents (bounding boxes / intervals) are allowed per Collection
+- In the scientific extension, a link with the rel-type 'cite-as' SHOULD be used for the main publication of the dataset (the same as the one described in `sci:doi`), and not for the DOIs referenced in the `sci:publications` property.
 
 ### Removed
 - Validation instructions

--- a/extensions/scientific/README.md
+++ b/extensions/scientific/README.md
@@ -56,7 +56,7 @@ This extension adds the following types as applicable `rel` types for the [Link 
 
 | Type    | Description |
 | ------- | ----------- |
-| cite-as | For all DOI names specified the respective DOI links SHOULD be added to the links section with the `rel` type `cite-as` (see the [RFC 8574](https://tools.ietf.org/html/rfc8574)). |
+| cite-as | A DOI link SHOULD be added to the links section for the publication referenced by the `sci:doi` property with the `rel` type `cite-as` (see the [RFC 8574](https://tools.ietf.org/html/rfc8574)). |
 
 ## Implementations
 

--- a/extensions/scientific/examples/collection.json
+++ b/extensions/scientific/examples/collection.json
@@ -38,10 +38,6 @@
     {
       "rel": "cite-as",
       "href": "https://doi.org/10.5061/dryad.s2v81.2"
-    },
-    {
-      "rel": "cite-as",
-      "href": "https://doi.org/10.1038/sdata.2017.78"
     }
   ]
 }

--- a/extensions/scientific/examples/item.json
+++ b/extensions/scientific/examples/item.json
@@ -49,14 +49,6 @@
     {
       "rel": "cite-as",
       "href": "https://doi.org/10.5061/dryad.s2v81.2/27.2"
-    },
-    {
-      "rel": "cite-as",
-      "href": "https://doi.org/10.5061/dryad.s2v81.2"
-    },
-    {
-      "rel": "cite-as",
-      "href": "https://doi.org/10.1038/sdata.2017.78"
     }
   ],
   "assets": {


### PR DESCRIPTION
**Related Issue(s):** #915


**Proposed Changes:**

1. Modify the scientific extension to state that the main DOI of the data should be linked with a reltype `cite-as`, removing the language that indicated that also the DOIs referenced in the `sci:publications` properties should have links with reltype 'cite-as'.
2. Modified the examples to reflect these changes.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] ~~This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.~~
