### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# This file tells GitHub who should "own" different extensions.
+# Ownership for us means:
+# - owners are (automatically) requested for review on any PR touching code in
+#   the extensions that they own
+# - owners are shown in the UI in GitHub when someone is browsing files
+#
+# For more information about this file format see an example in the GitHub
+# documentation:
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file
+#
+# For more information about code owners in general, start at the beginning of that page'
+# instead of at the example file:
+#
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+/extensions/collection-assets/ @m-mohr
+/extensions/datacube/ @m-mohr
+/extensions/eo/ @matthewhanson
+/extensions/file/ @m-mohr
+/extensions/item-assets/ @matthewhanson
+/extensions/label/ @jisantuc
+/extensions/pointcloud/ @matthewhanson
+/extensions/processing/ @emmanuelmathot
+/extensions/projection/ @matthewhanson
+/extensions/sar/ @emmanuelmathot @m-mohr
+/extensions/sat/ @emmanuelmathot
+/extensions/scientific/ @m-mohr
+/extensions/single-file-stac/ @matthewhanson
+/extensions/tiled-assets/ @constantinius
+/extensions/timestamps/ @m-mohr
+/extensions/version/ @m-mohr
+/extensions/view/ @matthewhanson

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ It includes things like the spatial and temporal extent of the data, the license
 It enables discovery at a higher level than individual items, providing a simple way to describe sets of data.
 
 **Extensions:** The *[extensions/](extensions/)* folder is where extensions live. Extensions can extend the 
-functionality of the core spec or add fields for specific domains.
+functionality of the core spec or add fields for specific domains. Each extension has at least one _owner_. You can find extension owners in each extension's README or in the [`CODEOWNERS`](.github/CODEOWNERS) file.
 
 **Additional documents:** The supporting documents include a complementary [best practices](best-practices.md) 
 document, and information on contributing (links in the next section). We also maintain a [changelog](CHANGELOG.md) of

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ It includes things like the spatial and temporal extent of the data, the license
 It enables discovery at a higher level than individual items, providing a simple way to describe sets of data.
 
 **Extensions:** The *[extensions/](extensions/)* folder is where extensions live. Extensions can extend the 
-functionality of the core spec or add fields for specific domains. Each extension has at least one _owner_. You can find extension owners in each extension's README or in the [`CODEOWNERS`](.github/CODEOWNERS) file.
+functionality of the core spec or add fields for specific domains. Each extension has at least one *owner*. You can find extension owners in each extension's README or in the [`CODEOWNERS`](.github/CODEOWNERS) file.
 
 **Additional documents:** The supporting documents include a complementary [best practices](best-practices.md) 
 document, and information on contributing (links in the next section). We also maintain a [changelog](CHANGELOG.md) of

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -28,7 +28,7 @@ on the extension.
 | ----------------------- | ----------- | ----------- | --------- |
 | Proposal                | 0           | An idea put forward by a community member to gather feedback | Not stable - breaking changes almost guaranteed as implementers try out the idea. |
 | Pilot                   | 1           | Idea is fleshed out, with examples and a JSON schema, and implemented in one or more catalogs. Additional implementations encouraged to help give feedback | Approaching stability - breaking changes are not anticipated but can easily come from additional feedback |
-| Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. The extension has a [code owner](../.github/CODEOWNERS).|
+| Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. The extension has a [code owner](../.github/CODEOWNERS). |
 | Stable                  | 6           | Highest current level of maturity. The community of extension maintainers commits to a STAC review process for any changes, which are not made lightly. | Completely stable, all changes require a new version number and review process. |
 | Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | DO NOT USE, is not supported |
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -28,7 +28,7 @@ on the extension.
 | ----------------------- | ----------- | ----------- | --------- |
 | Proposal                | 0           | An idea put forward by a community member to gather feedback | Not stable - breaking changes almost guaranteed as implementers try out the idea. |
 | Pilot                   | 1           | Idea is fleshed out, with examples and a JSON schema, and implemented in one or more catalogs. Additional implementations encouraged to help give feedback | Approaching stability - breaking changes are not anticipated but can easily come from additional feedback |
-| Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. |
+| Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. The extension has a [code owner](../.github/CODEOWNERS).|
 | Stable                  | 6           | Highest current level of maturity. The community of extension maintainers commits to a STAC review process for any changes, which are not made lightly. | Completely stable, all changes require a new version number and review process. |
 | Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | DO NOT USE, is not supported |
 

--- a/extensions/collection-assets/README.md
+++ b/extensions/collection-assets/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: -**
 - **Scope: Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @m-mohr
 
 A Collection extension to provide a way to specify assets available on the collection-level.
 

--- a/extensions/datacube/README.md
+++ b/extensions/datacube/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: cube**
 - **Scope: Item, Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @m-mohr
 
 Data cube related metadata, especially to describe their dimensions.
 

--- a/extensions/eo/README.md
+++ b/extensions/eo/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: eo**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @matthewhanson
 
 This document explains the fields of the STAC Electro-Optical (EO) Extension to a STAC Item. 
 

--- a/extensions/file/README.md
+++ b/extensions/file/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: file**
 - **Scope: Item, Catalog, Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @m-mohr
 
 Provides a way to specify file related details such as checksum, data type and size for assets and links in [STAC Items](../../item-spec/item-spec.md), [STAC Catalogs](../../catalog-spec/catalog-spec.md) and [STAC Collections](../../collection-spec/collection-spec.md).
 

--- a/extensions/item-assets/README.md
+++ b/extensions/item-assets/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: -**
 - **Scope: Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @matthewhanson
 
 A Collection extension to provide details about assets that are available in member Items.
 

--- a/extensions/label/README.md
+++ b/extensions/label/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: label**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @jisantuc
 
 This extension is meant to support using labeled AOIs with Machine Learning models, particularly training data sets, but can be used in any application where labeled AOIs are needed.
 

--- a/extensions/pointcloud/README.md
+++ b/extensions/pointcloud/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: pc**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @matthewhanson
 
 This document explains the fields of the Point Cloud Extension to a STAC Item,
 which allows STAC to more fully describe point cloud datasets. The point clouds can

--- a/extensions/processing/README.md
+++ b/extensions/processing/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: processing**
 - **Scope: Item, Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @emmanuelmathot
 
 Processing metadata is considered to be data that indicate from which processing chain a data originates and how the data itself has been produced. Overall, it helps to increase traceability and search among processing levels and multiple algorithm versions.
 

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: proj**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @matthewhanson
 
 This document explains the fields of the STAC Projection (`proj`) Extension to a STAC Item. Here `proj` is short
 for "projection", and not a reference to the use of the PROJ/PROJ4 formats.

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: sar**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @m-mohr, @emmanuelmathot
 
 This document explains the fields of the STAC Synthetic-Aperture Radar (SAR) Extension to a STAC Item.
 SAR data is considered to be data that represents a snapshot of the earth for a single date and time taken by a synthetic-aperture radar system such as Sentinel-1, RADARSAT or EnviSAT.

--- a/extensions/sat/README.md
+++ b/extensions/sat/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: sat**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @emmanuelmathot
 
 This document explains the fields of the Satellite Extension to a STAC Item. Sat adds metadata related to a satellite that carries an instrument for collecting data. It will often be combined with other extensions that describe the actual data, such as the `eo`, `os` or `sar` extensions.
 

--- a/extensions/scientific/README.md
+++ b/extensions/scientific/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: sci**
 - **Scope: Item, Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @m-mohr
 
 Scientific metadata is considered to be data that indicate from which publication a data originates and how
 the data itself should be cited or referenced. Overall, it helps to increase reproducibility and citability.

--- a/extensions/single-file-stac/README.md
+++ b/extensions/single-file-stac/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: -**
 - **Scope: Catalog**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @matthewhanson
 
 An extension to provide a set of Collections and Items within a single file catalog. The single file is a STAC catalog that contains everything that would normally be in a linked set of STAC files. This format is useful to save a portion of a catalog, or when creating a small catalog from derived data that should remain portable. It is most useful for saving the results of a search from a STAC API, as the Items, Collections, and optionally the search parameters are all saved within the single file. Hierarchical links have no meaning in a single file STAC, and so, if present, should be removed when creating a single file catalog.
 

--- a/extensions/tiled-assets/README.md
+++ b/extensions/tiled-assets/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: tiles**
 - **Scope: Item, Catalog, Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @constantinius
 
 Some data products are too big to be handled in a single file or a small set of enumerated files and are thus split into tiles. For example, Sentinel-2 datastrips are tiled into overlapping granules, in some cases in even more than one coordinate reference system. Other very big datasets, such as continental or global mosaics can also only be handled in a tiled fashion. Usually, they go one step further and provide multiple layers of resolution to allow a quick inspection of larger areas but also retain the possibility to get to the full resolution data.
 

--- a/extensions/timestamps/README.md
+++ b/extensions/timestamps/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: -**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @m-mohr
 
 This document explains the fields of the Timestamps Extension to a STAC Item.
 Allows to specify numerous timestamps for assets and metadata in addition to [`created`, `updated` and `datetime` (incl. start and end)](../../item-spec/common-metadata.md#date-and-time).

--- a/extensions/version/README.md
+++ b/extensions/version/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: -**
 - **Scope: Item, Collection**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @m-mohr
 
 This extension allows to version STAC Collections and STAC Items. Therefore, it also allows to deprecate legacy versions. Only fields and possible link relation types are defined in this extension, but it does NOT suggest any versioning best practices to structure static or dynamic catalogs. Instead check the [Versioning Best Practices for Catalogs](../../best-practices.md#versioning-for-catalogs).
 

--- a/extensions/view/README.md
+++ b/extensions/view/README.md
@@ -5,6 +5,7 @@
 - **Field Name Prefix: view**
 - **Scope: Item**
 - **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
+- **Owner**: @matthewhanson
 
 This document explains the fields of the View Geometry Extension to a STAC Item. View Geometry adds metadata related to angles of sensors and other radiance angles that affect the view of resulting data. It will often be combined with other extensions that describe the actual data, such as the `eo`, `sat` or `sar` extensions.
 


### PR DESCRIPTION
**Related Issue(s):** #928 

**Proposed Changes:**

1. Add a [`CODEOWNERS`](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) file
2. Add owners to each extension README
3. Document use of code owners in main README

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] ~I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or**~ a CHANGELOG entry is not required. (not consumer-facing changes so I propose that it would just be changelog noise)
