### PR TITLE
Update STAC Node Validator, fix examples, fix #1088

### DIFF
--- a/examples/extensions-collection/proj-example/proj-example.json
+++ b/examples/extensions-collection/proj-example/proj-example.json
@@ -219,6 +219,11 @@
       "rel": "parent",
       "href": "../collection.json",
       "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "../collection.json",
+      "type": "application/json"
     }
   ],
   "assets": {

--- a/examples/extensions-collection/proj-example/proj-example.json
+++ b/examples/extensions-collection/proj-example/proj-example.json
@@ -242,7 +242,6 @@
       "eo:bands": [
         {
           "name": "B8",
-          "common_name": "panchromatic",
           "center_wavelength": 0.59,
           "full_width_half_max": 0.18
         }

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -183,7 +183,7 @@ This happens where there is not a clear official option, or where STAC uses an o
 | self         | STRONGLY RECOMMENDED. *Absolute* URL to the Item if it is available at a public URL. This is particularly useful when in a download package that includes metadata, so that the downstream user can know where the data has come from. |
 | root         | URL to the root STAC Catalog or Collection. |
 | parent       | URL to the parent STAC Catalog or Collection. |
-| collection   | STRONGLY RECOMMENDED. URL to a Collection. *Absolute* URLs should be used whenever possible. The referenced Collection is STRONGLY RECOMMENDED to implement the same STAC version as the Item. |
+| collection   | STRONGLY RECOMMENDED. URL to a Collection. *Absolute* URLs should be used whenever possible. The referenced Collection is STRONGLY RECOMMENDED to implement the same STAC version as the Item. A link with this `rel` type is *required* if the `collection` field in properties is present. |
 | derived_from | URL to a STAC Item that was used as input data in the creation of this Item. |
 
 A more complete list of potential `rel` types and their meaning in STAC can be found in the [Using Relation 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -63,7 +63,7 @@ inherited from GeoJSON.
 | properties | [Properties Object](#properties-object)                                    | **REQUIRED.** A dictionary of additional metadata for the Item. |
 | links      | \[[Link Object](#link-object)]                                             | **REQUIRED.** List of link objects to resources and related URLs. A link with the `rel` set to `self` is strongly recommended. |
 | assets     | Map<string, [Asset Object](#asset-object)>                                 | **REQUIRED.** Dictionary of asset objects that can be downloaded, each with a unique key. |
-| collection | string                                                                     | The `id` of the STAC Collection this Item references to (see [`collection` relation type](#relation-types)). This field is *required* if such a relation type is present. This field provides an easy way for a user to search for any Items that belong in a specified Collection. Must be a non-empty string. |
+| collection | string                                                                     | The `id` of the STAC Collection this Item references to (see [`collection` relation type](#relation-types)). This field is *required* if such a relation type is present and is *not allowed* otherwise. This field provides an easy way for a user to search for any Items that belong in a specified Collection. Must be a non-empty string. |
 
 ### Additional Field Information
 

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -159,12 +159,42 @@
                   ]
                 }
               ]
-            },
-            "collection": {
-              "title": "Collection ID",
-              "description": "The ID of the STAC Collection this Item references to.",
-              "type": "string",
-              "minLength": 1
+            }
+          },
+          "if": {
+            "properties": {
+              "links": {
+                "contains": {
+                  "required": [
+                    "rel"
+                  ],
+                  "properties": {
+                    "rel": {
+                      "const": "collection"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "collection"
+            ],
+            "properties": {
+              "collection": {
+                "title": "Collection ID",
+                "description": "The ID of the STAC Collection this Item references to.",
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "collection": {
+                "not": {}
+              }
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "remark-preset-lint-markdown-style-guide": "^3.0.0",
     "remark-preset-lint-recommended": "^4.0.0",
     "remark-validate-links": "^10.0.0",
-    "stac-node-validator": "^0.4.6"
+    "stac-node-validator": "^1.0.1"
   }
 }


### PR DESCRIPTION
**Related Issue(s):** #1088


**Proposed Changes:**

1. Node Validator was not updated yet to v1.x.x and thus was not able to correctly validate
2. Fix issues in examples that were found
3. Implement and clarify #1088

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have opened issue/PR #XXX to track the change.
