### PR TITLE
Disallow two spatial bounding boxes in Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Common metadata: If a description is given, require that it is not empty
 - Clarified that trailing slashes in URIs are significant. ([#1212](https://github.com/radiantearth/stac-spec/discussions/1212))
 - All JSON Schema `$id` values no longer have `#` at the end.
+- Two spatial bounding boxes in a Collection don't make sense and will be reported as invalid by the schema. ([#1243](https://github.com/radiantearth/stac-spec/issues/1243))
 
 ### Removed
 
@@ -25,9 +26,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Several typos and minor language changes
-
-### Fixed
-
 - Clarified that collection IDs should be unique across all collections in the corresponding root catalog.
 
 ## [v1.0.0] - 2021-05-25

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -176,6 +176,7 @@ used to provide a more precise description of the extent and identify clusters o
 Clients only interested in the overall spatial extent will only need to access the first item in each array.
 It is recommended to only use multiple bounding boxes if a union of them would then include
 a large uncovered area (e.g. the union of Germany and Chile).
+Thus, it doesn't make sense to provide two bounding boxes and the validation will fail in this case.
 
 The length of the inner array must be 2*n where n is the number of dimensions.
 The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in

--- a/collection-spec/json-schema/collection.json
+++ b/collection-spec/json-schema/collection.json
@@ -69,7 +69,15 @@
                 "bbox": {
                   "title": "Spatial extents",
                   "type": "array",
-                  "minItems": 1,
+                  "oneOf": [
+                    {
+                      "minItems": 1,
+                      "maxItems": 1
+                    },
+                    {
+                      "minItems": 3
+                    }
+                  ],
                   "items": {
                     "title": "Spatial extent",
                     "type": "array",


### PR DESCRIPTION
**Related Issue(s):** #1243 


**Proposed Changes:**

Two spatial bounding boxes in a Collection don't make sense and will be reported as invalid by the schema. ([#1243]

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
