### PR TITLE
docs: clarify unit field usage in common metadata

### DIFF
--- a/commons/common-metadata.md
+++ b/commons/common-metadata.md
@@ -288,6 +288,10 @@ It is STRONGLY RECOMMENDED to provide units in one of the following two formats:
 - [UCUM](https://ucum.org/): The unit code that is compliant to the UCUM specification.
 - [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/): The unit symbol if available, otherwise the singular unit name.
 
+To specify that a value is unitless (dimensionless), provide an empty string (`""`).
+If unit information is not available or not applicable, the `unit` field SHOULD be omitted entirely.
+The value `null` is not valid for this field.
+
 ### Statistics Object
 
 Statistics usually specify the range of values by providing the `minimum` and `maximum` values,


### PR DESCRIPTION
**Related Issue(s):** https://github.com/radiantearth/stac-best-practices/pull/29#discussion_r2432531597


**Proposed Changes:**

1. Clarified that the `unit` field should use an empty string (`""`) for unitless values, should be omitted if not available, and `null` is not a valid value.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
