### PR TITLE
Avoid processing info in item IDs

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -157,6 +157,15 @@ unique, so may need a prefix. But the use of URI or file path reserved character
 result in [percented encoded](https://tools.ietf.org/html/rfc3986#section-2) [STAC API](https://github.com/radiantearth/stac-api-spec) 
 endpoints and it prevents the use of IDs as file names as recommended in the [catalog layout](#catalog-layout) best practices.
 
+In general, we recommend that item IDs *not* include any kind of processing timestamp. If, for whatever reason, an
+item needs to be reprocessed the new item would have a different ID. This might result in "duplicate" items: multiple
+items with the same spatio-temporal footprint, which might not be desirable for end users.
+
+Instead, we recommend cataloging processing information with the [Processing extension](https://github.com/stac-extensions/processing)
+and handling updates to existing items with the [Versioning extension](https://github.com/stac-extensions/version). With
+these extensions the reprocessed item would have the same item ID, updated `processing` fields, and links between the old
+and new items.
+
 ### Searchable Identifiers
 
 When coming up with values for fields that contain searchable identifiers of some sort, like `constellation` or `platform`,


### PR DESCRIPTION
This proposes a change to the Item ID best practices, based on some experiences and conversations with folks like @gadomski.

In my experience, many upstream data providers (USGS / landsat & MODIS, Copernicus / Sentinel,) include some kind of "processing timestamp" in their IDs. They'll occasionally reprocess assets, leading to new upstream IDs with the same "acquisition" timestamp but a new "processing" timestamp (what happens to the old assets varies, but I think doesn't matter for this discussion).

*It's fundamentally ambiguous whether a reprocessed item is the "same" as an existing item*. But I think the best recommendation is that the new, reprocessed item / assets should replace the old item / assets. That satisfies the common case of "Give me the item at this datetime over this area". If the processing datetime is included in the item ID then a provider would either

1. Delete the old item, breaking anything linking directly to it
2. Keep both the old and new items, causing "duplicate" items with the same spatio-temporal footprint (differing only by processing stuff).

Between the versioning and processing extensions, STAC has all the building blocks to handle this elegantly. So this PR updates the recommendation to use those instead of stuffing a processing timestamp in the item ID.