### PR TITLE
Fix Item example with collections inside properties

### DIFF
--- a/examples/simple-item.json
+++ b/examples/simple-item.json
@@ -37,9 +37,9 @@
     ]
   },
   "properties": {
-    "datetime": "2020-12-11T22:38:32.125000Z",
-    "collection": "simple-collection"
+    "datetime": "2020-12-11T22:38:32.125000Z"
   },
+  "collection": "simple-collection",
   "links": [
     {
       "rel": "collection",


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

1. One of the item examples has the `collection` key inside properties, when I believe it should be at the top level.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
