### PR TITLE
Removed ItemCollection from STAC detection heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Removed ItemCollection from the STAC detection heuristic in Best Practices. It can't easily be differentiated from GeoJSON FeatureCollections any longer. ([API#141](https://github.com/radiantearth/stac-api-spec/issues/141))
+
 ## [v1.0.0-rc.4] - 2021-05-11
 
 ### Changed

--- a/best-practices.md
+++ b/best-practices.md
@@ -728,8 +728,7 @@ database, but it could just as easily be a server-based process.
 ## How to Differentiate STAC Files
 
 Any tool that crawls a STAC implementation or encounters a STAC file in the wild needs a clear way to determine if it is an Item, 
-Collection, Catalog or [ItemCollection](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1/fragments/itemcollection) 
-(part of the [STAC API spec](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1)). As of 1.0.0 this is done primarily
+Collection or Catalog. As of 1.0.0 this is done primarily
 with the `type` field, and secondarily in Items with `stac_version`, or optionally the `rel` of the link to it.
 
 ```shell
@@ -739,8 +738,6 @@ else if type is 'Catalog'
   => Catalog
 else if type is 'Feature' and stac_version is defined
   => Item
-else if type is 'FeatureCollection' and stac_version is defined
-  => ItemCollection
 else
   => Invalid (JSON)
 ```


### PR DESCRIPTION
**Related Issue(s):** https://github.com/radiantearth/stac-api-spec/issues/141


**Proposed Changes:**

1. Due to the potential changes in the ItemCollections (see https://github.com/radiantearth/stac-api-spec/issues/141) and also due to the fact that it's not really part of the core spec, removed the ItemCollection from the Stac "detection" heuristic.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
