### PR TITLE
Remove invalid trailing comma from docs

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -619,7 +619,7 @@ After migrating to STAC 1.1 this is ideally provided as follows:
       "bands": [
         {
           "name": "r",
-          "eo:common_name": "red",
+          "eo:common_name": "red"
         },
         {
           "name": "g",


### PR DESCRIPTION
**Proposed Changes:**

1. In the bands migration JSON example, there was an invalid trailing comma.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
