### PR TITLE
Adding GDAL as implementation of tiled-assets extension

### DIFF
--- a/extensions/tiled-assets/README.md
+++ b/extensions/tiled-assets/README.md
@@ -135,4 +135,4 @@ This list is not exhaustive, other useful template substitutions may exist.
 
 ## Implementations
 
-None. Still in proposal stage
+[GDAL (since version 3.3)](https://gdal.org/drivers/raster/stacta.html) provides read support of tiled assets.


### PR DESCRIPTION
**Related Issue(s):** #

none

**Proposed Changes:**

1. Adding GDAL as tiled-asset implementor

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.