### PR TITLE
Inclusive date time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Clarified that trailing slashes in URIs are significant. ([#1212](https://github.com/radiantearth/stac-spec/discussions/1212))
 - All JSON Schema `$id` values no longer have `#` at the end.
 - Two spatial bounding boxes in a Collection don't make sense and will be reported as invalid by the schema. ([#1243](https://github.com/radiantearth/stac-spec/issues/1243))
+- Clarify in descriptions that start_datetime and end_datetime are inclusive bounds ([#1280](https://github.com/radiantearth/stac-spec/issues/1280))
 
 ### Deprecated
 

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -78,6 +78,8 @@ The datetime property in a STAC Item and these fields are not mutually exclusive
 | start_datetime | string | The first or start date and time for the resource, in UTC. It is formatted as `date-time` according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | end_datetime   | string | The last or end date and time for the resource, in UTC. It is formatted as `date-time` according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).    |
 
+`start_datetime` and `end_datetime` constitute inclusive bounds, meaning that the range covers the entire time interval between the two timestamps.
+
 ## Licensing
 
 Information about the license(s) of the data, which is not necessarily the same license that applies to the metadata.

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -78,7 +78,8 @@ The datetime property in a STAC Item and these fields are not mutually exclusive
 | start_datetime | string | The first or start date and time for the resource, in UTC. It is formatted as `date-time` according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | end_datetime   | string | The last or end date and time for the resource, in UTC. It is formatted as `date-time` according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).    |
 
-`start_datetime` and `end_datetime` constitute inclusive bounds, meaning that the range covers the entire time interval between the two timestamps and the timestamps itself.
+`start_datetime` and `end_datetime` constitute inclusive bounds,
+meaning that the range covers the entire time interval between the two timestamps and the timestamps itself.
 
 ## Licensing
 

--- a/item-spec/common-metadata.md
+++ b/item-spec/common-metadata.md
@@ -78,7 +78,7 @@ The datetime property in a STAC Item and these fields are not mutually exclusive
 | start_datetime | string | The first or start date and time for the resource, in UTC. It is formatted as `date-time` according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 | end_datetime   | string | The last or end date and time for the resource, in UTC. It is formatted as `date-time` according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).    |
 
-`start_datetime` and `end_datetime` constitute inclusive bounds, meaning that the range covers the entire time interval between the two timestamps.
+`start_datetime` and `end_datetime` constitute inclusive bounds, meaning that the range covers the entire time interval between the two timestamps and the timestamps itself.
 
 ## Licensing
 


### PR DESCRIPTION
**Related Issue(s):** #1255


**Proposed Changes:**

1. Clarify in descriptions that start_datetime and end_datetime are inclusive bounds

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [X] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR https://github.com/radiantearth/stac-api-spec/issues/444to track the change.
