### PR TITLE
JSON Schemas don't allow "shortcuts" for core extensions any longer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Clarified that collection summaries do not require that all property fields are summarized. ([#1106](https://github.com/radiantearth/stac-spec/issues/1106))
 - Clarified that gsd should only be used on an asset to represent the sensor, not just different processing. ([#1105](https://github.com/radiantearth/stac-spec/pull/1105))
 
+### Fixed
+
+- JSON Schemas don't allow "shortcuts" for core extensions any longer
+
 ## [v1.0.0-rc.2] - 2021-03-30
 
 ### Changed

--- a/catalog-spec/json-schema/catalog-core.json
+++ b/catalog-spec/json-schema/catalog-core.json
@@ -29,17 +29,9 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "anyOf": [
-              {
-                "title": "Reference to a JSON Schema",
-                "type": "string",
-                "format": "iri"
-              },
-              {
-                "title": "Reference to a core extension",
-                "type": "string"
-              }
-            ]
+            "title": "Reference to a JSON Schema",
+            "type": "string",
+            "format": "iri"
           }
         },
         "id": {

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -31,17 +31,9 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "anyOf": [
-              {
-                "title": "Reference to a JSON Schema",
-                "type": "string",
-                "format": "iri"
-              },
-              {
-                "title": "Reference to a core extension",
-                "type": "string"
-              }
-            ]
+            "title": "Reference to a JSON Schema",
+            "type": "string",
+            "format": "iri"
           }
         },
         "keywords": {

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -100,17 +100,9 @@
               "type": "array",
               "uniqueItems": true,
               "items": {
-                "anyOf": [
-                  {
-                    "title": "Reference to a JSON Schema",
-                    "type": "string",
-                    "format": "iri"
-                  },
-                  {
-                    "title": "Reference to a core extension",
-                    "type": "string"
-                  }
-                ]
+                "title": "Reference to a JSON Schema",
+                "type": "string",
+                "format": "iri"
               }
             },
             "id": {


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. JSON Schemas don't allow "shortcuts" for core extensions any longer

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
