### PR TITLE
fix(examples): change epsg summary example to an array of all values

### DIFF
--- a/examples/collection.json
+++ b/examples/collection.json
@@ -61,10 +61,9 @@
       "minimum": 1.2,
       "maximum": 1.2
     },
-    "proj:epsg": {
-      "minimum": 32659,
-      "maximum": 32659
-    },
+    "proj:epsg": [
+      32659
+    ],
     "view:sun_elevation": {
       "minimum": 54.9,
       "maximum": 54.9


### PR DESCRIPTION
**Related Issue(s):** #

N/A

**Proposed Changes:**

`proj:epsg` should be summarised as an array of all values, not a Range Object, per [stac-fields](https://github.com/stac-utils/stac-fields/blob/v1.0.0-beta.10/fields.json#L575) and [other examples](https://github.com/radiantearth/stac-spec/blob/master/examples/collection-only/collection.json#L90).

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
