### PR TITLE
Update instrument.json to include a target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-
+- 'target' to the instrument.json specification.
 - 'via' and 'canonical' rel types as options in items.
 - Assets on Collections are now defined in the core Collection specification ([#1008](https://github.com/radiantearth/stac-spec/pull/1008))
 - Added clarification about how collection-level asset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))

--- a/item-spec/json-schema/instrument.json
+++ b/item-spec/json-schema/instrument.json
@@ -29,7 +29,7 @@
     },
     "target": {
       "title" : "Body targeted by the observation",
-      "type" "string"
+      "type": "string"
     }
   }
 }

--- a/item-spec/json-schema/instrument.json
+++ b/item-spec/json-schema/instrument.json
@@ -26,6 +26,10 @@
     "gsd": {
       "title": "Ground Sample Distance",
       "type": "number"
+    },
+    "target": {
+      "title" : "Body targeted by the observation",
+      "type" "string"
     }
   }
 }


### PR DESCRIPTION
We have been using the STAC specification for non-terrestrially focused data, e.g., Mars. For non-Earth focused data, we need some mechanism to identify the target of the observation. By target, we mean the planet, moon, asteroid, comet, etc. that was the primary objective of the observation. If a given instrument imaged a single body over the mission lifecycle, we could make use of the mission string. For many missions, observations are captured enroute (for example a few quick snaps of Venus during a gravity assist on the way to the outer planets) or multiple targets can exist (sensors targeting Mars can be rolled to capture data of Phobos for example).

The instrument section of the item specification seems to be the most appropriate place to inject a target keyword. We envision the target keyword being used to identify the body/bodies which was the target of a particular observation. For example:

```
{"instruments":["Kaguya Terrain Camera"], 
"mission":"Kaguya/SELENE", 
"gsd": "6",
"target":"Moon"}
```

**Related Issue(s):**
No opened related issue at this time. I am quite happy to use the test above as the start of an issue on the repo.


**Proposed Changes:**

1. Add 'target' to the instrument object of the item specification.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #1014  to track the change.
