### PR TITLE
Fix a missing pluralization

### DIFF
--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -48,7 +48,7 @@ specified in [*OGC API - Features*](https://ogcapi.ogc.org/features/), but they 
 | type            | string                                           | **REQUIRED.** Must be set to `Collection` to be a valid Collection. |
 | stac_version    | string                                           | **REQUIRED.** The STAC version the Collection implements. |
 | stac_extensions | \[string]                                        | A list of extension identifiers the Collection implements.   |
-| id              | string                                           | **REQUIRED.** Identifier for the Collection that is unique across the provider. |
+| id              | string                                           | **REQUIRED.** Identifier for the Collection that is unique across the providers. |
 | title           | string                                           | A short descriptive one-line title for the Collection.       |
 | description     | string                                           | **REQUIRED.** Detailed multi-line description to fully explain the Collection. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | keywords        | \[string]                                        | List of keywords describing the Collection.                  |


### PR DESCRIPTION
**Related Issue(s):** N/A


**Proposed Changes:**

1. Fixed a missing 's' on the word "providers".

   `providers` is an array so this sentence only makes sense if the ID is unique across all of the listed providers (plural).

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
