### PR TITLE
 Update license to follow OGC API - Records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - The `keywords` field known from Collections is available in common metadata. ([#1187](https://github.com/radiantearth/stac-spec/issues/1187))
+- The `license` field additionally supports SPDX expressions and the value `other`.
 
 ### Changed
 
@@ -17,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Common metadata: If a description is given, require that it is not empty
 - Clarified that trailing slashes in URIs are significant. ([#1212](https://github.com/radiantearth/stac-spec/discussions/1212))
 - All JSON Schema `$id` values no longer have `#` at the end.
+
+### Deprecated
+
+- `license`: The values `proprietary` and `various` are deprecated in favor of SPDX expressions and `other`.
 
 ### Removed
 

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -52,7 +52,7 @@ specified in [*OGC API - Features*](https://ogcapi.ogc.org/features/), but they 
 | title           | string                                                                                       | A short descriptive one-line title for the Collection.                                                                                                                                                                                 |
 | description     | string                                                                                       | **REQUIRED.** Detailed multi-line description to fully explain the Collection. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.                                                              |
 | keywords        | \[string]                                                                                    | List of keywords describing the Collection.                                                                                                                                                                                            |
-| license         | string                                                                                       | **REQUIRED.** Collection's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `various` if multiple licenses apply or `proprietary` for all other cases.                                                      |
+| license         | string                                                                                       | **REQUIRED** License(s) of the data collection as SPDX License identifier, SPDX License expression, or `other` (see below).                                                                                                            |
 | providers       | \[[Provider Object](#provider-object)]                                                       | A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list. |
 | extent          | [Extent Object](#extent-object)                                                              | **REQUIRED.** Spatial and temporal extents.                                                                                                                                                                                            |
 | summaries       | Map<string, \[\*]\|[Range Object](#range-object)\|[JSON Schema Object](#json-schema-object)> | STRONGLY RECOMMENDED. A map of property summaries, either a set of values, a range of values or a [JSON Schema](https://json-schema.org).                                                                                              |
@@ -81,11 +81,21 @@ This could be the provider's name if it is a fairly unique name, or their name c
 
 #### license
 
-Collection's license(s) as a SPDX [License identifier](https://spdx.org/licenses/).
-Alternatively, use `proprietary` (see below) if the license is not on the SPDX license list or `various` if multiple licenses apply.
-In all cases links to the license texts SHOULD be added, see the `license` link relation type.
-If no link to a license is included and the `license` field is set to `proprietary`, the Collection is private,
-and consumers have not been granted any explicit right to use the data.
+License(s) of the data that the STAC Collection and its children provides.
+If possible, license information should be defined at the Collection level.
+
+The license(s) can be provided as:
+1. [SPDX License identifier](https://spdx.org/licenses/)
+2. [SPDX License expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/)
+3. String with the value `other` if the license is not on the SPDX license list.
+   The strings `various` and `proprietary` are **deprecated**.
+
+If the license is **not** an SPDX license identifier, links to the license texts SHOULD be added.
+The links MUST use the [`license` link relation type](#relation-types).
+If there is no public license URL available,
+it is RECOMMENDED to supplement the STAC Item with the license text in a separate file and link to this file.
+If no link to a license is included and the `license` field is set to `other` (or one of the deprecated values),
+the Collection is private, and consumers have not been granted any explicit right to use the data.
 
 #### summaries
 
@@ -266,7 +276,7 @@ This is done where there is not a clear official option, or where STAC uses an o
 | parent       | URL to the parent STAC entity (Catalog or Collection). Non-root Collections should include a link to their parent.                                                                                                                                                 |
 | child        | URL to a child STAC entity (Catalog or Collection).                                                                                                                                                                                                                |
 | item         | URL to a STAC Item. All Items linked from a Collection MUST refer back to its Collection with the [`collection` relation type](../item-spec/item-spec.md#relation-types).                                                                                          |
-| license      | The license URL(s) for the Collection SHOULD be specified if the `license` field is set to `proprietary` or `various`. If there is no public license URL available, it is RECOMMENDED to put the license text in a separate file and link to this file.            |
+| license      | The license URL(s) for the Item SHOULD be specified if the `license` field is **not** a SPDX license identifier.                                                                                                                                                   |
 | derived_from | URL to a STAC Collection that was used as input data in the creation of this Collection. See the note in [STAC Item](../item-spec/item-spec.md#derived_from) for more info.                                                                                        |
 
 A more complete list of possible `rel` types and their meaning in STAC can be found in the

--- a/examples/collection-only/collection-with-schemas.json
+++ b/examples/collection-only/collection-with-schemas.json
@@ -9,7 +9,7 @@
   "type": "Collection",
   "title": "Sentinel-2 MSI: MultiSpectral Instrument, Level-2A",
   "description": "The SENTINEL-2 mission is a land monitoring constellation of two satellites each equipped with a MSI (Multispectral Imager) instrument covering 13 spectral bands providing high resolution optical imagery (i.e., 10m, 20m, 60 m) every 10 days with one satellite and 5 days with two satellites",
-  "license": "proprietary",
+  "license": "other",
   "extent": {
     "spatial": {
       "bbox": [

--- a/examples/collection-only/collection.json
+++ b/examples/collection-only/collection.json
@@ -9,7 +9,7 @@
   "id": "sentinel-2",
   "title": "Sentinel-2 MSI: MultiSpectral Instrument, Level-1C",
   "description": "Sentinel-2 is a wide-swath, high-resolution, multi-spectral\nimaging mission supporting Copernicus Land Monitoring studies,\nincluding the monitoring of vegetation, soil and water cover,\nas well as observation of inland waterways and coastal areas.\n\nThe Sentinel-2 data contain 13 UINT16 spectral bands representing\nTOA reflectance scaled by 10000. See the [Sentinel-2 User Handbook](https://sentinel.esa.int/documents/247904/685211/Sentinel-2_User_Handbook)\nfor details. In addition, three QA bands are present where one\n(QA60) is a bitmask band with cloud mask information. For more\ndetails, [see the full explanation of how cloud masks are computed.](https://sentinel.esa.int/web/sentinel/technical-guides/sentinel-2-msi/level-1c/cloud-masks)\n\nEach Sentinel-2 product (zip archive) may contain multiple\ngranules. Each granule becomes a separate Earth Engine asset.\nEE asset ids for Sentinel-2 assets have the following format:\nCOPERNICUS/S2/20151128T002653_20151128T102149_T56MNN. Here the\nfirst numeric part represents the sensing date and time, the\nsecond numeric part represents the product generation date and\ntime, and the final 6-character string is a unique granule identifier\nindicating its UTM grid reference (see [MGRS](https://en.wikipedia.org/wiki/Military_Grid_Reference_System)).\n\nFor more details on Sentinel-2 radiometric resoltuon, [see this page](https://earth.esa.int/web/sentinel/user-guides/sentinel-2-msi/resolutions/radiometric).\n",
-  "license": "proprietary",
+  "license": "other",
   "keywords": [
     "copernicus",
     "esa",

--- a/examples/collectionless-item.json
+++ b/examples/collectionless-item.json
@@ -47,7 +47,7 @@
     "end_datetime": "2016-05-03T13:27:30Z",
     "created": "2016-05-04T00:00:01Z",
     "updated": "2017-01-01T00:30:55Z",
-    "license": "various",
+    "license": "other",
     "providers": [
       {
         "name": "Remote Data, Inc",

--- a/examples/extensions-collection/collection.json
+++ b/examples/extensions-collection/collection.json
@@ -64,5 +64,5 @@
       ]
     }
   },
-  "license": "PDDL-1.0"
+  "license": "other"
 }

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -84,21 +84,30 @@ Information about the license(s) of the data, which is not necessarily the same 
 
 - [JSON Schema](json-schema/licensing.json)
 
-| Field Name | Type   | Description                                                                                                                                                                                                          |
-| ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| license    | string | Item's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `various` if multiple licenses apply or `proprietary` for all other cases. Should be defined at the Collection level if possible. |
+| Field Name | Type   | Description                                                                                         |
+| ---------- | ------ | --------------------------------------------------------------------------------------------------- |
+| license    | string | License(s) of the data as SPDX License identifier, SPDX License expression, or `other` (see below). |
 
-**license**: Data license(s) as a SPDX [License identifier](https://spdx.org/licenses/). Alternatively, use
-`proprietary` (see below) if the license is not on the SPDX license list or `various` if multiple licenses apply.
-In all cases links to the license texts SHOULD be added, see the [`license` link relation type](#relation-types).
-If no link to a license is included and the `license` field is set to `proprietary`, the Collection is private,
-and consumers have not been granted any explicit right to use the data.
+**license**: License(s) of the data that the STAC entity provides.
+
+The license(s) can be provided as:
+1. [SPDX License identifier](https://spdx.org/licenses/)
+2. [SPDX License expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/)
+3. String with the value `other` if the license is not on the SPDX license list.
+   The strings `various` and `proprietary` are **deprecated**.
+
+If the license is **not** an SPDX license identifier, links to the license texts SHOULD be added.
+The links MUST use the [`license` link relation type](#relation-types).
+If there is no public license URL available,
+it is RECOMMENDED to supplement the STAC Item with the license text in a separate file and link to this file.
+If no link to a license is included and the `license` field is set to `other` (or one of the deprecated values),
+the data is private, and consumers have not been granted any explicit right to use it.
 
 ### Relation types
 
-| Type    | Description                                                                                                                                                                                                                                                                 |
-| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| license | The license URL(s) for the Item SHOULD be specified if the `license` field is set to `proprietary` or `various`. If there is no public license URL available, it is RECOMMENDED to supplement the STAC Item with the license text in a separate file and link to this file. |
+| Type    | Description                                                                                                      |
+| ------- | ---------------------------------------------------------------------------------------------------------------- |
+| license | The license URL(s) for the Item SHOULD be specified if the `license` field is **not** a SPDX license identifier. |
 
 ## Provider
 


### PR DESCRIPTION
**Related Issue(s):** #1232 

**Proposed Changes:**

- The `license` field additionally supports SPDX expressions and the value `other`.
- The values `proprietary` and `various` are deprecated in favor of SPDX expressions and `other`.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
