### PR TITLE
Clarification on multiple bounding boxes in an extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- The first extent in a Collection is always the overall extent, followed by more specific extents. ([#1064](https://github.com/radiantearth/stac-spec/issues/1064), [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520))
+
 ## [v1.0.0-rc.2] - 2021-03-30
 
 ### Changed

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -147,7 +147,12 @@ The object describes the spatial extents of the Collection.
 | ------- | ------------ | -------------------------------------------------------------------- |
 | bbox    | \[\[number]] | **REQUIRED.** Potential *spatial extents* covered by the Collection. |
 
-**bbox**: Bounding Boxes of the assets represented by this Collection using either 2D or 3D geometries. Each outer array element can be a separate bounding box, but it is recommended to only use multiple bounding boxes if a union of them would then include a large uncovered area (e.g. the union of Germany and Chile).
+**bbox**: Each outer array element can be a separate spatial extent describing the bounding Boxes of the assets represented by this Collection using either 2D or 3D geometries.
+
+The first bounding box always describes the overall spatial extent of the data. All subsequent bounding boxes can be
+used to provide a more precise description of the extent and identify clusters of data.
+Clients only interested in the overall spatial extent will only need to access the first item in each array.
+It is recommended to only use multiple bounding boxes if a union of them would then include a large uncovered area (e.g. the union of Germany and Chile).
 
 The length of the inner array must be 2*n where n is the number of dimensions. The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most extent is the minimum depth/height in meters and the elevation of the northeasterly most extent is the maximum.
 
@@ -161,7 +166,12 @@ The object describes the temporal extents of the Collection.
 | -------- | ------------------ | --------------------------------------------------------------------- |
 | interval | \[\[string\|null]] | **REQUIRED.** Potential *temporal extents* covered by the Collection. |
 
-**interval**: Each outer array element can be a separate temporal extent, but it is recommended to only use multiple temporal extents if a union of them would then include a large uncovered time span (e.g. only having data for the years 2000, 2010 and 2020).
+**interval**: Each outer array element can be a separate temporal extent.
+The first time interval always describes the overall temporal extent of the data. All subsequent time intervals
+can be used to provide a more precise description of the extent and identify clusters of data.
+Clients only interested in the overall extent will only need to access the first item in each array.
+It is recommended to only use multiple temporal extents if a union of them would then include a large
+uncovered time span (e.g. only having data for the years 2000, 2010 and 2020).
 
 Each inner array consists of exactly two dates and times. Each date and time MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). The temporal reference system is the Gregorian calendar.
 


### PR DESCRIPTION
**Related Issue(s):** 
- https://github.com/radiantearth/stac-spec/issues/1064
- https://github.com/opengeospatial/ogcapi-features/pull/520


**Proposed Changes:**

1. Adopt clarification by OGC API - Features on multiple extents in collections

cc @cportele

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR https://github.com/radiantearth/stac-api-spec/pull/117 to track the change.
