### PR TITLE
Add 'cfloat16' as a valid data_type value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Clarify that keys to `item.assets` should be a finite (and preferably consistent) static set of values within a Collection.
+- Add ``cfloat16`` for 16-bit complex float as an allowed `data_type` value.
 
 ### Changed
 

--- a/commons/common-metadata.md
+++ b/commons/common-metadata.md
@@ -336,6 +336,7 @@ The allowed values for `data_type` are:
 - `float64`: 64-big float
 - `cint16`: 16-bit complex integer
 - `cint32`: 32-bit complex integer
+- `cfloat16`: 16-bit complex float
 - `cfloat32`: 32-bit complex float
 - `cfloat64`: 64-bit complex float
 - `other`: Other data type than the ones listed above (e.g. boolean, string, higher precision numbers)

--- a/item-spec/json-schema/data-values.json
+++ b/item-spec/json-schema/data-values.json
@@ -21,6 +21,7 @@
         "float64",
         "cint16",
         "cint32",
+        "cfloat16",
         "cfloat32",
         "cfloat64",
         "other"


### PR DESCRIPTION
**Proposed Changes:**

The current list of data types include all GDAL raster data type, but this one. Let's add it.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
