### PR TITLE
Better integrate common metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Validate common metadata also in Catalogs, Collections and Links.
+- Common metadata: If a description is given, require that it is not empty
+
 ### Removed
 
 - "Strongly recommended" language around `self` links in the item spec. ([#1173](https://github.com/radiantearth/stac-spec/pull/1173))
+
+### Fixed
+
+- Several typos and minor language changes
 
 ## [v1.0.0] - 2021-05-25
 

--- a/catalog-spec/json-schema/catalog.json
+++ b/catalog-spec/json-schema/catalog.json
@@ -6,12 +6,16 @@
   "allOf": [
     {
       "$ref": "#/definitions/catalog"
+    },
+    {
+      "$ref": "../../item-spec/json-schema/common.json#"
     }
   ],
   "definitions": {
     "catalog": {
       "title": "STAC Catalog",
       "type": "object",
+      "$comment": "title and description is validated through the common metadata.",
       "required": [
         "stac_version",
         "type",
@@ -44,49 +48,8 @@
           "type": "string",
           "minLength": 1
         },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "type": "string",
-          "minLength": 1
-        },
         "links": {
-          "title": "Links",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/link"
-          }
-        }
-      }
-    },
-    "link": {
-      "type": "object",
-      "required": [
-        "rel",
-        "href"
-      ],
-      "properties": {
-        "href": {
-          "title": "Link reference",
-          "type": "string",
-          "format": "iri-reference",
-          "minLength": 1
-        },
-        "rel": {
-          "title": "Link relation type",
-          "type": "string",
-          "minLength": 1
-        },
-        "type": {
-          "title": "Link type",
-          "type": "string"
-        },
-        "title": {
-          "title": "Link title",
-          "type": "string"
+          "$ref": "../../item-spec/json-schema/item.json#/definitions/links"
         }
       }
     }

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -6,13 +6,17 @@
   "allOf": [
     {
       "$ref": "#/definitions/collection"
+    },
+    {
+      "$ref": "../../item-spec/json-schema/common.json#"
     }
   ],
   "definitions": {
     "collection": {
       "title": "STAC Collection",
-      "description": "These are the fields specific to a STAC Collection. All other fields are inherited from STAC Catalog.",
+      "description": "These are the fields specific to a STAC Collection.",
       "type": "object",
+      "$comment": "title, description, providers and license is validated through the common metadata.",
       "required": [
         "stac_version",
         "type",
@@ -47,62 +51,11 @@
           "type": "string",
           "minLength": 1
         },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "type": "string",
-          "minLength": 1
-        },
         "keywords": {
           "title": "Keywords",
           "type": "array",
           "items": {
             "type": "string"
-          }
-        },
-        "license": {
-          "title": "Collection License Name",
-          "type": "string",
-          "pattern": "^[\\w\\-\\.\\+]+$"
-        },
-        "providers": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name"
-            ],
-            "properties": {
-              "name": {
-                "title": "Organization name",
-                "type": "string"
-              },
-              "description": {
-                "title": "Organization description",
-                "type": "string"
-              },
-              "roles": {
-                "title": "Organization roles",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "producer",
-                    "licensor",
-                    "processor",
-                    "host"
-                  ]
-                }
-              },
-              "url": {
-                "title": "Organization homepage",
-                "type": "string",
-                "format": "iri"
-              }
-            }
           }
         },
         "extent": {
@@ -178,42 +131,10 @@
           "$ref": "../../item-spec/json-schema/item.json#/definitions/assets"
         },
         "links": {
-          "title": "Links",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/link"
-          }
+          "$ref": "../../item-spec/json-schema/item.json#/definitions/links"
         },
         "summaries": {
           "$ref": "#/definitions/summaries"
-        }
-      }
-    },
-    "link": {
-      "type": "object",
-      "required": [
-        "rel",
-        "href"
-      ],
-      "properties": {
-        "href": {
-          "title": "Link reference",
-          "type": "string",
-          "format": "iri-reference",
-          "minLength": 1
-        },
-        "rel": {
-          "title": "Link relation type",
-          "type": "string",
-          "minLength": 1
-        },
-        "type": {
-          "title": "Link type",
-          "type": "string"
-        },
-        "title": {
-          "title": "Link title",
-          "type": "string"
         }
       }
     },

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -18,8 +18,6 @@ or [Collection Asset](../collection-spec/collection-spec.md#asset-object).
 Various *examples* are available in the folder [`examples`](../examples/).
 *JSON Schemas* can be found in the folder [`json-schema`](json-schema/).
 
-By default, these fields are only included and validated against in the core [Item schema](json-schema/item.json).
-
 Implementation of any of the fields is not required, unless explicitly required by a specification using the field.
 For example, `datetime` is required in STAC Items.
 

--- a/item-spec/json-schema/basics.json
+++ b/item-spec/json-schema/basics.json
@@ -5,14 +5,15 @@
   "type": "object",
   "properties": {
     "title": {
-      "title": "Item Title",
-      "description": "A human-readable title describing the Item.",
+      "title": "Title",
+      "description": "A human-readable title describing the entity.",
       "type": "string"
     },
     "description": {
-      "title": "Item Description",
-      "description": "Detailed multi-line description to fully explain the Item.",
-      "type": "string"
+      "title": "Description",
+      "description": "Detailed multi-line description to fully explain the entity.",
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/item-spec/json-schema/common.json
+++ b/item-spec/json-schema/common.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/commonjson#",
+  "title": "STAC Common Metadata",
+  "type": "object",
+  "description": "This schema includes all common metadata fields.",
+  "allOf": [
+    {
+      "$ref": "basics.json"
+    },
+    {
+      "$ref": "datetime.json"
+    },
+    {
+      "$ref": "instrument.json"
+    },
+    {
+      "$ref": "licensing.json"
+    },
+    {
+      "$ref": "provider.json"
+    }
+  ]
+}

--- a/item-spec/json-schema/datetime.json
+++ b/item-spec/json-schema/datetime.json
@@ -18,21 +18,21 @@
   "properties": {
     "datetime": {
       "title": "Date and Time",
-      "description": "The searchable date/time of the assets, in UTC (Formatted in RFC 3339) ",
+      "description": "The searchable date/time of the data, in UTC (Formatted in RFC 3339) ",
       "type": ["string", "null"],
       "format": "date-time",
       "pattern": "(\\+00:00|Z)$"
     },
     "start_datetime": {
       "title": "Start Date and Time",
-      "description": "The searchable start date/time of the assets, in UTC (Formatted in RFC 3339) ",
+      "description": "The searchable start date/time of the data, in UTC (Formatted in RFC 3339) ",
       "type": "string",
       "format": "date-time",
       "pattern": "(\\+00:00|Z)$"
     }, 
     "end_datetime": {
       "title": "End Date and Time", 
-      "description": "The searchable end date/time of the assets, in UTC (Formatted in RFC 3339) ",                  
+      "description": "The searchable end date/time of the data, in UTC (Formatted in RFC 3339) ",                  
       "type": "string",
       "format": "date-time",
       "pattern": "(\\+00:00|Z)$"

--- a/item-spec/json-schema/item.json
+++ b/item-spec/json-schema/item.json
@@ -10,25 +10,6 @@
     }
   ],
   "definitions": {
-    "common_metadata": {
-      "allOf": [
-        {
-          "$ref": "basics.json"
-        },
-        {
-          "$ref": "datetime.json"
-        },
-        {
-          "$ref": "instrument.json"
-        },
-        {
-          "$ref": "licensing.json"
-        },
-        {
-          "$ref": "provider.json"
-        }
-      ]
-    },
     "core": {
       "allOf": [
         {
@@ -112,12 +93,7 @@
               "minLength": 1
             },
             "links": {
-              "title": "Item links",
-              "description": "Links to item relations",
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/link"
-              }
+              "$ref": "#/definitions/links"
             },
             "assets": {
               "$ref": "#/definitions/assets"
@@ -125,7 +101,7 @@
             "properties": {
               "allOf": [
                 {
-                  "$ref": "#/definitions/common_metadata"
+                  "$ref": "common.json"
                 },
                 {
                   "anyOf": [
@@ -192,33 +168,48 @@
         }
       ]
     },
-    "link": {
-      "type": "object",
-      "required": [
-        "rel",
-        "href"
-      ],
-      "properties": {
-        "href": {
-          "title": "Link reference",
-          "type": "string",
-          "format": "iri-reference",
-          "minLength": 1
-        },
-        "rel": {
-          "title": "Link relation type",
-          "type": "string",
-          "minLength": 1
-        },
-        "type": {
-          "title": "Link type",
-          "type": "string"
-        },
-        "title": {
-          "title": "Link title",
-          "type": "string"
-        }
+    "links": {
+      "title": "Item links",
+      "description": "Links to item relations",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/link"
       }
+    },
+    "link": {
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "rel",
+            "href"
+          ],
+          "properties": {
+            "href": {
+              "title": "Link reference",
+              "type": "string",
+              "format": "iri-reference",
+              "minLength": 1
+            },
+            "rel": {
+              "title": "Link relation type",
+              "type": "string",
+              "minLength": 1
+            },
+            "type": {
+              "title": "Link type",
+              "type": "string"
+            },
+            "title": {
+              "title": "Link title",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "$ref": "common.json"
+        }
+      ]
     },
     "assets": {
       "title": "Asset links",
@@ -264,7 +255,7 @@
           }
         },
         {
-          "$ref": "#/definitions/common_metadata"
+          "$ref": "common.json"
         }
       ]
     }


### PR DESCRIPTION
**Related Issue(s):** #1199 #1187


**Proposed Changes:**

1. Validate common metadata also in Catalogs, Collections and Links. Also, re-uses the schemas from common metadata in Collections so that they don't diverge (which was the case).
2. Includes a very minor somewhat breaking change: Provider, Asset and Item descriptions can't be empty now. Either they need to be omitted or contain at least one character. This aligns with Catalog and Collection description as part of the common metadata model. 

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
