### PR TITLE
replace the use of 'atomic' with a less overloaded term

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ together, but are designed so each piece is small, self-contained and reusable i
 The **[Overview](overview.md)** describes the three core specifications and how they relate to one another.
 
 The **[Item Specification](item-spec/)** defines a STAC Item, which is a [GeoJSON](http://geojson.org) Feature
-with additional fields for things like time, links to related entities and assets (including thumbnails). This is the 
-atomic unit that describes the data to be discovered.
+with additional fields for things like time, links to related entities and assets (including thumbnails). This 
+is the entity that describes the data to be discovered.
 
 The **[Catalog Specification](catalog-spec/)** specifies a structure to link various STAC Items together to be crawled or browsed. It is a
 simple, flexible JSON file of links to Items, Catalogs or Collections that can be used in a variety of ways.

--- a/catalog-spec/README.md
+++ b/catalog-spec/README.md
@@ -1,6 +1,6 @@
 # STAC Catalogs
 
-While a [STAC Item](../item-spec/item-spec.md) is the atomic unit of a SpatioTemporal Asset Catalog,
+While a [STAC Item](../item-spec/item-spec.md) is the most important entity in a SpatioTemporal Asset Catalog,
 the Catalog JSON definition is the core structure that enables browsers and crawlers to access
 the sets of Items. A Catalog consists of links to other Catalogs and Items, and can include
 additional metadata to further describe its holdings. It is defined in full in the 

--- a/item-spec/README.md
+++ b/item-spec/README.md
@@ -1,8 +1,8 @@
 # STAC Items
 
 The core of a SpatioTemporal Asset Catalog (STAC) is a set of JSON fields defined by the 
-[STAC Item spec](item-spec.md). These fields define an Item - the atomic units that contain 
-metadata for search as plus links to the actual assets that they represent. Their main function 
+[STAC Item spec](item-spec.md). These fields define an **Item** - the entity that contains 
+metadata for search as well as links to the actual assets that they represent. Their main function 
 is as the leaf nodes of a [Catalog](../catalog-spec/catalog-spec.md).
 See the [overview](../overview.md) document for more information on how all the pieces fit together.
 

--- a/overview.md
+++ b/overview.md
@@ -2,8 +2,8 @@
 
 There are three component specifications that together make up the core SpatioTemporal Asset Catalog specification.
 Each can be used alone, but they work best in concert with one another. The [STAC API specification](https://github.com/radiantearth/stac-api-spec) 
-builds on top of that core, but is out of scope for this overview. An [Item](item-spec/item-spec.md) is the core atomic unit, 
-representing a single [spatiotemporal asset](#what-is-a-spatiotemporal-asset) as GeoJSON so it can be searched. 
+builds on top of that core, but is out of scope for this overview. An [Item](item-spec/item-spec.md) represents a 
+single [spatiotemporal asset](#what-is-a-spatiotemporal-asset) as GeoJSON so it can be searched. 
 The [Catalog](catalog-spec/catalog-spec.md) specification provides structural elements, to group Items
 and [Collections](collection-spec/collection-spec.md). Collections *are* catalogs, that add more required metadata and 
 describe a group of related Items. For more on the differences see the [section below](#catalogs-vs-collections).
@@ -13,9 +13,11 @@ provided to help with navigating the specification.
 
 ## Item Overview
 
-Fundamental to any SpatioTemporal Asset Catalog, an [Item](item-spec/item-spec.md) represents an atomic collection of inseparable 
-data and metadata. A STAC Item is a [GeoJSON](http://geojson.org/) [Feature](https://tools.ietf.org/html/rfc7946#section-3.2)
-and can be easily read by any modern GIS or geospatial library, and it describes a [SpatioTemporal Asset](#what-is-a-spatiotemporal-asset). 
+Fundamental to any SpatioTemporal Asset Catalog, an [Item](item-spec/item-spec.md) object represents a unit of
+data and metadata, typically representing a single scene of data at one place and time.   A STAC Item is a 
+[GeoJSON](http://geojson.org/) [Feature](https://tools.ietf.org/html/rfc7946#section-3.2)
+and can be easily read by any modern GIS or geospatial library, and it describes a 
+[SpatioTemporal Asset](#what-is-a-spatiotemporal-asset). 
 The STAC Item JSON specification uses the GeoJSON geometry to describe the location of the asset, and 
 then includes additional information:
 


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

1. replace the use of "atomic unit" with a term less overloaded in computer science

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [ ] n/a I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
