### PR TITLE
Additional SAR fields #961

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 'via' and 'canonical' rel types as options in items.
 - Added clarification about how collection-level asset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))
 - Added [processing extension](extensions/processing/README.md)
-- Added [file info extension](extensions/file/README.md) ([#879](https://github.com/radiantearth/stac-spec/pull/879), [#921](https://github.com/radiantearth/stac-spec/issues/921))
+- Added [file info extension](extensions/file/README.md) ([#879](https://github.com/radiantearth/stac-spec/pull/879), [#921](https://github.com/radiantearth/stac-spec/issues/921))
 - Added additional acquisition parameters in the `sat` extension: `sat:platform_international_designator`, `sat:absolute_orbit`, `sat:anx_datetime` ([#894](https://github.com/radiantearth/stac-spec/pull/894))
-- Added properties to the `sar` extension: `sar:measurement_type`, `sar:measurement_convention`, `sar:product_pixel_spacing`, `sar:product_line_spacing` ([#961](https://github.com/radiantearth/stac-spec/pull/961))
+- Added properties to the `sar` extension: `sar:measurement_type`, `sar:measurement_convention` ([#961](https://github.com/radiantearth/stac-spec/pull/961))
 - Recommendation to enable CORS
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added [processing extension](extensions/processing/README.md)
 - Added [file info extension](extensions/file/README.md) ([#879](https://github.com/radiantearth/stac-spec/pull/879), [#921](https://github.com/radiantearth/stac-spec/issues/921))
 - Added additional acquisition parameters in the `sat` extension: `sat:platform_international_designator`, `sat:absolute_orbit`, `sat:anx_datetime` ([#894](https://github.com/radiantearth/stac-spec/pull/894))
-- Added properties to the `sar` extension: `sar:measurement_type`, `sar:measurement_convention` ([#961](https://github.com/radiantearth/stac-spec/pull/961))
+- Added properties to the `sar` extension: `sar:measurement_type`, `sar:measurement_convention`, `sar:product_pixel_spacing`, `sar:product_line_spacing` ([#961](https://github.com/radiantearth/stac-spec/pull/961))
 - Recommendation to enable CORS
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added clarification about how collection-level asset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))
 - Added [processing extension](extensions/processing/README.md)
 - Added [file info extension](extensions/file/README.md) ([#879](https://github.com/radiantearth/stac-spec/pull/879), [#921](https://github.com/radiantearth/stac-spec/issues/921))
-- Added additional acquisition parameters in the `sat` extension: sat:platform_international_designator, sat:absolute_orbit, sat:anx_datetime* ([#894](https://github.com/radiantearth/stac-spec/pull/894))
+- Added additional acquisition parameters in the `sat` extension: `sat:platform_international_designator`, `sat:absolute_orbit`, `sat:anx_datetime` ([#894](https://github.com/radiantearth/stac-spec/pull/894))
+- Added properties to the `sar` extension: `sar:measurement_type`, `sar:measurement_convention` ([#961](https://github.com/radiantearth/stac-spec/pull/961))
 - Recommendation to enable CORS
 
 ### Changed

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -31,7 +31,7 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 | sar:resolution_range        | number    | The range resolution, which is the maximum ability to distinguish two adjacent targets perpendicular to the flight path, in meters (m).  |
 | sar:resolution_azimuth      | number    | The azimuth resolution, which is the maximum ability to distinguish two adjacent targets parallel to the flight path, in meters (m).  |
 | sar:pixel_spacing_range     | number    | The range pixel spacing, which is the distance between adjacent pixels perpendicular to the flight path, in meters (m). Strongly RECOMMENDED to be specified for 'ground-range detected' products. |
-| sar:pixel_spacing_azimuth   | number    | The azimuth pixel spacing, which is the distance between adjacent pixels parallel to the flight path, in meters (m). Strongly RECOMMENDED to be specified for products of type 'ground-range detected' products. |
+| sar:pixel_spacing_azimuth   | number    | The azimuth pixel spacing, which is the distance between adjacent pixels parallel to the flight path, in meters (m). Strongly RECOMMENDED to be specified for 'ground-range detected' products. |
 | sar:looks_range             | number    | Number of range looks, which is the number of groups of signal samples (looks) perpendicular to the flight path. |
 | sar:looks_azimuth           | number    | Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path. |
 | sar:looks_equivalent_number | number    | The equivalent number of looks (ENL). |

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -39,7 +39,7 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 | sar:looks_equivalent_number | number    | The equivalent number of looks (ENL). |
 | sar:observation_direction   | string    | Antenna pointing direction relative to the flight trajectory of the satellite, either `left` or `right`. |
 | sar:measurement_type        | string    | The product's type of measurement. One of `beta0`, `gamma0` or `sigma0`. |
-| sar:measurment_convention   | string    | The product's measurement convention. One of `amplitude` (linear amplitude), `power` (linear power) or `angle`. |
+| sar:measurement_convention  | string    | The product's measurement convention. For example, `amplitude` (linear amplitude), `power` (linear power) or `angle`. |
 
 **sar:polarizations** specifies a single polarization or a polarization combination. For single polarized radars one of `HH`, `VV`, `HV` or `VH` must be set. Fully polarimetric radars add all four polarizations to the array. Dual polarized radars and alternating polarization add the corresponding polarizations to the array, for instance for `HH+HV` add both `HH` and `HV`.
 

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -30,10 +30,10 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 | sar:product_type            | string    | **REQUIRED.** The product type, for example `SSC`, `MGD`, or `SGC` |
 | sar:resolution_range        | number    | The range resolution, which is the maximum ability to distinguish two adjacent targets perpendicular to the flight path, in meters (m).  |
 | sar:resolution_azimuth      | number    | The azimuth resolution, which is the maximum ability to distinguish two adjacent targets parallel to the flight path, in meters (m).  |
-| sar:pixel_spacing_range     | number    | The range pixel spacing, which is the distance between adjacent pixels perpendicular to the flight path, in meters (m). Strongly RECOMMENDED to be specified for products of type `GRD`. |
-| sar:pixel_spacing_azimuth   | number    | The azimuth pixel spacing, which is the distance between adjacent pixels parallel to the flight path, in meters (m). Strongly RECOMMENDED to be specified for products of type `GRD`. |
-| sar:product_pixel_spacing   | number    | The actual product pixel (column) spacing, in meters (m). While `sar:pixel_spacing_range` is given in in radar geometry, this property is in ground geometry. |
-| sar:product_line_spacing    | number    | The actual product line (row) spacing, in meters (m). While `sar:pixel_spacing_azimuth` is given in in radar geometry, this property is in ground geometry. |
+| sar:pixel_spacing_range     | number    | The range pixel spacing, which is the distance between adjacent pixels perpendicular to the flight path, in meters (m). Strongly RECOMMENDED to be specified for 'ground-range detected' products. |
+| sar:pixel_spacing_azimuth   | number    | The azimuth pixel spacing, which is the distance between adjacent pixels parallel to the flight path, in meters (m). Strongly RECOMMENDED to be specified for products of type 'ground-range detected' products. |
+| sar:product_pixel_spacing   | number    | The actual product pixel (column) spacing, in meters (m). While `sar:pixel_spacing_range` is given in in radar geometry, this property is in ground geometry. The two properties are usually mutually exlusive. |
+| sar:product_line_spacing    | number    | The actual product line (row) spacing, in meters (m). While `sar:pixel_spacing_azimuth` is given in in radar geometry, this property is in ground geometry.  The two properties are usually mutually exlusive. |
 | sar:looks_range             | number    | Number of range looks, which is the number of groups of signal samples (looks) perpendicular to the flight path. |
 | sar:looks_azimuth           | number    | Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path. |
 | sar:looks_equivalent_number | number    | The equivalent number of looks (ENL). |

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -36,6 +36,8 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 | sar:looks_azimuth           | number    | Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path. |
 | sar:looks_equivalent_number | number    | The equivalent number of looks (ENL). |
 | sar:observation_direction   | string    | Antenna pointing direction relative to the flight trajectory of the satellite, either `left` or `right`. |
+| sar:measurement_type        | string    | The product's type of measurement. One of `beta0`, `gamma0` or `sigma0`. |
+| sar:measurment_convention   | string    | The product's measurement convention. One of `amplitude` (linear amplitude), `power` (linear power) or `angle`. |
 
 **sar:polarizations** specifies a single polarization or a polarization combination. For single polarized radars one of `HH`, `VV`, `HV` or `VH` must be set. Fully polarimetric radars add all four polarizations to the array. Dual polarized radars and alternating polarization add the corresponding polarizations to the array, for instance for `HH+HV` add both `HH` and `HV`.
 

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -32,6 +32,8 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 | sar:resolution_azimuth      | number    | The azimuth resolution, which is the maximum ability to distinguish two adjacent targets parallel to the flight path, in meters (m).  |
 | sar:pixel_spacing_range     | number    | The range pixel spacing, which is the distance between adjacent pixels perpendicular to the flight path, in meters (m). Strongly RECOMMENDED to be specified for products of type `GRD`. |
 | sar:pixel_spacing_azimuth   | number    | The azimuth pixel spacing, which is the distance between adjacent pixels parallel to the flight path, in meters (m). Strongly RECOMMENDED to be specified for products of type `GRD`. |
+| sar:product_pixel_spacing   | number    | The actual product pixel (column) spacing, in meters (m). While `sar:pixel_spacing_range` is given in in radar geometry, this property is in ground geometry. |
+| sar:product_line_spacing    | number    | The actual product line (row) spacing, in meters (m). While `sar:pixel_spacing_azimuth` is given in in radar geometry, this property is in ground geometry. |
 | sar:looks_range             | number    | Number of range looks, which is the number of groups of signal samples (looks) perpendicular to the flight path. |
 | sar:looks_azimuth           | number    | Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path. |
 | sar:looks_equivalent_number | number    | The equivalent number of looks (ENL). |

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -32,8 +32,6 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 | sar:resolution_azimuth      | number    | The azimuth resolution, which is the maximum ability to distinguish two adjacent targets parallel to the flight path, in meters (m).  |
 | sar:pixel_spacing_range     | number    | The range pixel spacing, which is the distance between adjacent pixels perpendicular to the flight path, in meters (m). Strongly RECOMMENDED to be specified for 'ground-range detected' products. |
 | sar:pixel_spacing_azimuth   | number    | The azimuth pixel spacing, which is the distance between adjacent pixels parallel to the flight path, in meters (m). Strongly RECOMMENDED to be specified for products of type 'ground-range detected' products. |
-| sar:product_pixel_spacing   | number    | The actual product pixel (column) spacing, in meters (m). While `sar:pixel_spacing_range` is given in in radar geometry, this property is in ground geometry. The two properties are usually mutually exlusive. |
-| sar:product_line_spacing    | number    | The actual product line (row) spacing, in meters (m). While `sar:pixel_spacing_azimuth` is given in in radar geometry, this property is in ground geometry.  The two properties are usually mutually exlusive. |
 | sar:looks_range             | number    | Number of range looks, which is the number of groups of signal samples (looks) perpendicular to the flight path. |
 | sar:looks_azimuth           | number    | Number of azimuth looks, which is the number of groups of signal samples (looks) parallel to the flight path. |
 | sar:looks_equivalent_number | number    | The equivalent number of looks (ENL). |

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -135,14 +135,9 @@
                 "sigma0"
               ]
             },
-            "sar:measurment_convention": {
+            "sar:measurement_convention": {
               "title": "Product measurement convention",
-              "type": "string",
-              "enum": [
-                "amplitude",
-                "power",
-                "angle"
-              ]
+              "type": "string"
             }
           }
         },

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -93,6 +93,16 @@
               "type": "number",
               "minimum": 0
             },
+            "sar:product_pixel_spacing": {
+              "title": "Product pixel spacing (m)",
+              "type": "number",
+              "minimum": 0
+            },
+            "sar:product_line_spacing": {
+              "title": "Product line spacing (m)",
+              "type": "number",
+              "minimum": 0
+            },
             "sar:looks_range": {
               "title": "Looks range",
               "type": "integer",

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -115,6 +115,24 @@
                 "left",
                 "right"
               ]
+            },
+            "sar:measurement_type": {
+              "title": "Product measurement type",
+              "type": "string",
+              "enum": [
+                "beta0",
+                "gamma0",
+                "sigma0"
+              ]
+            },
+            "sar:measurment_convention": {
+              "title": "Product measurement convention",
+              "type": "string",
+              "enum": [
+                "amplitude",
+                "power",
+                "angle"
+              ]
             }
           }
         },

--- a/extensions/sar/json-schema/schema.json
+++ b/extensions/sar/json-schema/schema.json
@@ -93,16 +93,6 @@
               "type": "number",
               "minimum": 0
             },
-            "sar:product_pixel_spacing": {
-              "title": "Product pixel spacing (m)",
-              "type": "number",
-              "minimum": 0
-            },
-            "sar:product_line_spacing": {
-              "title": "Product line spacing (m)",
-              "type": "number",
-              "minimum": 0
-            },
             "sar:looks_range": {
               "title": "Looks range",
               "type": "integer",


### PR DESCRIPTION
**Related Issue(s):** #961, #922


**Proposed Changes:**

Adding four fields mostly for products:
* `sar:measurement_type`
* `sar:measurement_convention`
* ~`sar:product_pixel_spacing`~ use `gsd` instead
* ~`sar:product_line_spacing`~ use `gsd` instead

This has been brought up by @fangfy in https://github.com/radiantearth/stac-spec/pull/922#issuecomment-770502545 (and the follow-up comment) and seems like a good idea.

With my limited SAR knowledge, I tried to come up with a list of allowed values and descriptions, but please correct me if there are more values to add or if anything is wrong (which I assume).

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
