### PR TITLE
updates stac_extensions values to replace short names with uris

### DIFF
--- a/examples/collectionless-item.json
+++ b/examples/collectionless-item.json
@@ -1,8 +1,8 @@
 {
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
-    "eo",
-    "view"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "type": "Feature",
   "id": "CS3-20160503_132131_08",

--- a/examples/extended-item.json
+++ b/examples/extended-item.json
@@ -1,10 +1,10 @@
 {
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
-    "eo",
-    "projection",
-    "scientific",
-    "view"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "type": "Feature",
   "id": "20201211_223832_CS2",

--- a/examples/extensions-collection/proj-example/proj-example.json
+++ b/examples/extensions-collection/proj-example/proj-example.json
@@ -271,8 +271,8 @@
     60.63437
   ],
   "stac_extensions": [
-    "eo",
-    "projection"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
   ],
   "collection": "landsat-8-l1"
 }


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

1. Update extension references to be URIs instead of shortnames


**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] n/a This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
