### PR TITLE
Collection: Open intervals for temporal extents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - An empty Catalog is now allowed, removed the requirement that it must have a child or item link. ([#1115](https://github.com/radiantearth/stac-spec/issues/1115))
+- An open date range to both sides is now allowed in the Collection's temporal extents. ([#1125](https://github.com/radiantearth/stac-spec/issues/1125))
 - Catalog and Collection JSON Schemas don't have a common JSON Schema any more
 
 ### Removed 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -209,7 +209,7 @@ Timestamps consist of a date and time in UTC and MUST be formatted according to
 The temporal reference system is the Gregorian calendar.
 
 Open date ranges are supported by setting the start and/or the end time to `null`.
-Example for data from the beginning of 2019 until now: `[["2009-01-01T00:00:00Z", null]]`.
+Example for data from the beginning of 2019 until now: `[["2019-01-01T00:00:00Z", null]]`.
 It is recommended to provide at least a rough guideline on the temporal extent and thus
 it's not recommended to set both start and end time to `null`. Nevertheless, this is possible
 if there's a strong use case for an open date range to both sides.

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -202,12 +202,17 @@ Clients only interested in the overall extent will only need to access the first
 It is recommended to only use multiple temporal extents if a union of them would then include a large
 uncovered time span (e.g. only having data for the years 2000, 2010 and 2020).
 
-Each inner array consists of exactly two dates and times, each in UTC.
-Each date and time MUST be formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
+Each inner array consists of exactly two elements, either a timestamp or `null`.
+
+Timestamps consist of a date and time in UTC and MUST be formatted according to
+[RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
 The temporal reference system is the Gregorian calendar.
 
-Open date ranges are supported by setting either the start or the end time to `null`.
-Example for data from the beginning of 2019 until now: `[["2009-01-01T00:00:00Z", null]]`. 
+Open date ranges are supported by setting the start and/or the end time to `null`.
+Example for data from the beginning of 2019 until now: `[["2009-01-01T00:00:00Z", null]]`.
+It is recommended to provide at least a rough guideline on the temporal extent and thus
+it's not recommended to set both start and end time to `null`. Nevertheless, this is possible
+if there's a strong use case for an open date range to both sides.
 
 ### Provider Object
 


### PR DESCRIPTION
**Related Issue(s):** #1125


**Proposed Changes:**

1. An open date range to both sides is now allowed in the Collection's temporal extents.


**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
