### PR TITLE
Avoid duplicate band in example

### DIFF
--- a/item-spec/examples/sample-full.json
+++ b/item-spec/examples/sample-full.json
@@ -46,9 +46,6 @@
         "name": "band1"
       },
       {
-        "name": "band1"
-      },
-      {
         "name": "band2"
       },
       {


### PR DESCRIPTION
The bands contain "band1" twice, seems like a copy/paste error?


**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change (did not yet, it's a minor change in an example file)
