### PR TITLE
Fix common schema typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Typo fix in `common.json` schema `$id` ([#1381](https://github.com/radiantearth/stac-spec/pull/1381))
+
 ### Added
 
 - Clarify that keys to `item.assets` should be a finite (and preferably consistent) static set of values within a Collection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Typo fix in `common.json` schema `$id` ([#1381](https://github.com/radiantearth/stac-spec/pull/1381))
-
 ### Added
 
 - Clarify that keys to `item.assets` should be a finite (and preferably consistent) static set of values within a Collection.
@@ -19,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Recommend that thumbnails and similar assets use HTTP(S) as access mechanism
 - Remove best practices content and reference new best practices repo ([#1370](https://github.com/radiantearth/stac-spec/pull/1370))
+
+### Fixed
+
+- Typo fix in `common.json` schema `$id` ([#1381](https://github.com/radiantearth/stac-spec/pull/1381))
 
 ## [v1.1.0] - 2024-09-10
 

--- a/item-spec/json-schema/common.json
+++ b/item-spec/json-schema/common.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/commonjson",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/common.json",
   "title": "STAC Common Metadata",
   "type": "object",
   "description": "This schema includes all common metadata fields.",


### PR DESCRIPTION
**Related Issue(s):** #


**Proposed Changes:**

1. Typo fix in `item-spec/json-schema/common.json` `$id` field

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-spec/blob/dev/CHANGELOG.md)
      **or** a CHANGELOG entry is not required.
- [ ] This PR affects the [STAC API spec](https://github.com/radiantearth/stac-api-spec),
      and I have opened issue/PR #XXX to track the change.
