### PR TITLE
Move JSON Schema for summaries to Catalog

### DIFF
--- a/catalog-spec/json-schema/catalog.json
+++ b/catalog-spec/json-schema/catalog.json
@@ -60,6 +60,9 @@
           "items": {
             "$ref": "#/definitions/link"
           }
+        },
+        "summaries": {
+          "$ref": "#/definitions/summaries"
         }
       }
     },
@@ -87,6 +90,39 @@
           "title": "Link title",
           "type": "string"
         }
+      }
+    },
+    "summaries": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "title": "Stats",
+            "type": "object",
+            "required": [
+              "minimum",
+              "maximum"
+            ],
+            "properties": {
+              "minimum": {
+                "title": "Minimum value",
+                "type": ["number", "string"]
+              },
+              "maximum": {
+                "title": "Maximum value",
+                "type": ["number", "string"]
+              }
+            }
+          },
+          {
+            "title": "Set of values",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "description": "Any data type could occur."
+            }
+          }
+        ]
       }
     }
   }

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -155,39 +155,6 @@
               }
             }
           }
-        },
-        "summaries": {
-          "type": "object",
-          "additionalProperties": {
-            "oneOf": [
-              {
-                "title": "Stats",
-                "type": "object",
-                "required": [
-                  "minimum",
-                  "maximum"
-                ],
-                "properties": {
-                  "minimum": {
-                    "title": "Minimum value",
-                    "type": ["number", "string"]
-                  },
-                  "maximum": {
-                    "title": "Maximum value",
-                    "type": ["number", "string"]
-                  }
-                }
-              },
-              {
-                "title": "Set of values",
-                "type": "array",
-                "minItems": 1,
-                "items": {
-                  "description": "Any data type could occur."
-                }
-              }
-            ]
-          }
         }
       }
     }


### PR DESCRIPTION
**Related Issue(s):** #978


**Proposed Changes:**

1. Move JSON Schema for summaries to Catalog, was forgotten in #942 

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
