### PR TITLE
Clarified stac_extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified that stac_extensions should also list extensions that are used in Collection summaries. ([#1077](https://github.com/radiantearth/stac-spec/issues/1077))
+
 ## [v1.0.0-rc.2] - 2021-03-30
 
 ### Changed

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -64,7 +64,7 @@ A list of extensions the Catalog implements.
 The list consists of URLs to JSON Schema files that can be used for validation.
 This list must only contain extensions that extend the Catalog specification itself,
 see the 'Scope' for each of the extensions.
-This must **not** declare the extensions that are only implemented in child Collection or Items.
+This must **not** declare the extensions that are only implemented in child Collection objects or child Item objects.
 
 ### Link Object
 

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -63,7 +63,7 @@ In general, STAC versions can be mixed, but please keep the [recommended best pr
 A list of extensions the Catalog implements.
 The list consists of URLs to JSON Schema files that can be used for validation.
 This list must only contain extensions that extend the Catalog specification itself,
-see the the 'Scope' for each of the extensions.
+see the 'Scope' for each of the extensions.
 This must **not** declare the extensions that are only implemented in child Collection or Items.
 
 ### Link Object

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -61,9 +61,10 @@ In general, STAC versions can be mixed, but please keep the [recommended best pr
 #### stac_extensions
 
 A list of extensions the Catalog implements.
-This list must only contain extensions that extend the Catalog itself, see the the 'Scope' column in the list of
-extensions. This does NOT declare the extensions of child Catalog, Collection, or Item
-objects. The list contains URLs to the JSON Schema files it can be validated against.
+The list consists of URLs to JSON Schema files that can be used for validation.
+This list must only contain extensions that extend the Catalog specification itself,
+see the the 'Scope' for each of the extensions.
+This must **not** declare the extensions that are only implemented in child Collection or Items.
 
 ### Link Object
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -65,16 +65,11 @@ In general, STAC versions can be mixed, but please keep the [recommended best pr
 
 #### stac_extensions
 
-A list of extensions the Collection implements.  
-This list must only contain extensions that extend the Collection itself, see the the 'Scope' column in the list of 
-extensions. This does NOT declare the extensions of child Collection or Item 
-objects. The list contains URLs to the JSON Schema files it can be validated against.
-
-If an extension has influence on multiple parts 
-of the whole STAC structure, it must be listed in all affected parts (e.g. Collection and Item for the `datacube` extension). 
-If a structure, such as the summaries extension, provides fields in their JSON structure, these extensions must not be listed 
-here as they don't extend the Collection itself. For example, if a Collection includes the field `sat:platform` in the 
-summaries, the Collection should not list the `sat` extension in the `stac_extensions` field.
+A list of extensions the Collection implements.
+The list consists of URLs to JSON Schema files that can be used for validation.
+This list must only contain extensions that extend the Collection specification itself,
+see the the 'Scope' for each of the extensions.
+This must **not** declare the extensions that are only implemented in child Collection or Items.
 
 #### id
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -69,7 +69,7 @@ A list of extensions the Collection implements.
 The list consists of URLs to JSON Schema files that can be used for validation.
 This list must only contain extensions that extend the Collection specification itself,
 see the the 'Scope' for each of the extensions.
-This must **not** declare the extensions that are only implemented in child Collection or Items.
+This must **not** declare the extensions that are only implemented in child Collection objects or child Item objects.
 
 #### id
 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -73,11 +73,10 @@ In general, STAC versions can be mixed, but please keep the [recommended best pr
 
 #### stac_extensions
 
-A list of extensions the Item implements.  
-This list must only contain extensions that extend the Item itself, see the the 'Scope' column in the list of 
-extensions. The list contains URLs to the JSON Schema files it can be validated against.
-If an extension such as the `tiled-assets` extension has influence on multiple parts of the whole catalog 
-structure, it must be listed in all affected parts (e.g. Catalog, Collection and Item for the `tiled-assets` extension).
+A list of extensions the Item implements.
+The list consists of URLs to JSON Schema files that can be used for validation.
+This list must only contain extensions that extend the Item specification itself,
+see the the 'Scope' for each of the extensions.
 
 #### id
 


### PR DESCRIPTION
**Related Issue(s):** #1077


**Proposed Changes:**

1. For context see #1077, but it basically makes it more consistent that stac_extensions also allow to list extensions that are used in collection summaries.
2. Re-phrased the stac_extensions description in all specs.
3. Removed the wording around "multiple affected parts" as that should be clear from each individual stac_extensions description, which requires to list stac_extensions if they are implemented. That was mostly for the commons extension back in the days, but nowadays had no real good example anymore. The data cube example in collections for example was not really correct.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
