### PR TITLE
Fix typos

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -281,7 +281,7 @@ providing them at the Asset level can prove to be very useful for using the data
 ### Working with Media Types
 
 [Media Types](https://en.wikipedia.org/wiki/Media_type) are a key element that enables STAC to be a rich source of information for
-clients. The best practice is to use as specific of a media type as is possible (so if a file is a GeoJSON then don't use a JSON
+clients. The best practice is to use as specific of a media type as possible (so if a file is a GeoJSON then don't use a JSON
 media type), and to use [registered](https://www.iana.org/assignments/media-types/media-types.xhtml) IANA types as much as possible.
 The following table lists types that commonly show up in STAC assets. And the [section](#formats-with-no-registered-media-type)
 past that gives recommendations on what to do if you have a format in your asset that does not have an IANA registered type.
@@ -341,7 +341,7 @@ In addition to the thumbnail, data and overview [roles listed](item-spec/item-sp
 are a number of roles that are emerging in practice, but don't have enough widespread use to justify standardizing them. So if
 you want to re-use other roles then try to find them on the list below, and also feel free to suggest more to include here.
 
-The 'source' field lists where the role comes from. The ones the say Item Spec are the only 'official' roles that are fully
+The 'source' field lists where the role comes from. The ones that say Item Spec are the only 'official' roles that are fully
 standardized. In time others on this list may migrate to a more 'official' list. Those that say 'best practice' are just from this 
 doc, the listing is the table below. The ones from extensions are mostly just 'best practices' in the extensions, as there are few
 actual role requirements.

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -70,7 +70,7 @@ In general, STAC versions can be mixed, but please keep the [recommended best pr
 A list of extensions the Collection implements.
 The list consists of URLs to JSON Schema files that can be used for validation.
 This list must only contain extensions that extend the Collection specification itself,
-see the the 'Scope' for each of the extensions.
+see the 'Scope' for each of the extensions.
 This must **not** declare the extensions that are only implemented in child Collection objects or child Item objects.
 
 #### id

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -76,7 +76,7 @@ In general, STAC versions can be mixed, but please keep the [recommended best pr
 A list of extensions the Item implements.
 The list consists of URLs to JSON Schema files that can be used for validation.
 This list must only contain extensions that extend the Item specification itself,
-see the the 'Scope' for each of the extensions.
+see the 'Scope' for each of the extensions.
 
 #### id
 
@@ -247,7 +247,7 @@ is recommended only in special cases. See [Additional Fields for Assets](#additi
 
 Any media type can be used in an Item's asset `type` field, and [registered](https://www.iana.org/assignments/media-types/media-types.xhtml) 
 Media Types are preferred. STAC Items that have sidecar metadata files associated with a data asset (e.g, `.tfw`, Landsat 8 MTL files)
-should use media types appropriate for the the metadata file.  For example, if it is a plain text file, then `text/plain`
+should use media types appropriate for the metadata file.  For example, if it is a plain text file, then `text/plain`
 would be appropriate; if it is an XML, then `text/xml` is appropriate. For more information on media types as well as a 
 list of [common media types](../best-practices.md#common-media-types-in-stac) used in STAC see the [best practice on 
 working with media types](../best-practices.md#working-with-media-types).


### PR DESCRIPTION
**Related Issue(s):**

 #1163 is related PR.

**Proposed Changes:**

1. Fix typos in best-practices.md
   1. Remove unnecessary `is`
      - > The best practice *is* to use as specific of a media type as ~*is*~ possible
   2. Fix typo `the` => `that`
      - > The ones ~*the*~ *that* say Item Spec are the only 'official' roles that are fully standardized
2. Remove repeated `the`
   - I confirmed there are no repeated `the` anymore by searching `the the` in this repository.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] ~I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)~
      **or** a CHANGELOG entry is not required.
- [ ] ~This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.~
