### PR TITLE
Fix minor citation issue

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,4 +16,4 @@ preferred-citation:
   repository: https://github.com/radiantearth/stac-spec
   authors:
     - name: "STAC Contributors"
-    - email: stac-psc@radiant.earth
+      email: stac-psc@radiant.earth


### PR DESCRIPTION
Dang it, there was a `-` too much in the Citation YAML, which leads to incorrect rendering.

This PR should fix it that instead of 
`STAC Contributors, & . (2021). SpatioTemporal Asset Catalog (STAC) specification (Version 1.0.0). https://stacspec.org`
it renders as 
`STAC Contributors (2021). SpatioTemporal Asset Catalog (STAC) specification (Version 1.0.0). https://stacspec.org`