### PR TITLE
Add roles to common metadata #1267

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - The `keywords` field known from Collections is available in common metadata. ([#1187](https://github.com/radiantearth/stac-spec/issues/1187))
 - The `license` field additionally supports SPDX expressions and the value `other`.
+- The `roles` field known from Assets and Providers is available in common metadata. ([#1267](https://github.com/radiantearth/stac-spec/issues/1267))
 
 ### Changed
 

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -39,6 +39,7 @@ Descriptive fields to give a basic overview of a STAC entity (e.g. Catalog, Coll
 | title       | string    | A human readable title describing the STAC entity.                                                                                                            |
 | description | string    | Detailed multi-line description to fully explain the STAC entity. [CommonMark 0.29](https://commonmark.org/) syntax MAY be used for rich text representation. |
 | keywords    | \[string] | List of keywords describing the STAC entity.                                                                                                                  |
+| roles       | \[string] | The semantic roles of the entity, e.g. for assets, links, providers, bands, etc.                                                                              |
 
 ## Date and Time
 

--- a/item-spec/json-schema/basics.json
+++ b/item-spec/json-schema/basics.json
@@ -22,6 +22,13 @@
       "items": {
         "type": "string"
       }
+    },
+    "roles": {
+      "title": "Roles",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
**Related Issue(s):** #1267


**Proposed Changes:**

1. Add roles to common metadata, currently used in Assets, Providers, Contacts extension, and planned to be used in the CEOS ARD and Web Map Links extension for links.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
