### PR TITLE
JSON Schema in summaries #1045

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Summaries are allowed to specify JSON Schema in addition to ranges and sets of values. ([#1045](https://github.com/radiantearth/stac-spec/issues/1045))
+
 ### Changed
 
 - The first extent in a Collection is always the overall extent, followed by more specific extents. ([#1064](https://github.com/radiantearth/stac-spec/issues/1064), [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520))
 - Updated examples for automatic collection creation from code and validation ([#1080](https://github.com/radiantearth/stac-spec/pull/1080)
 - Clarified that stac_extensions should also list extensions that are used in Collection summaries. ([#1077](https://github.com/radiantearth/stac-spec/issues/1077))
+- The Stats Object for Summaries has been renamed to Range Object (no functional change).
 
 ## [v1.0.0-rc.2] - 2021-03-30
 
@@ -46,7 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- The [Stats Object](collection-spec/collection-spec.md#stats-object) for Collection `summaries` changed `min` to `minimum` and `max` to `maximum` to align with JSON Schema. ([#967](https://github.com/radiantearth/stac-spec/pull/967))
+- The [Stats Object](collection-spec/collection-spec.md#range-object) for Collection `summaries` changed `min` to `minimum` and `max` to `maximum` to align with JSON Schema. ([#967](https://github.com/radiantearth/stac-spec/pull/967))
 - URIs (usually found int properties like `href`, `url`) are now validated using the `iri-reference` format in JSON Schema (allows international characters in URIs) ([#953](https://github.com/radiantearth/stac-spec/pull/953))
 - Enhanced the way the spec talks about ID's to encourage more global uniqueness. ([#883](https://github.com/radiantearth/stac-spec/pull/883))
 - Clarified how collection-level asset object properties do not remove the need for item-level asset object properties in the `item-assets` extension ([#880](https://github.com/radiantearth/stac-spec/pull/880))

--- a/catalog-spec/catalog-spec.md
+++ b/catalog-spec/catalog-spec.md
@@ -49,7 +49,7 @@ also a valid STAC Catalog.
 | id              | string        | **REQUIRED.** Identifier for the Catalog.                    |
 | title           | string        | A short descriptive one-line title for the Catalog.          |
 | description     | string        | **REQUIRED.** Detailed multi-line description to fully explain the Catalog. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| summaries       | Map<string, \[*]\|[Stats Object](../collection-spec/collection-spec.md#stats-object)> | A map of property summaries, either a set of values or statistics such as a range. More info in the [Collection spec](../collection-spec/collection-spec.md#summaries). |
+| summaries       | Map<string, \[\*]\|[Range Object](../collection-spec/collection-spec.md#range-object)\|[JSON Schema Object](../collection-spec/collection-spec.md#json-schema-object)> | A map of property summaries, either a set of values, a range of values or a [JSON Schema](https://json-schema.org). More info in the [Collection spec](../collection-spec/collection-spec.md#summaries). |
 | links           | [[Link Object](#link-object)] | **REQUIRED.** A list of references to other documents.       |
 
 ### Additional Field Information

--- a/catalog-spec/json-schema/catalog-core.json
+++ b/catalog-spec/json-schema/catalog-core.json
@@ -99,9 +99,18 @@
     "summaries": {
       "type": "object",
       "additionalProperties": {
-        "oneOf": [
+        "anyOf": [
           {
-            "title": "Stats",
+            "title": "JSON Schema",
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "http://json-schema.org/draft-07/schema"
+              }
+            ]
+          },
+          {
+            "title": "Range",
             "type": "object",
             "required": [
               "minimum",
@@ -129,7 +138,7 @@
             "type": "array",
             "minItems": 1,
             "items": {
-              "description": "Any data type could occur."
+              "description": "For each field only the original data type of the property can occur (except for arrays), but we can't validate that in JSON Schema yet. See the sumamry description in the STAC specification for details."
             }
           }
         ]

--- a/catalog-spec/json-schema/catalog-core.json
+++ b/catalog-spec/json-schema/catalog-core.json
@@ -103,6 +103,7 @@
           {
             "title": "JSON Schema",
             "type": "object",
+            "minProperties": 1,
             "allOf": [
               {
                 "$ref": "http://json-schema.org/draft-07/schema"

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -16,7 +16,8 @@
   - [Link Object](#link-object)
     - [Relation types](#relation-types)
   - [Asset Object](#asset-object)
-  - [Stats Object](#stats-object)
+  - [Range Object](#range-object)
+  - [JSON Schema Object](#json-schema-object)
 - [Media Type for STAC Collections](#media-type-for-stac-collections)
 - [Standalone Collections](#standalone-collections)
 
@@ -54,7 +55,7 @@ specified in [*OGC API - Features*](https://ogcapi.ogc.org/features/), but they 
 | license         | string                                           | **REQUIRED.** Collection's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `various` if multiple licenses apply or `proprietary` for all other cases. |
 | providers       | \[[Provider Object](#provider-object)]           | A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list. |
 | extent          | [Extent Object](#extent-object)                  | **REQUIRED.** Spatial and temporal extents.                  |
-| summaries       | Map<string, \[*]\|[Stats Object](#stats-object)> | STRONGLY RECOMMENDED. A map of property summaries, either a set of values or statistics such as a range. |
+| summaries       | Map<string, \[\*]\|[Range Object](#range-object)\|[JSON Schema Object](#json-schema-object)> | STRONGLY RECOMMENDED. A map of property summaries, either a set of values, a range of values or a [JSON Schema](https://json-schema.org). |
 | links           | \[[Link Object](#link-object)]                   | **REQUIRED.** A list of references to other documents.       |
 | assets          | Map<string, [Asset Object](#asset-object)>       | Dictionary of asset objects that can be downloaded, each with a unique key. |
 
@@ -95,12 +96,12 @@ Summaries help to fully define Collections, especially if they don't link to any
 build tailored user interfaces for querying the data, by presenting the potential values that are available.
 Summaries should summarize all values in every Item underneath the collection, including in any nested sub-Catalogs.
 
-A summary for a field can be specified in two ways:
+A summary for a field can be specified in three ways:
 
 1. A set of all distinct values in an array: The set of values must contain at least one element and it is strongly recommended to list all values.
    If the field summarizes an array (e.g. [`instruments`](../item-spec/common-metadata.md#instrument)),
    the field's array elements of each Item must be merged to a single array with unique elements.
-2. Statistics in a [Stats Object](#stats-object): Statistics by default only specify the range (minimum and maximum values),
+2. A Range in a [Range Object](#range-object): Statistics by default only specify the range (minimum and maximum values),
    but can optionally be accompanied by additional statistical values.
    The range specified by the `minimum` and `maximum` properties can specify the potential range of values,
    but it is recommended to be as precise as possible.
@@ -281,9 +282,9 @@ or streamed. The definition provided here, at the Collection level, is the same 
 | type        | string    | [Media type](../item-spec/item-spec.md#asset-media-type) of the asset. See the [common media types](../best-practices.md#common-media-types-in-stac) in the best practice doc for commonly used asset types. |
 | roles       | \[string] | The [semantic roles](../item-spec/item-spec.md#asset-role-types) of the asset, similar to the use of `rel` in links. |
 
-### Stats Object
+### Range Object
 
-For a good understanding of the summarized field, statistics can be added.
+For summaries with a lot of continuous values, statistics can be added.
 By default, only ranges with a minimum and a maximum value can be specified.
 Ranges can be specified for [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values only,
 which means they need to have a rank order.
@@ -294,6 +295,14 @@ Implementors are free to add other derived statistical values to the object, for
 | ---------- | -------------- | ----------- |
 | minimum    | number\|string | **REQUIRED.** Minimum value. |
 | maximum    | number\|string | **REQUIRED.** Maximum value. |
+
+### JSON Schema Object
+
+For a full understanding of the summarized field, a JSON Schema can be added for each summarized field.
+This allows very fine-grained information for each field and each value as JSON Schema is also extensible.
+
+It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
+to align with the JSON Schemas provided by STAC.
 
 ## Media Type for STAC Collections
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -284,7 +284,7 @@ or streamed. The definition provided here, at the Collection level, is the same 
 
 ### Range Object
 
-For summaries with a lot of continuous values, statistics can be added.
+For summaries that would normally consist of a lot of continuous values, statistics can be added instead.
 By default, only ranges with a minimum and a maximum value can be specified.
 Ranges can be specified for [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values only,
 which means they need to have a rank order.

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -307,6 +307,8 @@ Each schema must be valid against all corresponding values available for the pro
 It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
 to align with the JSON Schemas provided by STAC. Empty schemas are not allowed.
 
+For an introduction to JSON Schema, see "[Learn JSON Schema](https://json-schema.org/learn/)".
+
 ## Media Type for STAC Collections
 
 A STAC Collection is a JSON file ([RFC 8259](https://tools.ietf.org/html/rfc8259)), and thus should use the 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -300,9 +300,10 @@ Implementors are free to add other derived statistical values to the object, for
 
 For a full understanding of the summarized field, a JSON Schema can be added for each summarized field.
 This allows very fine-grained information for each field and each value as JSON Schema is also extensible.
+Each schema must be valid against all corresponding values available for the property in the sub-Items.
 
 It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
-to align with the JSON Schemas provided by STAC.
+to align with the JSON Schemas provided by STAC. Empty schemas are not allowed.
 
 ## Media Type for STAC Collections
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -105,6 +105,8 @@ A summary for a field can be specified in three ways:
    but can optionally be accompanied by additional statistical values.
    The range specified by the `minimum` and `maximum` properties can specify the potential range of values,
    but it is recommended to be as precise as possible.
+3. Extensible JSON Schema definitions for fine-grained information, see the [JSON Schema Object](#json-schema-object)
+   section for more.
 
 All values must follow the schema of the property they summarize.
 So the values in the array or the values given for `minimum` and `maxmimum` must comply to the original data type

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -22,6 +22,12 @@
       "title": "Collection with no items (standalone)"
     },
     {
+      "rel": "child",
+      "href": "./collection-only/collection-with-schemas.json",
+      "type": "application/json",
+      "title": "Collection with no items (standalone with JSON Schemas)"
+    },
+    {
       "rel": "item",
       "href": "./collectionless-item.json",
       "type": "application/json",

--- a/examples/collection-only/collection-with-schemas.json
+++ b/examples/collection-only/collection-with-schemas.json
@@ -1,0 +1,281 @@
+{
+  "stac_version": "1.0.0-rc.2",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
+  "id": "S2",
+  "type": "Collection",
+  "title": "Level 1C Sentinel-2 images",
+  "description": "The SENTINEL-2 mission is a land monitoring constellation of two satellites each equipped with a MSI (Multispectral Imager) instrument covering 13 spectral bands providing high resolution optical imagery (i.e., 10m, 20m, 60 m) every 10 days with one satellite and 5 days with two satellites",
+  "license": "proprietary",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180,
+          -82.852377834669,
+          180,
+          82.819463367711
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2017-04-12T02:57:21.459000Z",
+          "2021-04-22T11:30:12.767000Z"
+        ]
+      ]
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "https://tamn.snapplanet.io/collections/S2"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://tamn.snapplanet.io"
+    },
+    {
+      "rel": "license",
+      "href": "https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf",
+      "title": "Legal notice on the use of Copernicus Sentinel Data and Service Information"
+    }
+  ],
+  "providers": [
+    {
+      "name": "European Union/ESA/Copernicus",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi"
+    },
+    {
+      "name": "AWS",
+      "roles": [
+        "host"
+      ],
+      "url": "https://registry.opendata.aws/sentinel-2/"
+    },
+    {
+      "name": "jeobrowser",
+      "roles": [
+        "processor"
+      ],
+      "url": "https://github.com/jjrom/resto"
+    }
+  ],
+  "summaries": {
+    "datetime": {
+      "minimum": "2017-04-12T02:57:21.459000Z",
+      "maximum": "2021-04-22T11:30:12.767000Z"
+    },
+    "collection": {
+      "type": "string",
+      "const": "sentinel-2",
+      "title": "Sentinel 2",
+      "count": 6613407
+    },
+    "instruments": {
+      "type": "string",
+      "const": "msi",
+      "title": "MSI",
+      "count": 6613431
+    },
+    "landcover": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "landcover:cultivated",
+          "title": "Cultivated",
+          "count": 490750
+        },
+        {
+          "const": "landcover:desert",
+          "title": "Desert",
+          "count": 543120
+        },
+        {
+          "const": "landcover:flooded",
+          "title": "Flooded",
+          "count": 5187
+        },
+        {
+          "const": "landcover:forest",
+          "title": "Forest",
+          "count": 767807
+        },
+        {
+          "const": "landcover:herbaceous",
+          "title": "Herbaceous",
+          "count": 674281
+        },
+        {
+          "const": "landcover:ice",
+          "title": "Ice",
+          "count": 231285
+        },
+        {
+          "const": "landcover:urban",
+          "title": "Urban",
+          "count": 1219
+        },
+        {
+          "const": "landcover:water",
+          "title": "Water",
+          "count": 2303314
+        }
+      ]
+    },
+    "location": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "tropical",
+          "title": "Tropical",
+          "count": 1807474
+        },
+        {
+          "const": "southern",
+          "title": "Southern",
+          "count": 1671685
+        },
+        {
+          "const": "northern",
+          "title": "Northern",
+          "count": 4876669
+        },
+        {
+          "const": "equatorial",
+          "title": "Equatorial",
+          "count": 27302
+        },
+        {
+          "const": "coastal",
+          "title": "Coastal",
+          "count": 1495516
+        }
+      ]
+    },
+    "platform": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "sentinel-2b",
+          "title": "Sentinel 2B",
+          "count": 3495597
+        },
+        {
+          "const": "sentinel-2a",
+          "title": "Sentinel 2A",
+          "count": 3117831
+        }
+      ]
+    },
+    "season": {
+      "type": "integer",
+      "oneOf": [
+        {
+          "const": 0,
+          "title": "Winter",
+          "count": 1621108
+        },
+        {
+          "const": 2,
+          "title": "Summer",
+          "count": 2279472
+        },
+        {
+          "const": 1,
+          "title": "Spring",
+          "count": 1577067
+        },
+        {
+          "const": 3,
+          "title": "Autumn",
+          "count": 1098015
+        }
+      ]
+    },
+    "eo:bands": [
+      {
+        "title": "B1",
+        "common_name": "coastal",
+        "center_wavelength": 4.439,
+        "gsd": 60
+      },
+      {
+        "title": "B2",
+        "common_name": "blue",
+        "center_wavelength": 4.966,
+        "gsd": 10
+      },
+      {
+        "title": "B3",
+        "common_name": "green",
+        "center_wavelength": 5.6,
+        "gsd": 10
+      },
+      {
+        "title": "B4",
+        "common_name": "red",
+        "center_wavelength": 6.645,
+        "gsd": 10
+      },
+      {
+        "title": "B5",
+        "center_wavelength": 7.039,
+        "gsd": 20
+      },
+      {
+        "title": "B6",
+        "center_wavelength": 7.402,
+        "gsd": 20
+      },
+      {
+        "title": "B7",
+        "center_wavelength": 7.825,
+        "gsd": 20
+      },
+      {
+        "title": "B8",
+        "common_name": "nir",
+        "center_wavelength": 8.351,
+        "gsd": 10
+      },
+      {
+        "title": "B8A",
+        "center_wavelength": 8.648,
+        "gsd": 20
+      },
+      {
+        "title": "B9",
+        "center_wavelength": 9.45,
+        "gsd": 60
+      },
+      {
+        "title": "B10",
+        "center_wavelength": 1.3735,
+        "gsd": 60
+      },
+      {
+        "title": "B11",
+        "common_name": "swir16",
+        "center_wavelength": 1.6137,
+        "gsd": 20
+      },
+      {
+        "title": "B12",
+        "common_name": "swir22",
+        "center_wavelength": 2.2024,
+        "gsd": 20
+      }
+    ]
+  }
+}

--- a/examples/collection-only/collection-with-schemas.json
+++ b/examples/collection-only/collection-with-schemas.json
@@ -5,9 +5,9 @@
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
-  "id": "S2",
+  "id": "sentinel-2",
   "type": "Collection",
-  "title": "Level 1C Sentinel-2 images",
+  "title": "Sentinel-2 MSI: MultiSpectral Instrument, Level-2A",
   "description": "The SENTINEL-2 mission is a land monitoring constellation of two satellites each equipped with a MSI (Multispectral Imager) instrument covering 13 spectral bands providing high resolution optical imagery (i.e., 10m, 20m, 60 m) every 10 days with one satellite and 5 days with two satellites",
   "license": "proprietary",
   "extent": {
@@ -32,14 +32,12 @@
   },
   "links": [
     {
-      "rel": "self",
-      "type": "application/json",
-      "href": "https://tamn.snapplanet.io/collections/S2"
+      "rel": "parent",
+      "href": "../catalog.json"
     },
     {
       "rel": "root",
-      "type": "application/json",
-      "href": "https://tamn.snapplanet.io"
+      "href": "../catalog.json"
     },
     {
       "rel": "license",
@@ -73,67 +71,61 @@
   ],
   "summaries": {
     "datetime": {
-      "minimum": "2017-04-12T02:57:21.459000Z",
-      "maximum": "2021-04-22T11:30:12.767000Z"
-    },
-    "collection": {
-      "type": "string",
-      "const": "sentinel-2",
-      "title": "Sentinel 2",
-      "count": 6613407
+      "minimum": "2017-04-12T02:57:21Z",
+      "maximum": "2021-04-22T11:30:12Z"
     },
     "instruments": {
       "type": "string",
       "const": "msi",
-      "title": "MSI",
+      "title": "Multispectral Intrument",
       "count": 6613431
     },
-    "landcover": {
+    "resto:landcover": {
       "type": "string",
       "oneOf": [
         {
-          "const": "landcover:cultivated",
+          "const": "cultivated",
           "title": "Cultivated",
           "count": 490750
         },
         {
-          "const": "landcover:desert",
+          "const": "desert",
           "title": "Desert",
           "count": 543120
         },
         {
-          "const": "landcover:flooded",
+          "const": "flooded",
           "title": "Flooded",
           "count": 5187
         },
         {
-          "const": "landcover:forest",
+          "const": "forest",
           "title": "Forest",
           "count": 767807
         },
         {
-          "const": "landcover:herbaceous",
+          "const": "herbaceous",
           "title": "Herbaceous",
           "count": 674281
         },
         {
-          "const": "landcover:ice",
+          "const": "ice",
           "title": "Ice",
           "count": 231285
         },
         {
-          "const": "landcover:urban",
+          "const": "urban",
           "title": "Urban",
           "count": 1219
         },
         {
-          "const": "landcover:water",
+          "const": "water",
           "title": "Water",
           "count": 2303314
         }
       ]
     },
-    "location": {
+    "resto:location": {
       "type": "string",
       "oneOf": [
         {
@@ -178,7 +170,7 @@
         }
       ]
     },
-    "season": {
+    "resto:season": {
       "type": "integer",
       "oneOf": [
         {

--- a/examples/collection-only/collection.json
+++ b/examples/collection-only/collection.json
@@ -78,9 +78,11 @@
       "minimum": 6.78,
       "maximum": 89.9
     },
-    "sci:citation": [
-      "Copernicus Sentinel data [Year]"
-    ],
+    "sci:citation": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "string",
+      "pattern": "Copernicus Sentinel data \\d{4}"
+    },
     "gsd": [
       10,
       30,

--- a/examples/collection-only/collection.json
+++ b/examples/collection-only/collection.json
@@ -1,7 +1,12 @@
 {
   "type": "Collection",
   "stac_version": "1.0.0-rc.2",
-  "stac_extensions": [],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+  ],
   "id": "sentinel-2",
   "title": "Sentinel-2 MSI: MultiSpectral Instrument, Level-1C",
   "description": "Sentinel-2 is a wide-swath, high-resolution, multi-spectral\nimaging mission supporting Copernicus Land Monitoring studies,\nincluding the monitoring of vegetation, soil and water cover,\nas well as observation of inland waterways and coastal areas.\n\nThe Sentinel-2 data contain 13 UINT16 spectral bands representing\nTOA reflectance scaled by 10000. See the [Sentinel-2 User Handbook](https://sentinel.esa.int/documents/247904/685211/Sentinel-2_User_Handbook)\nfor details. In addition, three QA bands are present where one\n(QA60) is a bitmask band with cloud mask information. For more\ndetails, [see the full explanation of how cloud masks are computed.](https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-2-msi/level-1c/cloud-masks)\n\nEach Sentinel-2 product (zip archive) may contain multiple\ngranules. Each granule becomes a separate Earth Engine asset.\nEE asset ids for Sentinel-2 assets have the following format:\nCOPERNICUS/S2/20151128T002653_20151128T102149_T56MNN. Here the\nfirst numeric part represents the sensing date and time, the\nsecond numeric part represents the product generation date and\ntime, and the final 6-character string is a unique granule identifier\nindicating its UTM grid reference (see [MGRS](https://en.wikipedia.org/wiki/Military_Grid_Reference_System)).\n\nFor more details on Sentinel-2 radiometric resoltuon, [see this page](https://earth.esa.int/web/sentinel/user-guides/sentinel-2-msi/resolutions/radiometric).\n",

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -2,6 +2,7 @@
   "id": "simple-collection",
   "type": "Collection",
   "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "stac_version": "1.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "remark-preset-lint-markdown-style-guide": "^3.0.0",
     "remark-preset-lint-recommended": "^4.0.0",
     "remark-validate-links": "^10.0.0",
-    "stac-node-validator": "^1.0.1"
+    "stac-node-validator": "^1.1.0"
   }
 }


### PR DESCRIPTION
**Related Issue(s):** #1045


**Proposed Changes:**

1. Support JSON Schema in summaries - I hadn't had a lot of time to flesh out the language, improvements appreciated.
2. Rename Stats Object to Range Object
3. Fix collection examples (add missing stac_extensions entries), but that fails right now due to https://github.com/stac-extensions/scientific/pull/2

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec), and I have NOT opened an issue/PR yet!
