### PR TITLE
Item Properties and Item Asset clarification

### DIFF
--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -109,7 +109,7 @@ The object provides information about a provider. A provider is any of the organ
 
 ### Link Object
 
-This object describe a relationship with another entity. Data providers are advised to be liberal with links.
+This object describes a relationship with another entity. Data providers are advised to be liberal with links.
 
 | Field Name | Type   | Description                                                  |
 | ---------- | ------ | ------------------------------------------------------------ |

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -109,7 +109,7 @@ The object provides information about a provider. A provider is any of the organ
 
 ### Link Object
 
-This object describes a relationship with another entity. Data providers are advised to be liberal with links.
+This object describe a relationship with another entity. Data providers are advised to be liberal with links.
 
 | Field Name | Type   | Description                                                  |
 | ---------- | ------ | ------------------------------------------------------------ |

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -25,8 +25,7 @@ stac-spec repository to collaborate.
 1. Additional attributes relating to an Item should be added into the Item Properties object, rather than directly in the Item object. 
 2. In general, additional attributes that apply to an Item Asset should also be allowed in Item Properties and vice-versa.
 For example, the `eo:bands` attribute may be used in Item Properties to describe the aggregation of all bands available in 
-the Item Assets for the Item, but may also be used in an individual Item Asset to describe only the bands available in 
-that asset.
+the Item Asset objects contained in the Item, but may also be used in an individual Item Asset to describe only the bands available in that asset.
 
 ## Extension Maturity
 

--- a/extensions/datacube/README.md
+++ b/extensions/datacube/README.md
@@ -14,7 +14,9 @@ Data cube related metadata, especially to describe their dimensions.
   - [Collection](examples/example-collection.json)
 - [JSON Schema](json-schema/schema.json)
 
-## Item Fields
+## Item Properties and Collection Fields
+
+These fields may be added to either Item Properties or Collection.
 
 | Field Name      | Type                                               | Description                                 |
 | --------------- | -------------------------------------------------- | ------------------------------------------- |

--- a/extensions/eo/README.md
+++ b/extensions/eo/README.md
@@ -37,7 +37,7 @@ For defining view geometry of data, it is strongly recommended to use the [`view
 
 **eo:bands**: In STAC versions 0.9.x and prior, `eo:bands` could only be used by an Asset putting the the Band Object definitions in an Item Properties and referencing these via array index. **Starting with STAC 1.0.0-beta.1, an Asset may only have an `eo:bands` array containing Band Object entities.** Since `eo:bands` definitions in Item Properties can no longer be referenced by array index from an Asset, their primary use now is only to advertise a set of bands that may be available in some of the Assets in this Item, which may be aggregated into Collection `summaries` object.
 
-**eo:cloud_cover**: Estimate of cloud cover as a percentage (0-100) of the entire scene. If not available, the field should not be provided. Generally, this value should be used in Item Properties rather than Item Assets, as an Item from an electro-optical source is a single snapshot of the Earth, so the cloud cover value would apply to all assets. 
+**eo:cloud_cover**: Estimate of cloud cover as a percentage (0-100) of the entire scene. If not available, the field should not be provided. Generally, this value should be used in Item Properties rather than in an Item Asset, as an Item from an electro-optical source is a single snapshot of the Earth, so the cloud cover value would apply to all assets. 
 
 ### Band Object
 

--- a/extensions/label/README.md
+++ b/extensions/label/README.md
@@ -35,13 +35,13 @@ This document explains the fields of the STAC Label Extension to a STAC Item. It
 ## Schema
 - [JSON Schema](json-schema/schema.json)
 
-## Item fields
+## Fields
 
 A Label Item represents a polygon, set of polygons, or raster data defining labels and label metadata and should be part of a Collection. See the [raster label notes](#raster-label-notes) section below for details on raster-formatted labels. It is up to the data provider how to group their catalog, but a typical use might have a Collection of a series of label sets (Items) that are related. For example a "Building" collection might have 50 Items, each one was a set of building AOIs for a single country. The Collection holds details on the data providers and the license.
 
 Like other content extensions, the Label extension adds additional fields to a STAC Item, which are detailed after some additional clarification on what the core fields mean with respect to a Label Item.
 
-### Core Item fields
+### Item fields
 Some additional notes are given here for some of the core STAC Item fields and what they represent for label.
 
 - **bbox** and **geometry**: The bounding box and the geometry of a Label Item represents the region for which the label(s) is/are valid. The geometry _must_ include areas for which labeling was attempted but no features were identified, if such areas exist. For example, consider a cloud labeling object detection task for this chip taken from a Sentinel-2 image, which happens not to have any clouds. The geometry for the label item with this item as its `source` must be the geometry of the image (or whatever area within the image was considered), even though the label item's asset won't have any features.
@@ -51,7 +51,7 @@ Some additional notes are given here for some of the core STAC Item fields and w
 - **properties.datetime**: The datetime of a Label Item is the nominal datetime for which the label applies, typically this is the datetime of the source imagery used to generate the labels. If the label applies over a range of datetimes (e.g., generated from multiple source images) then use the [Date and Time Range fields](../../item-spec/common-metadata.md#date-and-time-range) to indicate start and end datetimes.
 - **assets**: The label assets are GeoJSON FeatureCollection assets containing the actual label features. As with the core STAC Item a thumbnail asset is also strongly encouraged.
 
-### New Item properties
+### Item Properties fields
 | Field Name        | Type                             | Name                       | Description |
 | ----------------- | -------------------------------- | -------------------------- | ----------- |
 | label:properties  | \[string]\|null                  | Name                       | **REQUIRED** These are the names of the property field(s) in each `Feature` of the label asset's `FeatureCollection` that contains the  classes (keywords from `label:classes` if the property defines classes). If labels are rasters, use `null`. |

--- a/extensions/pointcloud/README.md
+++ b/extensions/pointcloud/README.md
@@ -15,7 +15,7 @@ tools such as LiDAR or coincidence-matched imagery.
 - [Example](examples/example-autzen.json)
 - [JSON Schema](json-schema/schema.json)
 
-## Item Fields
+## Item Properties fields
 
 | Field Name    | Type                              | Description |
 | ------------- | --------------------------------- | ----------- |

--- a/extensions/projection/README.md
+++ b/extensions/projection/README.md
@@ -15,7 +15,7 @@ When specified in Item Properties, the values are assumed to apply to all Assets
 several related Assets each representing a band or layer for the Item, and which typically all use the same CRS,
 e.g., a UTM Zone. However, there may also be Assets intended for display, like a preview image or thumbnail, that have
 been reprojected to a different CRS, e.g., Web Mercator, or resized to better accommodate that use case. In this case, the 
-fields should be specified at the Item Asset level, while those Item Assets that use the defaults can remain unspecified.
+fields should be specified at the Item Asset level, while those Item Asset objects that use the defaults can remain unspecified.
 
 ## Examples
 
@@ -72,7 +72,7 @@ of the lower left corner, followed by coordinates of upper right corner, , e.g.,
 **proj:centroid** - Coordinates representing the centroid of the item in the asset data CRS.  Coordinates are
 defined in latitude and longitude, even if the data coordinate system does not use lat/long.
 
-**proj:shape** - An array of integers that represents the number of pixels in the most common pixel grid used by the Item Assets.
+**proj:shape** - An array of integers that represents the number of pixels in the most common pixel grid used by the Item Asset objects.
 The number of pixels should be specified in Y, X order. If the shape is defined in Item Properties, it is used as
 the default shape for all assets that don't have an overriding shape.
 

--- a/extensions/sar/README.md
+++ b/extensions/sar/README.md
@@ -17,7 +17,7 @@ To describe frame start and end times, use the [Date and Time Range fields](../.
 - [Examples](examples/) (for example [Sentinel-1](examples/sentinel1.json) and [Envisat](examples/envisat.json))
 - [JSON Schema](json-schema/schema.json)
 
-## Item fields
+## Item Properties or Item Asset fields
 
 **Note:** In the following specification *range* values are meant to be measured perpendicular to the flight path and *azimuth* values are meant to be measured parallel to the flight path.
 

--- a/extensions/sat/README.md
+++ b/extensions/sat/README.md
@@ -15,7 +15,7 @@ The Satellite extension requires the [Instrument Fields](../../item-spec/common-
 - [Example (Sentinel 1)](examples/example-sentinel1.json)
 - [JSON Schema](json-schema/schema.json)
 
-## Item fields
+## Item Properties or Item Asset fields
 
 | Field Name       | Type                     | Description |
 | ---------------- | ------------------------ | ----------- |

--- a/extensions/tiled-assets/README.md
+++ b/extensions/tiled-assets/README.md
@@ -20,6 +20,8 @@ This extension is modelled in close alignment to the [OGC Two Dimensional Tile M
 
 ## Item Properties, Collection, and Catalog Fields
 
+These fields can be applied to Item Properties, Collection, or Catalog objects.
+
 | Field Name               | Type                                                                  | Description                                                                                                          |
 | ------------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | tiles:tile_matrix_sets   | Map<string, [TileMatrixSet Object](#tile-matrix-set-object)>          | **REQUIRED for Collections and Catalogs.** A mapping of tile matrix set identifier to a tile matrix set link object. |
@@ -101,7 +103,7 @@ Pixel buffer objects allow the definition of image boundaries, so that the inter
 | border_bottom | boolean | Whether or not the pixel-buffer is included images on the bottom border of the last tile row. Default is `true`.   |
 | border_right  | boolean | Whether or not the pixel-buffer is included images on the right border of the last tile column. Default is `true`. |
 
-## Item Properties fields
+## Item fields
 
 | Field Name          | Type                                                                   | Description                                                                                   |
 | ------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |

--- a/extensions/tiled-assets/README.md
+++ b/extensions/tiled-assets/README.md
@@ -18,7 +18,7 @@ This extension is modelled in close alignment to the [OGC Two Dimensional Tile M
 - Examples: [Tiled](examples/example-tiled.json), [Dimension](examples/example-dimension.json)
 - [JSON Schema](json-schema/schema.json)
 
-## Item, Collection and Catalog properties
+## Item Properties, Collection, and Catalog Fields
 
 | Field Name               | Type                                                                  | Description                                                                                                          |
 | ------------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -28,7 +28,7 @@ This extension is modelled in close alignment to the [OGC Two Dimensional Tile M
 
 Tile matrix sets can be directly embedded in a collection, catalog or item. Such directly embedded tile matrix set objects must conform to the [OGC Two Dimensional Tile Matrix Set JSON schema](http://schemas.opengis.net/tms/1.0/json/tms-schema.json).
 
-## Item properties
+## Item Properties fields
 
 | Field Name                  | Type                                                                  | Description                                                                                                     |
 | --------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
@@ -101,7 +101,7 @@ Pixel buffer objects allow the definition of image boundaries, so that the inter
 | border_bottom | boolean | Whether or not the pixel-buffer is included images on the bottom border of the last tile row. Default is `true`.   |
 | border_right  | boolean | Whether or not the pixel-buffer is included images on the right border of the last tile column. Default is `true`. |
 
-## Item fields
+## Item Properties fields
 
 | Field Name          | Type                                                                   | Description                                                                                   |
 | ------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |

--- a/extensions/timestamps/README.md
+++ b/extensions/timestamps/README.md
@@ -13,7 +13,7 @@ Allows to specify numerous timestamps for assets and metadata in addition to [`c
 - [Example (Landsat 8)](examples/example-landsat8.json)
 - [JSON Schema](json-schema/schema.json)
 
-## Item fields
+## Item Properties or Asset fields
 
 | Field Name  | Type   | Description |
 | ----------- | ------ | ----------- |

--- a/extensions/view/README.md
+++ b/extensions/view/README.md
@@ -12,7 +12,7 @@ This document explains the fields of the View Geometry Extension to a STAC Item.
 - [Example (Landsat 8)](../eo/examples/example-landsat8.json)
 - [JSON Schema](json-schema/schema.json)
 
-## Item fields
+## Item Properties and Item Asset fields
 
 | Field Name           | Type                     | Description |
 | -------------------- | ------------------------ | ----------- |

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -2,7 +2,7 @@
 
 This document outlines commonly used fields in STAC.
 They are often used in [STAC Item properties](item-spec.md#properties-object),
-but can also be used in other places, e.g. [Item Assets](item-spec.md#asset-object)
+but can also be used in other places, e.g. an [Item Asset](item-spec.md#asset-object)
 or [Collection Assets](../extensions/collection-assets/README.md).
 
 - [STAC Common Metadata](#stac-common-metadata)


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

1. Clarify which objects (e.g., Item Properties or Item Asset) fields apply to
2. Change uses of "Item Assets" to "Item Asset objects" so not to confuse with the item-assets extension (in general, I think we should adopt this style -- instead of pluralizing a STAC type (Type->Types), refer to `Type objects`)

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] n/a This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
