### PR TITLE
Disallow GeometryCollection, reformatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Several typos and minor language changes
 - Clarified that collection IDs should be unique across all collections in the corresponding root catalog.
 - Clarified which media types should be used for the hierarchical relation types
+- Clarified in the Markdown specification that GeometryCollections are not allowed as Item Geometry ([#1160](https://github.com/radiantearth/stac-spec/pull/1160))
 
 ## [v1.0.0] - 2021-05-25
 

--- a/best-practices.md
+++ b/best-practices.md
@@ -505,7 +505,8 @@ if you follow these recommendations.
 3. Items should be named `<id>.json`.
 4. Sub-Catalogs or sub-Collections should be stored in subdirectories of their parent
    (and only 1 subdirectory deeper than a document's parent, e.g. `.../sample/sub1/catalog.json`).
-5. Items should be stored in subdirectories of their parent Catalog or Collection if there are usually [sidecar files](https://en.wikipedia.org/wiki/Sidecar_file) stored alongside the Item.
+5. Items should be stored in subdirectories of their parent Catalog or Collection
+   if there are usually [sidecar files](https://en.wikipedia.org/wiki/Sidecar_file) stored alongside the Item.
    This means that each Item and its assets are contained in a unique subdirectory unless this would regularly lead to a single Item in a directory.
 6. Limit the number of Items in a Catalog or Collection, grouping / partitioning as relevant to the dataset.
 7. Use structural elements (Catalog and Collection) consistently across each 'level' of your hierarchy.

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -112,8 +112,6 @@ Items that are linked to, but the best practices around this are still emerging.
 
 Defines the full footprint of the asset represented by this item, formatted according to RFC 7946.
 
-The footprint should be the default GeoJSON geometry, though additional geometries can be included.
-
 If **a geometry** is provided, the value must be a Geometry Object according to
 [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1)
 with the exception that the type `GeometryCollection` is not allowed in STAC.

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -139,7 +139,7 @@ STAC compliant APIs are required to compute intersection operations with the Ite
 The `id` of the STAC Collection this Item references to with the [`collection` relation type](#relation-types) in the `links`  array.
 
 This field provides an easy way for a user to search for any Items that belong in a specified Collection.
-Must be a non-empty string.
+If present, must be a non-empty string.
 
 ### Properties Object
 

--- a/item-spec/item-spec.md
+++ b/item-spec/item-spec.md
@@ -7,7 +7,9 @@
     - [stac\_extensions](#stac_extensions)
     - [id](#id)
     - [assets](#assets)
+    - [geometry](#geometry)
     - [bbox](#bbox)
+    - [collection](#collection)
   - [Properties Object](#properties-object)
     - [datetime](#datetime)
     - [Additional Fields](#additional-fields)
@@ -52,18 +54,18 @@ required fields is a valid STAC Item.
 This object describes a STAC Item. The fields `id`, `type`, `bbox`, `geometry` and `properties` are
 inherited from GeoJSON.
 
-| Field Name      | Type                                                                                                                                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type            | string                                                                                                                                | **REQUIRED.** Type of the GeoJSON Object. MUST be set to `Feature`.                                                                                                                                                                                                                                                                                                                                                                   |
-| stac_version    | string                                                                                                                                | **REQUIRED.** The STAC version the Item implements.                                                                                                                                                                                                                                                                                                                                                                                   |
-| stac_extensions | \[string]                                                                                                                             | A list of extensions the Item implements.                                                                                                                                                                                                                                                                                                                                                                                             |
-| id              | string                                                                                                                                | **REQUIRED.** Provider identifier. The ID should be unique within the  [Collection](../collection-spec/collection-spec.md) that contains the Item.                                                                                                                                                                                                                                                                                    |
-| geometry        | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) \| [null](https://tools.ietf.org/html/rfc7946#section-3.2) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
-| bbox            | \[number]                                                                                                                             | **REQUIRED if `geometry` is not `null`, prohibited if `geometry` is `null`.** Bounding Box of the asset represented by this Item, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5).                                                                                                                                                                                                        |
-| properties      | [Properties Object](#properties-object)                                                                                               | **REQUIRED.** A dictionary of additional metadata for the Item.                                                                                                                                                                                                                                                                                                                                                                       |
-| links           | \[[Link Object](#link-object)]                                                                                                        | **REQUIRED.** List of link objects to resources and related URLs. See the [best practices](../best-practices.md#use-of-links) for details on when the use `self` links is strongly recommended.                                                                                                                                                                                                                                       |
-| assets          | Map<string, [Asset Object](#asset-object)>                                                                                            | **REQUIRED.** Dictionary of asset objects that can be downloaded, each with a unique key.                                                                                                                                                                                                                                                                                                                                             |
-| collection      | string                                                                                                                                | The `id` of the STAC Collection this Item references to (see [`collection` relation type](#relation-types)). This field is *required* if such a relation type is present and is *not allowed* otherwise. This field provides an easy way for a user to search for any Items that belong in a specified Collection. Must be a non-empty string.                                                                                        |
+| Field Name      | Type                                       | Description                                                                                                                                                                                                                                                                                               |
+| --------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type            | string                                     | **REQUIRED.** Type of the GeoJSON Object. MUST be set to `Feature`.                                                                                                                                                                                                                                       |
+| stac_version    | string                                     | **REQUIRED.** The STAC version the Item implements.                                                                                                                                                                                                                                                       |
+| stac_extensions | \[string]                                  | A list of extensions the Item implements.                                                                                                                                                                                                                                                                 |
+| id              | string                                     | **REQUIRED.** Provider identifier. The ID should be unique within the  [Collection](../collection-spec/collection-spec.md) that contains the Item.                                                                                                                                                        |
+| geometry        | GeoJSON Geometry Object \| null            | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to RFC 7946, [section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1) if a geometry is provided or [section 3.2](https://tools.ietf.org/html/rfc7946#section-3.2) if *no* geometry is provided. |
+| bbox            | \[number]                                  | **REQUIRED if `geometry` is not `null`, prohibited if `geometry` is `null`.** Bounding Box of the asset represented by this Item, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5).                                                                            |
+| properties      | [Properties Object](#properties-object)    | **REQUIRED.** A dictionary of additional metadata for the Item.                                                                                                                                                                                                                                           |
+| links           | \[[Link Object](#link-object)]             | **REQUIRED.** List of link objects to resources and related URLs. See the [best practices](../best-practices.md#use-of-links) for details on when the use `self` links is strongly recommended.                                                                                                           |
+| assets          | Map<string, [Asset Object](#asset-object)> | **REQUIRED.** Dictionary of asset objects that can be downloaded, each with a unique key.                                                                                                                                                                                                                 |
+| collection      | string                                     | The `id` of the STAC Collection this Item references to. This field is **required** if a link with a `collection` relation type is present and is **not allowed** otherwise.                                                                                                                              |
 
 ### Additional Field Information
 
@@ -107,6 +109,20 @@ by multiple files - all should be linked to. It is generally recommended that di
 levels or formats are not exhaustively listed in an Item, but instead are represented by related
 Items that are linked to, but the best practices around this are still emerging.
 
+#### geometry
+
+Defines the full footprint of the asset represented by this item, formatted according to RFC 7946.
+
+The footprint should be the default GeoJSON geometry, though additional geometries can be included.
+
+If **a geometry** is provided, the value must be a Geometry Object according to
+[RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1)
+with the exception that the type `GeometryCollection` is not allowed in STAC.
+If **no geometry** is provided, the value must be `null` according to
+[RFC 7946, section 3.2](https://tools.ietf.org/html/rfc7946#section-3.2).
+
+Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84).
+
 #### bbox
 
 Bounding Box of the asset represented by this Item using either 2D or 3D geometries,
@@ -118,6 +134,13 @@ When using 3D geometries, the elevation of the southwesterly most extent is the 
 and the elevation of the northeasterly most extent is the maximum.
 This field enables more naive clients to easily index and search geospatially.
 STAC compliant APIs are required to compute intersection operations with the Item's geometry field, not its bbox.
+
+#### collection
+
+The `id` of the STAC Collection this Item references to with the [`collection` relation type](#relation-types) in the `links`  array.
+
+This field provides an easy way for a user to search for any Items that belong in a specified Collection.
+Must be a non-empty string.
 
 ### Properties Object
 


### PR DESCRIPTION
**Related Issue(s):** #1160


**Proposed Changes:**

1. Disallow GeometryCollection in Item Spec (as defined in the schema) #1160
2. Reformatted the Item Field table to be more lightweight by moving geometry, bbox, and collection descriptions to separate sections. Also, clarified that RFC section 3.1 and 3.2 apply, for Geometry Object and null respectively.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
