### PR TITLE
docs: clarify description of Catalog, Collection, and Item

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ and tools to access metadata, instead of needing to write new code to interact
 with each data provider's proprietary formats and APIs. 
 
 The STAC specifications define related JSON object types connected by link 
-relations to support a "browse" style of traversable interface and a RESTful/HATEOAS
-API providing additional browse and search interfaces. 
+relations to support a [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS)-style traversable
+interface and a [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer) API
+providing additional browse and search interfaces.
 Typically, several STAC specifications are composed together to create an implementation. 
 The **Item**, **Catalog**, and **Collection** specifications define a minimal core 
 of the most frequently used JSON object types. Because of the hierarchical structure 

--- a/README.md
+++ b/README.md
@@ -4,26 +4,27 @@
 
 ## About
 
-The SpatioTemporal Asset Catalog (STAC) family of specifications aims to 
+The SpatioTemporal Asset Catalog (STAC) family of specifications aim to 
 standardize the way geospatial asset metadata is structured and queried. 
 A "spatiotemporal asset" is any file that represents information about 
 the Earth at a certain place and time. The original focus was on scenes 
-of satellite imagery, but now covers a broad variety of uses, including 
-sources such as aircraft and drone, and data such as hyperspectral optical, 
+of satellite imagery, but the specifications now cover a broad variety of uses, 
+including sources such as aircraft and drone and data such as hyperspectral optical, 
 synthetic aperture radar (SAR), video, point clouds, lidar, digital elevation 
 models (DEM), vector, machine learning labels, and composites like NDVI and 
 mosaics. STAC is intentionally designed with a minimal core and flexible 
-extension semantics to support a broad set of use cases.
+extension mechanism to support a broad set of use cases.
 
-The STAC specifications define JSON object types and hypermedia interface to be used 
-by providers and consumers of geospatial data.  
-This is advantageous to providers, as they can simply use a well-designed, 
-standard format without needing to design their own proprietary one. This 
-is advantageous to consumers because they can use existing libraries and 
-tools to access metadata, instead of needing to write new code to interact 
+This is advantageous to providers of geospatial data, as they can simply use a
+well-designed, standard format and API without needing to design their own proprietary one.
+This is advantageous to consumers  of geospatial data, as they can use existing libraries 
+and tools to access metadata, instead of needing to write new code to interact 
 with each data provider's proprietary formats and APIs. 
 
-Typically, several STAC specifications are composed together to create a catalog. 
+The STAC specifications define related JSON object types connected by link 
+relations to support a "browse" style of traversable interface and a RESTful/HATEOAS
+API providing additional browse and search interfaces. 
+Typically, several STAC specifications are composed together to create an implementation. 
 The **Item**, **Catalog**, and **Collection** specifications define a minimal core 
 of the most frequently used JSON object types. Because of the hierarchical structure 
 between these objects, a STAC catalog can be implemented in a completely 'static' 
@@ -44,8 +45,9 @@ with additional web service endpoints and object attributes.
 
 This specification has matured over the past several years, and is used in 
 [numerous production deployments](https://stacindex.org/catalogs). 
-With the 1.0 release, implementors should expect that most definitions will remain stable. Our goal
-is to not change the core in any backwards-incompatible way for a long time. 
+With the 1.0.0 release, implementors should expect that most definitions will remain 
+stable. Our goal
+is to maintain backwards-compatiblity within the core for a long time. 
 The STAC specification follows [Semantic Versioning](https://semver.org/), so once 
 1.0.0 is reached, any breaking change will require the spec to go to 2.0.0. 
 

--- a/catalog-spec/README.md
+++ b/catalog-spec/README.md
@@ -5,17 +5,14 @@ and [Item](../item-spec/item-spec.md) objects.  A Catalog contains an array of L
 objects and can include additional metadata to describe the objects contained therein. It is defined in full 
 in the [STAC Catalog Specification](catalog-spec.md).
 
-For more information on how the parts of STAC fit
-together see the [overview](../overview.md) document
+For more information on how the parts of STAC fit together see the [overview](../overview.md) document.
 
 A Catalog is typically the "entry point" into a STAC object hierarchy. For example, the root endpoint ("landing page") of a STAC API implementation is a Catalog. For many static STAC catalogs (e.g., those defined only by a set of files on disk or in a cloud object store), the root URL points to a Catalog that acts as the starting point to traverse the entire catalog of Catalog, Collection, and Item objects. 
 
-What's the diff between a Catalog and Collection?
-
 While STAC Catalogs mostly describe a structure of links and Items, a key related specification is the [STAC Collection Specification](../collection-spec/collection-spec.md),
-which extends Catalogs with additional fields to further describe the set of Items in a Catalog. 
+which contains fields that further describe the group of Items in a Catalog. 
 
-A STAC Catalog requires a subset of the fields required by a Collection. These are distinguished from one another by the `type` field, which will have the value `Catalog` or `Collection`.  This means that a Collection can be changed to a Catalog simply by changing this `type` field. 
+A STAC Catalog requires a subset of the fields required by a Collection. These are distinguished from one another by the `type` field, which will have the value `Catalog` or `Collection`.  This means that a Collection can be changed to a Catalog simply by changing this `type` field.  The parent-child relationships among Catalogs and Collections are for objects of these types, as there is no subtyping relationship between the Collection and Catalog types, even through they share field names.
 
 Catalogs are designed so that a simple file server on the web or object store like Amazon S3 can store JSON that defines a 
 full Catalog. More dynamic services can also return a Catalog structure, and the [STAC API](https://github.com/radiantearth/stac-api-spec)

--- a/catalog-spec/README.md
+++ b/catalog-spec/README.md
@@ -1,15 +1,21 @@
-# STAC Catalogs
+# STAC Catalog Specification
 
-While a [STAC Item](../item-spec/item-spec.md) is the most important entity in a SpatioTemporal Asset Catalog,
-the Catalog JSON definition is the core structure that enables browsers and crawlers to access
-the sets of Items. A Catalog consists of links to other Catalogs and Items, and can include
-additional metadata to further describe its holdings. It is defined in full in the 
-[STAC Catalog Specification](catalog-spec.md).
+A STAC [Catalog](catalog-spec.md) is a top-level object that logically groups other Catalog, Collection, 
+and [Item](../item-spec/item-spec.md) objects.  A Catalog contains an array of Link objects to these other 
+objects and can include additional metadata to describe the objects contained therein. It is defined in full 
+in the [STAC Catalog Specification](catalog-spec.md).
+
+For more information on how the parts of STAC fit
+together see the [overview](../overview.md) document
+
+A Catalog is typically the "entry point" into a STAC object hierarchy. For example, the root endpoint ("landing page") of a STAC API implementation is a Catalog. For many static STAC catalogs (e.g., those defined only by a set of files on disk or in a cloud object store), the root URL points to a Catalog that acts as the starting point to traverse the entire catalog of Catalog, Collection, and Item objects. 
+
+What's the diff between a Catalog and Collection?
 
 While STAC Catalogs mostly describe a structure of links and Items, a key related specification is the [STAC Collection Specification](../collection-spec/collection-spec.md),
-which extends Catalogs with additional fields to further describe the set of Items in a Catalog. STAC Collections share the same 
-fields with Catalogs and therefore every Collection is also a valid Catalog. For more information on how the parts of STAC fit
-together see the [overview](../overview.md) document.
+which extends Catalogs with additional fields to further describe the set of Items in a Catalog. 
+
+A STAC Catalog requires a subset of the fields required by a Collection. These are distinguished from one another by the `type` field, which will have the value `Catalog` or `Collection`.  This means that a Collection can be changed to a Catalog simply by changing this `type` field. 
 
 Catalogs are designed so that a simple file server on the web or object store like Amazon S3 can store JSON that defines a 
 full Catalog. More dynamic services can also return a Catalog structure, and the [STAC API](https://github.com/radiantearth/stac-api-spec)
@@ -17,7 +23,7 @@ specification contains an OpenAPI definition of the standard way to do this, at 
 
 ## In this directory
 
-**The Specification:** The main Catalog specification is in *[catalog-spec.md](catalog-spec.md)*.
+**Specification:** The main Catalog specification is in *[catalog-spec.md](catalog-spec.md)*.
 It includes in depth explanation of the structures and fields.
 
 **Schemas:** The schemas to validate the core Catalog definition are found in the *[json-schema/](json-schema/)* folder.

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -1,23 +1,28 @@
 # STAC Catalog Specification
 
-- [Catalog fields](#catalog-fields)
-  - [Additional Field Information](#additional-field-information)
-    - [stac_extensions](#stac_extensions)
-  - [Link Object](#link-object)
-    - [Relation types](#relation-types)
-- [Media Types](#media-types)
-  - [Media Type for STAC Catalogs](#media-type-for-stac-catalogs)
-  - [STAC Media Types](#stac-media-types)
-- [Extensions](#extensions)
+- [STAC Catalog Specification](#stac-catalog-specification)
+  - [Catalog fields](#catalog-fields)
+    - [Additional Field Information](#additional-field-information)
+      - [stac_extensions](#stac_extensions)
+    - [Link Object](#link-object)
+      - [Relation types](#relation-types)
+  - [Media Types](#media-types)
+    - [Media Type for STAC Catalogs](#media-type-for-stac-catalogs)
+    - [STAC Media Types](#stac-media-types)
+  - [Extensions](#extensions)
 
-This document explains the structure and content of a STAC Catalog. A STAC Catalog is a 
-[Collection](../collection-spec/collection-spec.md) of [STAC Items](../item-spec/item-spec.md). These Items can be 
-linked to directly from a Catalog, or the Catalog can link to other Catalogs (often called sub-Catalogs) that contain 
-links to Items. The division of sub-catalogs is up to the implementor, but is generally done to aid the ease of 
-online browsing by people.
+This document explains the structure and content of a STAC **Catalog** object. A STAC Catalog object 
+represents a logical group of other Catalog, 
+[Collection](../collection-spec/collection-spec.md), and [Item](../item-spec/item-spec.md) objects. 
+These Items can be linked to directly from a Catalog, or the Catalog can link to other Catalogs (often called 
+sub-catalogs) that contain links to Collections and Items. The division of sub-catalogs is up to the implementor,
+but is generally done to aid the ease of online browsing by people.
 
-Catalogs are not intended to be queried. Their purpose is discovery: to be browsed by people and crawled
-by machines to build a search index. A Catalog can be represented in JSON format. Any JSON object 
+A Catalog object will typically be the entry point into a STAC catalog. Their 
+purpose is discovery: to be browsed by people or be crawled
+by clients to build a searchable index.  
+
+Any JSON object 
 that contains all the required fields is a valid STAC Catalog.
 
 - [Examples](../examples/)
@@ -60,12 +65,12 @@ This list must only contain extensions that extend the Catalog itself, see the t
 This object describes a relationship with another entity. Data providers are advised to be liberal
 with links.
 
-| Field Name | Type   | Description                                                                                                                         |
-| ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| href       | string | **REQUIRED.** The actual link in the format of an URL. Relative and absolute links are both allowed.        |
+| Field Name | Type   | Description |
+| ---------- | ------ | ----------- |
+| href       | string | **REQUIRED.** The actual link in the format of an URL. Relative and absolute links are both allowed. |
 | rel        | string | **REQUIRED.** Relationship between the current document and the linked document. See chapter ["Relation types"](#relation-types) for more information. |
-| type       | string | [Media type](#media-types) of the referenced entity.                               |
-| title      | string | A human readable title to be used in rendered displays of the link.                                         |
+| type       | string | [Media type](#media-types) of the referenced entity. |
+| title      | string | A human readable title to be used in rendered displays of the link. |
 
 For a full discussion of the situations where relative and absolute links are recommended see the
 ['Use of links'](../best-practices.md#use-of-links) section of the STAC best practices.
@@ -106,11 +111,11 @@ A STAC Catalog is a JSON file ([RFC 8259](https://tools.ietf.org/html/rfc8259)),
 
 The following table lists the Media Types to use for STAC structures.
 
-| Media Type                     | Description                                                  |
-| ------------------------------ | ------------------------------------------------------------ |
-| `application/geo+json`	     | A STAC [Item](../item-spec/item-spec.md)                        |
-| `application/json`             | A STAC [Catalog](#stac-catalog-specification)                |
-| `application/json`             | A STAC [Collection](../collection-spec/collection-spec.md)            |
+| Media Type             | Description                                                |
+| ---------------------- | ---------------------------------------------------------- |
+| `application/geo+json` | A STAC [Item](../item-spec/item-spec.md)                   |
+| `application/json`     | A STAC [Catalog](#stac-catalog-specification)              |
+| `application/json`     | A STAC [Collection](../collection-spec/collection-spec.md) |
 
 ## Extensions
 

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -16,14 +16,13 @@ represents a logical group of other Catalog,
 [Collection](../collection-spec/collection-spec.md), and [Item](../item-spec/item-spec.md) objects. 
 These Items can be linked to directly from a Catalog, or the Catalog can link to other Catalogs (often called 
 sub-catalogs) that contain links to Collections and Items. The division of sub-catalogs is up to the implementor,
-but is generally done to aid the ease of online browsing by people.
+but is generally done to aid the ease of online browsing by people. 
 
 A Catalog object will typically be the entry point into a STAC catalog. Their 
 purpose is discovery: to be browsed by people or be crawled
 by clients to build a searchable index.  
 
-Any JSON object 
-that contains all the required fields is a valid STAC Catalog.
+Any JSON object that contains all the required fields is a valid STAC Catalog object.
 
 - [Examples](../examples/)
   - See an example [catalog.json](../examples/catalog.json). The [collection.json](../examples/collection.json) is also a valid

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -1,15 +1,14 @@
 # STAC Catalog Specification
 
-- [STAC Catalog Specification](#stac-catalog-specification)
-  - [Catalog fields](#catalog-fields)
-    - [Additional Field Information](#additional-field-information)
-      - [stac_extensions](#stac_extensions)
-    - [Link Object](#link-object)
-      - [Relation types](#relation-types)
-  - [Media Types](#media-types)
-    - [Media Type for STAC Catalogs](#media-type-for-stac-catalogs)
-    - [STAC Media Types](#stac-media-types)
-  - [Extensions](#extensions)
+- [Catalog fields](#catalog-fields)
+  - [Additional Field Information](#additional-field-information)
+    - [stac_extensions](#stac_extensions)
+  - [Link Object](#link-object)
+    - [Relation types](#relation-types)
+- [Media Types](#media-types)
+  - [Media Type for STAC Catalogs](#media-type-for-stac-catalogs)
+  - [STAC Media Types](#stac-media-types)
+- [Extensions](#extensions)
 
 This document explains the structure and content of a STAC **Catalog** object. A STAC Catalog object 
 represents a logical group of other Catalog, 

--- a/collection-spec/README.md
+++ b/collection-spec/README.md
@@ -1,26 +1,33 @@
-# STAC Collections
+# STAC Collection Specification
 
-The STAC [Collection specification](collection-spec.md) provides JSON fields to describe a set of Items, to help enable discovery. 
-It builds on fields from the [Catalog Specification](../catalog-spec/catalog-spec.md), using the flexible structure detailed there to 
-further define and explain logical groups of [Items](../item-spec/item-spec.md). Collections can have both parent Catalogs 
-and Collections as well as child Items, Catalogs and Collections.
+A STAC [Collection](collection-spec.md) object is used to describe a group of related 
+Items. It builds on fields defined for a [Catalog](../catalog-spec/catalog-spec.md) object
+by further defining and explaining logical groups of [Items](../item-spec/item-spec.md). A
+Collection can have parent Catalogs and Collections, as well as child Items, Catalogs, 
+and Collections.
 
-The Collection concept can be used very flexibly - it provides additional metadata about a set of Items. But it generally
-is used to describe a set of assets that are defined with the same properties and share higher level metadata. There is no standardized 
-name for this, and others called it: dataset series (ESA, ISO 19115), collection (CNES, NASA), dataset (JAXA), product (JAXA). Or
-viewed in GIS terms, the Items are '[features](https://en.wikipedia.org/wiki/Simple_Features)' (that link to assets) and a 
-Collection is the 'layer'. STAC uses the same terms as the [OGC Features API](https://ogcapi.ogc.org/features/), and indeed
-a STAC Collection is a valid [Feature API Collection](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#example_4), extending
-it with additional fields.
+A Collection provides a flexible mechanism to provide additional metadata about a set of Items.  
+Generally, is used to describe a set of assets that 
+are defined with the same properties and share higher-level metadata. There is no 
+standardized name for this sort of logical grouping, but other places it is called a "
+dataset series" (ESA, ISO 19115), "collection" (CNES, NASA), "dataset" (JAXA), or "product"
+(JAXA). In GIS terms, the Items are
+'[features](https://en.wikipedia.org/wiki/Simple_Features)' (that link to assets) and 
+a Collection is the 'layer'. STAC uses the same terms as the
+[OGC Features API](https://ogcapi.ogc.org/features/). A STAC Collection is a valid 
+[Feature API Collection](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#example_4), 
+extending it with additional fields.
 
-Thus the additional fields in a Collection detail the type of information a user would want to know about the set of Items it
-contains. Items are required to provide a link back to their collection definition. But the Collection is independent of STAC Items and 
-STAC Catalogs, and thus other parties can also use this specification standalone, as a way to describe collections in a lightweight way. 
-For more details on how the STAC specs fit together see the [overview](../overview.md) document. 
+Thus, the additional fields in a Collection detail the type of information a user would want to 
+know about the group of Items it contains. Items are required to provide a link back to their 
+collection definition. But the Collection is independent of STAC Items and STAC Catalogs, and thus 
+other parties can also use this specification standalone, as a way to describe collections in a 
+lightweight way. For more details on how the STAC specs fit together see the [overview](../overview.md) 
+document. 
 
 ## In this directory
 
-**The Specification:** The main STAC Collection specification is in *[collection-spec.md](collection-spec.md)*. It includes an overview and in depth explanation of the 
+**Specification:** The main STAC Collection specification is in *[collection-spec.md](collection-spec.md)*. It includes an overview and in depth explanation of the 
 structures and fields.
 
 **Schemas:** The schemas to validate the STAC Collection definition are found in the 

--- a/collection-spec/README.md
+++ b/collection-spec/README.md
@@ -3,8 +3,9 @@
 A STAC [Collection](collection-spec.md) object is used to describe a group of related 
 Items. It builds on fields defined for a [Catalog](../catalog-spec/catalog-spec.md) object
 by further defining and explaining logical groups of [Items](../item-spec/item-spec.md). A
-Collection can have parent Catalogs and Collections, as well as child Items, Catalogs, 
-and Collections.
+Collection can have parent Catalog and Collection objects, as well as child Item, Catalog, 
+and Collection objects. These parent-child relationships among objects of these types, as there is no 
+subtyping relationship between the Collection and Catalog types, even through they share field names.
 
 A Collection provides a flexible mechanism to provide additional metadata about a set of Items.  
 Generally, is used to describe a set of assets that 

--- a/item-spec/README.md
+++ b/item-spec/README.md
@@ -21,4 +21,3 @@ schemas validate additional fields defined in *[Common Metadata](common-metadata
 
 **Common Metadata:** A set of commonly-used fields for STAC Items is listed in 
 *[common-metadata.md](common-metadata.md)*.
-

--- a/item-spec/README.md
+++ b/item-spec/README.md
@@ -1,6 +1,6 @@
 # STAC Item Specification
 
-The [STAC Item spec](item-spec.md) defines the most important object in a STAC system. An
+The [STAC Item](item-spec.md) object is the most important object in a STAC system. An
 **Item** is the entity that contains metadata for a scene and links to the assets. 
 
 Item objects are the leaf nodes for a graph of [Catalog](../catalog-spec/catalog-spec.md) 

--- a/item-spec/README.md
+++ b/item-spec/README.md
@@ -1,19 +1,24 @@
 # STAC Items
 
-The core of a SpatioTemporal Asset Catalog (STAC) is a set of JSON fields defined by the 
-[STAC Item spec](item-spec.md). These fields define an **Item** - the entity that contains 
-metadata for search as well as links to the actual assets that they represent. Their main function 
-is as the leaf nodes of a [Catalog](../catalog-spec/catalog-spec.md).
-See the [overview](../overview.md) document for more information on how all the pieces fit together.
+The [STAC Item spec](item-spec.md) defines the most important object in a STAC system. An
+**Item** is the entity that contains metadata for a scene and links to the assets. 
+
+Item objects are the leaf nodes for a graph of [Catalog](../catalog-spec/catalog-spec.md) 
+and [Collection](../collection-spec/collection-spec.md) objects. See the 
+[overview](../overview.md) document for more information about how these objects relate 
+to each other.
 
 ## In this directory
 
-**Item Specification:** The main definition of the STAC Item specification is in 
+**Specification:** The STAC Item specification is in 
 *[item-spec.md](item-spec.md)*. It includes an overview and an in-depth explanation of the fields.
 
-**Common Metadata:** A set of commonly used metadata fields for STAC Items is listed in 
+**Schemas:** The OpenAPI specification in *[item.json](json-schema/item.json)* 
+defines an **Item** object. The [basics](json-schema/basics.json), 
+[datetime](json-schema/datetime.json), [instrument](json-schema/instrument.json), 
+[licensing](json-schema/licensing.json), and [provider](json-schema/provider.json)
+schemas validate additional fields defined in *[Common Metadata](common-metadata.md)*.
+
+**Common Metadata:** A set of commonly-used fields for STAC Items is listed in 
 *[common-metadata.md](common-metadata.md)*.
 
-**Schemas:** The schemas to validate the core Item definitions are found in the 
-*[json-schema/](json-schema/)* folder. The *[item.json](json-schema/item.json)* validates items overall
-and the additional schemas validate the various groups of *[Common Metadata](common-metadata.md)*.

--- a/item-spec/README.md
+++ b/item-spec/README.md
@@ -1,4 +1,4 @@
-# STAC Items
+# STAC Item Specification
 
 The [STAC Item spec](item-spec.md) defines the most important object in a STAC system. An
 **Item** is the entity that contains metadata for a scene and links to the assets. 


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

Clarify text around the uses of the different objects.   

Specifically, I think a new user coming to STAC would be confused about what the difference between a Catalog and Collection is, and how to divide their Items up. I also tried to be more precise in when we refer to a "STAC catalog" and the specific object type of Catalog -- this can get confusing, since you can have a small-c catalog that's a Collection. 

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
