### PR TITLE
Relative vs absolute link edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 'via' and 'canonical' rel types as options in items.
 - Added clarification about how collection-level asset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))
 - Added [processing extension](extensions/processing/README.md)
-- Added [file info extension](extensions/file/README.md) ([#879](https://github.com/radiantearth/stac-spec/pull/879), [#921](https://github.com/radiantearth/stac-spec/issues/921))
+- Added [file info extension](extensions/file/README.md) ([#879](https://github.com/radiantearth/stac-spec/pull/879), [#921](https://github.com/radiantearth/stac-spec/issues/921))
 - Added additional acquisition parameters in the `sat` extension: sat:platform_international_designator, sat:absolute_orbit, sat:anx_datetime* ([#894](https://github.com/radiantearth/stac-spec/pull/894))
 - Recommendation to enable CORS
 
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Clarified the role of geometries on items in the label extension
 - Data Cube Extension: Units for STAC dimensions in should now be compliant to UDUNITS-2 units (singular) whenever available.
+- URIs (usually found int properties like `href`, `url`) are now validated using the `iri-reference` format in JSON Schema (allows international characters in URIs)
 
 ### Removed
 

--- a/best-practices.md
+++ b/best-practices.md
@@ -253,10 +253,10 @@ STAC version. Otherwise some behaviour of functionality may be unpredictable (e.
 
 ## Use of links
 
-The main catalog specification allows both relative and absolute links, and says that `self` links are not required, but are 
+The main STAC specifications allow both relative and absolute links, and says that `self` links are not required, but are 
 strongly recommended. This is what the spec must say to enable the various use cases, but there is more subtlety for when it 
-is essential to use different link types. The best practice is to use one of the below 
-catalog types, applying the link recommendations consistently, instead of just haphazardly applying anything the spec allows.
+is essential to use different link types. The best practice is to use one of the below catalog types, applying the link 
+recommendations consistently, instead of just haphazardly applying relative links in some places and absolute ones in other places.
 
 ### Self-contained Catalogs
 

--- a/best-practices.md
+++ b/best-practices.md
@@ -254,7 +254,7 @@ STAC version. Otherwise some behaviour of functionality may be unpredictable (e.
 
 ## Use of links
 
-The main STAC specifications allow both relative and absolute links, and says that `self` links are not required, but are 
+The STAC specifications allow both relative and absolute links, and says that `self` links are not required, but are 
 strongly recommended. This is what the spec must say to enable the various use cases, but there is more subtlety for when it 
 is essential to use different link types. The best practice is to use one of the below catalog types, applying the link 
 recommendations consistently, instead of just haphazardly applying relative links in some places and absolute ones in other places.

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -53,9 +53,9 @@ with links.
 
 A more complete list of possible 'rel' types can be seen at the [IANA page of Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).
 
-Please see the chapter 'relative vs absolute links' in the [Item spec](../item-spec/item-spec.md#relative-vs-absolute-links)
-for a discussion on that topic, as well as the [use of links](../best-practices.md#use-of-links) section of the 
-catalog best practices document.
+Currently, the JSON schema for links does not require them to be formatted as URIs, to allow implementors 
+to provide relative links. For a full discussion of the situations where each are recommended see 
+[this section](../best-practices.md#use-of-links) of the STAC best practices.
 
 #### Relation types
 

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -53,7 +53,7 @@ with links.
 
 A more complete list of possible 'rel' types can be seen at the [IANA page of Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).
 
-Currently, the JSON schema for links does not require them to be formatted as URIs, to allow implementors 
+Currently, the JSON schema for link `href`s does not require them to be formatted as URIs, to allow implementors 
 to provide relative links. For a full discussion of the situations where each are recommended see 
 [this section](../best-practices.md#use-of-links) of the STAC best practices.
 

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -56,8 +56,6 @@ with links.
 | type       | string | [Media type](../item-spec/item-spec.md#media-types) of the referenced entity.                               |
 | title      | string | A human readable title to be used in rendered displays of the link.                                         |
 
-A more complete list of possible 'rel' types can be seen at the [IANA page of Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).
-
 For a full discussion of the situations where relative and absolute links are recommended see the
 ['Use of links'](../best-practices.md#use-of-links) section of the STAC best practices.
 

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -53,9 +53,8 @@ with links.
 
 A more complete list of possible 'rel' types can be seen at the [IANA page of Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).
 
-Currently, the JSON schema for link `href`s does not require them to be formatted as URIs, to allow implementors 
-to provide relative links. For a full discussion of the situations where each are recommended see 
-[this section](../best-practices.md#use-of-links) of the STAC best practices.
+For a full discussion of the situations where relative and absolute links are recommended see the
+['Use of links'](../best-practices.md#use-of-links) section of the STAC best practices.
 
 #### Relation types
 

--- a/catalog-spec/json-schema/catalog.json
+++ b/catalog-spec/json-schema/catalog.json
@@ -33,7 +33,7 @@
               {
                 "title": "Reference to a JSON Schema",
                 "type": "string",
-                "format": "uri"
+                "format": "iri"
               },
               {
                 "title": "Reference to a core extension",
@@ -72,7 +72,8 @@
       "properties": {
         "href": {
           "title": "Link reference",
-          "type": "string"
+          "type": "string",
+          "format": "iri-reference"
         },
         "rel": {
           "title": "Link relation type",

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -111,7 +111,9 @@ This object describes a relationship with another entity. Data providers are adv
 
 A more complete list of possible 'rel' types can be seen at the [IANA page of Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).
 
-Please see the chapter 'relative vs absolute links' in the [Item spec](../item-spec/item-spec.md#relative-vs-absolute-links) for a discussion on that topic. 
+Currently, the JSON schema for links does not require them to be formatted as URIs, to allow implementors 
+to provide relative links. For a full discussion of the situations where each are recommended see 
+[this section](../best-practices.md#use-of-links) of the STAC best practices.
 
 #### Relation types
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -111,9 +111,8 @@ This object describes a relationship with another entity. Data providers are adv
 
 A more complete list of possible 'rel' types can be seen at the [IANA page of Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).
 
-Currently, the JSON schema for links does not require them to be formatted as URIs, to allow implementors 
-to provide relative links. For a full discussion of the situations where each are recommended see 
-[this section](../best-practices.md#use-of-links) of the STAC best practices.
+For a full discussion of the situations where relative and absolute links are recommended see the
+['Use of links'](../best-practices.md#use-of-links) section of the STAC best practices.
 
 #### Relation types
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -118,18 +118,15 @@ This object describes a relationship with another entity. Data providers are adv
 | type       | string | [Media type](../item-spec/item-spec.md#media-types) of the referenced entity. |
 | title      | string | A human readable title to be used in rendered displays of the link. |
 
-A more complete list of possible 'rel' types can be seen at the [IANA page of Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml).
-
 For a full discussion of the situations where relative and absolute links are recommended see the
 ['Use of links'](../best-practices.md#use-of-links) section of the STAC best practices.
 
 #### Relation types
 
-STAC Collections use a variety of `rel` types in the link object, to describe the exact nature of the link between this collection
-and the entity it is linking to. It is recommended to use the official [IANA Link Relation 
-Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml) where possible. The following table explains places
-where custom STAC `rel` types are used for collections. This is done where there is not a clear official option, or where 
-STAC uses an official type but adds additional meaning for the STAC context.
+STAC Collections use a variety of `rel` types in the link object, to describe the exact nature of the link between this collection and the entity it is linking to.
+It is recommended to use the official [IANA Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml) where possible.
+The following table explains places where custom STAC `rel` types are used for collections.
+This is done where there is not a clear official option, or where STAC uses an official type but adds additional meaning for the STAC context.
 
 | Type    | Description                                                  |
 | ------- | ------------------------------------------------------------ |
@@ -141,8 +138,7 @@ STAC uses an official type but adds additional meaning for the STAC context.
 | license | The license URL(s) for the collection SHOULD be specified if the `license` field is set to `proprietary` or `various`. If there is no public license URL available, it is RECOMMENDED to supplement the STAC catalog with the license text in a separate file and link to this file. |
 | derived_from | URL to a STAC Collection that was used as input data in the creation of this collection. See the note in [STAC Item](../item-spec/item-spec.md#derived_from) for more info. |
 
-A more complete list of possible `rel` types and their meaning in STAC can be found in the [Using Relation 
-Types](../best-practices.md#using-relation-types) best practice. 
+A more complete list of possible `rel` types and their meaning in STAC can be found in the [Using Relation Types](../best-practices.md#using-relation-types) best practice. 
 
 **Note:** The [STAC Catalog specification](../catalog-spec/catalog-spec.md) requires a link to at least one `item` or `child` catalog. This is *not* a requirement for collections, but *recommended*. In contrast to catalogs, it is **REQUIRED** that items linked from a Collection MUST refer back to its Collection with the [`collection` relation type](../item-spec/item-spec.md#relation-types).
 

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -30,7 +30,7 @@
               {
                 "title": "Reference to a JSON Schema",
                 "type": "string",
-                "format": "uri"
+                "format": "iri"
               },
               {
                 "title": "Reference to a core extension",
@@ -83,7 +83,7 @@
               "url": {
                 "title": "Organization homepage",
                 "type": "string",
-                "format": "url"
+                "format": "iri"
               }
             }
           }

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -119,11 +119,10 @@ For a full discussion of the situations where relative and absolute links are re
 
 #### Relation types
 
-STAC Items use a variety of `rel` types in the link object, to describe the exact nature of the link between this item
-and the entity it is linking to. It is recommended to use the official [IANA Link Relation 
-Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml) where possible. The following table explains places
-where STAC use custom `rel` types are used with items. This happens where there is not a clear official option, or where 
-STAC uses an official type but adds additional meaning for the STAC context.
+STAC Items use a variety of `rel` types in the link object, to describe the exact nature of the link between this item and the entity it is linking to.
+It is recommended to use the official [IANA Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml) where possible.
+The following table explains places where STAC use custom `rel` types are used with items.
+This happens where there is not a clear official option, or where STAC uses an official type but adds additional meaning for the STAC context.
 
 | Type         | Description                                                  |
 | ------------ | ------------------------------------------------------------ |

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -116,11 +116,9 @@ It is allowed to add additional fields such as a `title` and `type`.
 
 #### Relative vs Absolute links
 
-Currently, the JSON schema for links does not require them to be formatted as URIs, to allow
-implementors to provide relative links. In general, Catalog APIs should aim to provide absolute links
-whenever possible. Static Catalogs are potentially more portable if they incorporate only
-relative links, so that every link doesn't need to be rewritten when the data is copied. Additional
-recommendations for particular `rel` types are given in the `rel` type description.
+Currently, the JSON schema for links does not require them to be formatted as URIs, to allow implementors 
+to provide relative links. For a full discussion of the situations where each are recommended see 
+[this section](../best-practices.md#use-of-links) of the STAC best practices.
 
 #### Relation types
 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -114,11 +114,8 @@ It is allowed to add additional fields such as a `title` and `type`.
 | type       | string | [Media type](#media-types) of the referenced entity. |
 | title      | string | A human readable title to be used in rendered displays of the link. |
 
-#### Relative vs Absolute links
-
-Currently, the JSON schema for links does not require them to be formatted as URIs, to allow implementors 
-to provide relative links. For a full discussion of the situations where each are recommended see 
-[this section](../best-practices.md#use-of-links) of the STAC best practices.
+For a full discussion of the situations where relative and absolute links are recommended see the
+['Use of links'](../best-practices.md#use-of-links) section of the STAC best practices.
 
 #### Relation types
 

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -104,7 +104,7 @@
                   {
                     "title": "Reference to a JSON Schema",
                     "type": "string",
-                    "format": "uri"
+                    "format": "iri"
                   },
                   {
                     "title": "Reference to a core extension",
@@ -150,7 +150,8 @@
       "properties": {
         "href": {
           "title": "Link reference",
-          "type": "string"
+          "type": "string",
+          "format": "iri-reference"
         },
         "rel": {
           "title": "Link relation type",
@@ -188,7 +189,8 @@
       "properties": {
         "href": {
           "title": "Asset reference",
-          "type": "string"
+          "type": "string",
+          "format": "iri-reference"
         },
         "title": {
           "title": "Asset title",

--- a/item-spec/json-schema/provider.json
+++ b/item-spec/json-schema/provider.json
@@ -37,7 +37,7 @@
           "url": {
             "title": "Organization homepage",
             "type": "string",
-            "format": "url"
+            "format": "iri"
           }
         }
       }


### PR DESCRIPTION
**Related Issue(s):** #952 , #957


**Proposed Changes:**

1. Clean up the relative vs absolute link section to just link to the best practice.
2. Remove talk about static and dynamic catalogs, as those are now just in the best practice, not the spec itself.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] a CHANGELOG entry is not required.
