### PR TITLE
add missing projection declaration in collection example

### DIFF
--- a/examples/collection.json
+++ b/examples/collection.json
@@ -3,6 +3,7 @@
   "type": "Collection",
   "stac_extensions": [
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "stac_version": "1.0.0-rc.3",


### PR DESCRIPTION
**Proposed Changes:**

1. add missing projection declaration in `stac_extensions` in collection example

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
