### PR TITLE
fix uses of RC.1 instead of rc.1

### DIFF
--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -23,7 +23,7 @@
     },
     {
       "rel": "self",
-      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0-RC.1/examples/catalog.json",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0-rc.1/examples/catalog.json",
       "type": "application/json"
     }
   ]

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -86,7 +86,7 @@
     },
     {
       "rel": "self",
-      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0-RC.1/examples/collection.json",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0-rc.1/examples/collection.json",
       "type": "application/json"
     }
   ]


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

1. fix two uses of RC.1 in examples

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [ ] n/a I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] n/a This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
