### PR TITLE
Fix wavelengths in `eo:bands` examples

### DIFF
--- a/examples/collection-only/collection-with-schemas.json
+++ b/examples/collection-only/collection-with-schemas.json
@@ -203,56 +203,56 @@
       {
         "title": "B1",
         "common_name": "coastal",
-        "center_wavelength": 4.439,
+        "center_wavelength": 0.4439,
         "gsd": 60
       },
       {
         "title": "B2",
         "common_name": "blue",
-        "center_wavelength": 4.966,
+        "center_wavelength": 0.4966,
         "gsd": 10
       },
       {
         "title": "B3",
         "common_name": "green",
-        "center_wavelength": 5.6,
+        "center_wavelength": 0.56,
         "gsd": 10
       },
       {
         "title": "B4",
         "common_name": "red",
-        "center_wavelength": 6.645,
+        "center_wavelength": 0.6645,
         "gsd": 10
       },
       {
         "title": "B5",
-        "center_wavelength": 7.039,
+        "center_wavelength": 0.7039,
         "gsd": 20
       },
       {
         "title": "B6",
-        "center_wavelength": 7.402,
+        "center_wavelength": 0.7402,
         "gsd": 20
       },
       {
         "title": "B7",
-        "center_wavelength": 7.825,
+        "center_wavelength": 0.7825,
         "gsd": 20
       },
       {
         "title": "B8",
         "common_name": "nir",
-        "center_wavelength": 8.351,
+        "center_wavelength": 0.8351,
         "gsd": 10
       },
       {
         "title": "B8A",
-        "center_wavelength": 8.648,
+        "center_wavelength": 0.8648,
         "gsd": 20
       },
       {
         "title": "B9",
-        "center_wavelength": 9.45,
+        "center_wavelength": 0.945,
         "gsd": 60
       },
       {

--- a/examples/collection-only/collection.json
+++ b/examples/collection-only/collection.json
@@ -153,47 +153,47 @@
       {
         "name": "B1",
         "common_name": "coastal",
-        "center_wavelength": 4.439
+        "center_wavelength": 0.4439
       },
       {
         "name": "B2",
         "common_name": "blue",
-        "center_wavelength": 4.966
+        "center_wavelength": 0.4966
       },
       {
         "name": "B3",
         "common_name": "green",
-        "center_wavelength": 5.6
+        "center_wavelength": 0.56
       },
       {
         "name": "B4",
         "common_name": "red",
-        "center_wavelength": 6.645
+        "center_wavelength": 0.6645
       },
       {
         "name": "B5",
-        "center_wavelength": 7.039
+        "center_wavelength": 0.7039
       },
       {
         "name": "B6",
-        "center_wavelength": 7.402
+        "center_wavelength": 0.7402
       },
       {
         "name": "B7",
-        "center_wavelength": 7.825
+        "center_wavelength": 0.7825
       },
       {
         "name": "B8",
         "common_name": "nir",
-        "center_wavelength": 8.351
+        "center_wavelength": 0.8351
       },
       {
         "name": "B8A",
-        "center_wavelength": 8.648
+        "center_wavelength": 0.8648
       },
       {
         "name": "B9",
-        "center_wavelength": 9.45
+        "center_wavelength": 0.945
       },
       {
         "name": "B10",

--- a/examples/extended-item.json
+++ b/examples/extended-item.json
@@ -119,25 +119,25 @@
         {
           "name": "band1",
           "common_name": "blue",
-          "center_wavelength": 470,
+          "center_wavelength": 0.470,
           "full_width_half_max": 70
         },
         {
           "name": "band2",
           "common_name": "green",
-          "center_wavelength": 560,
+          "center_wavelength": 0.560,
           "full_width_half_max": 80
         },
         {
           "name": "band3",
           "common_name": "red",
-          "center_wavelength": 645,
+          "center_wavelength": 0.645,
           "full_width_half_max": 90
         },
         {
           "name": "band4",
           "common_name": "nir",
-          "center_wavelength": 800,
+          "center_wavelength": 0.800,
           "full_width_half_max": 152
         }
       ]
@@ -161,19 +161,19 @@
         {
           "name": "band3",
           "common_name": "red",
-          "center_wavelength": 645,
+          "center_wavelength": 0.645,
           "full_width_half_max": 90
         },
         {
           "name": "band2",
           "common_name": "green",
-          "center_wavelength": 560,
+          "center_wavelength": 0.560,
           "full_width_half_max": 80
         },
         {
           "name": "band1",
           "common_name": "blue",
-          "center_wavelength": 470,
+          "center_wavelength": 0.470,
           "full_width_half_max": 70
         }
       ]


### PR DESCRIPTION
According to the spec of the `eo` extension, the `center_wavelength` is given in micrometers (µm), but the examples sometimes contained them in nanometers (extended-item.json) or tens of nanometers (in "collection-only" folder; interestingly there from B10 upwards it was already correct).

**Related Issue(s):** Instead of opening an issue first, I just plunged forward and fixed it straight away.


**Proposed Changes:**

1. Fix example files

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
