### PR TITLE
Clarify `bands` array in related best practices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Better describe the Statistics Object ([#1318](https://github.com/radiantearth/stac-spec/issues/1318))
 - bands as entity in UML model
 - Editorial edits
+- Clarified `bands` array references in "STAC Best Practices" document.
 
 ## [v1.1.0-beta.1] - 2024-08-08
 

--- a/best-practices.md
+++ b/best-practices.md
@@ -476,10 +476,10 @@ STAC recommands that single band assets should only use the `bands` array in the
    - This is the case if the data access mechanism requires you to specify the name of index of the band to retrieve the data,
      then the band should be specified as such.
    - This is also the case if the band has a specific name.
-     The `name` property is only available in bands and as such can't be specified for the Asset.
+     The `name` property is only available under the `bands` array and as such can't be specified for the Asset.
 2. **It is important that the (often spectral) band is part of a set of bands.**
    - For example, if the `bands` array is exposed in the Collection Summaries,
-     there should be bands defined in the Items or Item Assets as otherwise there's nothing to summarize.
+     then a `bands` array should be defined in the Items or Item Assets as otherwise there's nothing to summarize.
 3. **Individual bands are repeated in different assets.**
    - This may happen if you provide assets with different resolutions or file formats.
      The `name` property with the same value should be used so that users can identify that the bands are the same.
@@ -487,9 +487,9 @@ STAC recommands that single band assets should only use the `bands` array in the
 
 #### Multiple bands
 
-Generally, all properties that have the same value across all bands should not be listed in bands but in assets directly.
+Generally, all properties that have the same value across all bands should not be listed in the `bands` array but in the assets directly.
 
-For example, if your bands in an asset is defined as follows:
+For example, if your `bands` array in an asset is defined as follows:
 
 ```json
 {

--- a/best-practices.md
+++ b/best-practices.md
@@ -470,7 +470,7 @@ Example without bands:
 }
 ```
 
-STAC recommands that single band assets should only use the `bands` array in the following cases:
+STAC recommends that single band assets should only use the `bands` array in the following cases:
 
 1. **It's important in to convey that a band is present in the asset.**
    - This is the case if the data access mechanism requires you to specify the name of index of the band to retrieve the data,


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

1. Clarify reference to "`bands` array" (instead of just the term "bands") in best practices document


**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
