### PR TITLE
add(item.assets): clarify common practice in item.key naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Clarify that keys to `item.assets` should be a finite static set of values, within a Collection.
+
 ## [v1.1.0] - 2024-09-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Clarify that keys to `item.assets` should be a finite static set of values, within a Collection.
+- Clarify that keys to `item.assets` should be a finite (and preferably consistent) static set of values within a Collection.
 
 ## [v1.1.0] - 2024-09-10
 

--- a/commons/assets.md
+++ b/commons/assets.md
@@ -9,7 +9,7 @@ The property `assets` is a dictionary of [Asset Objects](#asset-object), each wi
 Each asset refers to data associated with the Item or Collection that can be downloaded or streamed.
 In general, the keys don't have any meaning and are considered to be non-descriptive unique identifiers.
 The asset keys used by Items in a Collection should be a static and consistent set across all Items.
-This allows for effective usage of the [STAC Collection `item_assets` field](../collection-spec.md#item_assets).
+This allows for effective usage of the [STAC Collection `item_assets` field](../collection-spec/collection-spec.md#item_assets).
 Providers may assign any meaning to the keys for their respective use cases, but must not expect that clients understand them.
 To communicate the purpose of an asset better use the [`roles` field](#roles)
 in the [Asset Object](#asset-object).

--- a/commons/assets.md
+++ b/commons/assets.md
@@ -8,7 +8,8 @@
 The property `assets` is a dictionary of [Asset Objects](#asset-object), each with a unique key.
 Each asset refers to data associated with the Item or Collection that can be downloaded or streamed.
 In general, the keys don't have any meaning and are considered to be non-descriptive unique identifiers.
-The asset keys used by Items in a Collection should be a static and definite set.  This allows for effective usage of the [STAC Collection item\_assets field](../collection-spec.md#item_assets).
+The asset keys used by Items in a Collection should be a static and consistent set across all Items.
+This allows for effective usage of the [STAC Collection `item_assets` field](../collection-spec.md#item_assets).
 Providers may assign any meaning to the keys for their respective use cases, but must not expect that clients understand them.
 To communicate the purpose of an asset better use the [`roles` field](#roles)
 in the [Asset Object](#asset-object).

--- a/commons/assets.md
+++ b/commons/assets.md
@@ -8,6 +8,7 @@
 The property `assets` is a dictionary of [Asset Objects](#asset-object), each with a unique key.
 Each asset refers to data associated with the Item or Collection that can be downloaded or streamed.
 In general, the keys don't have any meaning and are considered to be non-descriptive unique identifiers.
+The asset keys used by Items in a Collection should be a static and definite set.  This allows for effective usage of the [STAC Collection item\_assets field](../collection-spec.md#item_assets).
 Providers may assign any meaning to the keys for their respective use cases, but must not expect that clients understand them.
 To communicate the purpose of an asset better use the [`roles` field](#roles)
 in the [Asset Object](#asset-object).


### PR DESCRIPTION
The statement preceding the change in this commit, leads some to believe that keys for the `item.assets` object can be dynamically generated from an infinite set:

> In general, the keys don't have any meaning and are considered to be non-descriptive unique identifiers.

This change to the specification aims to:

1. discourage using dynamic keys from an infinite set, via a _should_ (though I'd rather _shall_).
2. highlights a reason why (connection to `Collection.item_assets`).

That keys should be drawn from a static, finite set seems a _de facto_ standard in most implementations, but there exist problematic ones.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
