### PR TITLE
remove scientific extension

### DIFF
--- a/examples/collection-only/collection.json
+++ b/examples/collection-only/collection.json
@@ -4,7 +4,6 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "id": "sentinel-2",
@@ -82,11 +81,6 @@
     "view:sun_elevation": {
       "minimum": 6.78,
       "maximum": 89.9
-    },
-    "sci:citation": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "type": "string",
-      "pattern": "Copernicus Sentinel data \\d{4}"
     },
     "gsd": [
       10,


### PR DESCRIPTION
**Related Issue(s):** #1045 #1093 


**Proposed Changes:**

1. Remove scientific so we can merge this, as discussed in https://github.com/radiantearth/stac-spec/pull/1093/files#r620248117 so we don't have to wait for https://github.com/stac-extensions/scientific/pull/2 to merge.

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md) 

