### PR TITLE
item_assets is not required #1311

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `item_assets` is not required
+
 ## [v1.1.0-beta.1] - 2024-08-08
 
 ### Added

--- a/collection-spec/collection-spec.md
+++ b/collection-spec/collection-spec.md
@@ -61,7 +61,7 @@ specified in [*OGC API - Features*](https://ogcapi.ogc.org/features/), but they 
 | summaries       | Map<string, \[\*]\|[Range Object](#range-object)\|[JSON Schema Object](#json-schema-object)> | STRONGLY RECOMMENDED. A map of property summaries, either a set of values, a range of values or a [JSON Schema](https://json-schema.org).                                 |
 | links           | \[[Link Object](#links)]                                                                     | **REQUIRED.** A list of references to other documents.                                                                                                                    |
 | assets          | Map<string, [Asset Object](#assets)>                                                         | Dictionary of asset objects that can be downloaded, each with a unique key.                                                                                               |
-| item_assets     | Map<string, [Item Asset Definition Object](#item-asset-definition-object)>                   | **REQUIRED.** A dictionary of assets that can be found in member Items.                                                                                                   |
+| item_assets     | Map<string, [Item Asset Definition Object](#item-asset-definition-object)>                   | A dictionary of assets that can be found in member Items.                                                                                                                 |
 
 ### stac_version
 


### PR DESCRIPTION
**Related Issue(s):** #1311


**Proposed Changes:**

1. Don't require item_assets in markdown

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
